### PR TITLE
Rework balance storage methods

### DIFF
--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -80,19 +80,20 @@ class DebtController extends Controller
     public function update(UpdateDebtRequest $request, DebtService $debtService): RedirectResponse
     {
         $validated = $request->validated();
-        $debt = Debt::findOrFail($validated['id']);
+        $original_amount = Debt::findOrFail($validated['id'])->amount;
         $updated = $debtService->updateDebt($validated);
-
+        
         // as mentioned in DebtService, discrepancy handling
-        if ($debt->amount != $updated->amount && $debt->split_even) {
-            $discrepancy = $updated->amount - $debt->amount;
+        if ($original_amount != $updated->amount && !$updated->split_even) {
+            $discrepancy = $updated->amount - $original_amount;
 
             return redirect()->route('dashboard')->withErrors([
                 'amount' => $discrepancy
             ]);
-        } 
 
-        return redirect()->route('dashboard')->with('status', 'Debt updated successfully.');
+        } else {
+            return redirect()->route('dashboard')->with('status', 'Debt updated successfully.');
+        }
     }
 
     /**

--- a/app/Http/Requests/StoreDebtRequest.php
+++ b/app/Http/Requests/StoreDebtRequest.php
@@ -35,7 +35,6 @@ class StoreDebtRequest extends FormRequest
                         }
                     }    
                 },],
-            // 'user_shares.*.name' => ['string', 'max:100'],
             'currency' => ['required', 'string', 'max:3'],
         ];
     }

--- a/app/Models/Debt.php
+++ b/app/Models/Debt.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use App\Observers\DebtObserver;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 
 class Debt extends Model
 {
@@ -30,7 +31,7 @@ class Debt extends Model
     ];
 
     protected $casts = [
-        'amount' => 'float',
+        'amount' => 'integer',
     ];
 
     /**
@@ -92,5 +93,16 @@ class Debt extends Model
     public function comments(): HasMany
     {
         return $this->hasMany(Comment::class);
+    }
+
+    /**
+     * For storing values as lowest numeration, show as currency
+     */
+    protected function amount(): Attribute
+    {
+        return Attribute::make(
+            get: fn (mixed $value) => $value / 100,
+            set: fn (mixed $value) => $value * 100,
+        );
     }
 }

--- a/app/Models/GroupUser.php
+++ b/app/Models/GroupUser.php
@@ -28,8 +28,8 @@ class GroupUser extends Model
         'balance',
     ];
 
-    protected $attributes = [
-        'balance' => 0.00,
+    protected $casts = [
+        'balance' => 'integer',
     ];
 
     /**

--- a/app/Models/GroupUser.php
+++ b/app/Models/GroupUser.php
@@ -10,6 +10,7 @@ use App\Models\Group;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 
 class GroupUser extends Model
 {
@@ -60,5 +61,16 @@ class GroupUser extends Model
     public function group(): BelongsTo
     {
         return $this->belongsTo(Group::class);
+    }
+
+    /**
+     * For storing values as lowest numeration, show as currency
+     */
+    protected function balance(): Attribute
+    {
+        return Attribute::make(
+            get: fn (mixed $value) => $value / 100,
+            set: fn (mixed $value) => $value * 100,
+        );
     }
 }

--- a/app/Models/Share.php
+++ b/app/Models/Share.php
@@ -9,6 +9,7 @@ use App\Models\Debt;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use App\Observers\ShareObserver;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 
 class Share extends Model
 {
@@ -26,7 +27,7 @@ class Share extends Model
     ];
 
     protected $casts = [
-        'amount' => 'float',
+        'amount' => 'integer',
     ];
 
     /**
@@ -58,5 +59,16 @@ class Share extends Model
     {
         // takes the two foreign keys and figures out the relationship (laravel magic)
         return $this->hasOne(GroupUser::class, 'user_id', 'user_id'); 
+    }
+
+    /**
+     * For storing values as lowest numeration, show as currency
+     */
+    protected function amount(): Attribute
+    {
+        return Attribute::make(
+            get: fn (mixed $value) => $value / 100,
+            set: fn (mixed $value) => $value * 100,
+        );
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -28,7 +28,6 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
-        'total_balance',
     ];
 
     /**

--- a/app/Services/DebtService.php
+++ b/app/Services/DebtService.php
@@ -56,17 +56,25 @@ class DebtService
 
             // if it's split even, update everyone's shares
             if ($debt->split_even) {
-                $rounded_split = floor(($data['amount'] / $debt->shares->count()) * 100) / 100;
-                
+                $difference = $data['amount'] - $original['amount'];
+             
+                $floor_split = floor($difference / $debt->shares->count() * 100) / 100;
+                $total_splits = $floor_split * $debt->shares->count();
+                $remainder = $difference - $total_splits;
+
+                $count = 0;
+
                 foreach ($debt->shares as $share) {
                     $data = [
                         'id' => $share->id,
-                        'amount' => $rounded_split,
+                        'amount' => $share->amount + ($count === 0 ? $floor_split + $remainder : $floor_split),
                         'user_id' => $share->user_id,
                     ];
           
                     $this->shareService->updateShare($data);
+                    $count++;
                 }
+                
             // if not split even, just update the amount
             // discrepancy is handled by the controller
             } else {

--- a/database/factories/DebtFactory.php
+++ b/database/factories/DebtFactory.php
@@ -30,6 +30,8 @@ class DebtFactory extends Factory
 
         return [
             'name' => $random_noun,
+            // debts, balances etc are now stored in lowest denomination possible
+            // e.g. 1000 = £10
             'amount' => random_int(1000,100000),
             'split_even' => rand(0,1),
             'cleared' => 0,
@@ -59,7 +61,6 @@ class DebtFactory extends Factory
         // find remainder by removing total base shares from original amount
         $remainder = round($debt->amount - $total_splits);
 
-        dump($rounded_split, $remainder);
         // start a count
         $count = 0;
         foreach ($group_users as $group_user) {
@@ -93,7 +94,7 @@ class DebtFactory extends Factory
             if ($total <= 0) {
                 return;
             }
-            // figure out a split +/- 10 of the even split, add decimals to simulate realism
+            // figure out a split +/- 1000 of the even split
             $split = rand(($rounded_split - 1000), ($rounded_split + 1000));
 
             // create the share

--- a/database/factories/DebtFactory.php
+++ b/database/factories/DebtFactory.php
@@ -55,12 +55,12 @@ class DebtFactory extends Factory
 
     private function splitEvenShares($debt, $group_users) {
         // figure out base share and round down
-        $rounded_split = floor($debt->amount / $group_users->count());
+        $rounded_split = floor(($debt->amount / $group_users->count()) * 100) / 100;
         // total base shares 
         $total_splits = $rounded_split * $group_users->count();
         // find remainder by removing total base shares from original amount
         $remainder = round($debt->amount - $total_splits, 2);
-
+     
         // start a count
         $count = 0;
         foreach ($group_users as $group_user) {
@@ -86,7 +86,7 @@ class DebtFactory extends Factory
         // set the total of the debt
         $total = $debt->amount;
         // figure out base share and round down, same as in split even
-        $rounded_split = floor($debt->amount / $group_users->count());
+        $rounded_split = floor(($debt->amount / $group_users->count()) * 100) / 100;
 
         // this way distributes shares until money runs out
         foreach ($group_users as $group_user) {
@@ -94,8 +94,9 @@ class DebtFactory extends Factory
             if ($total <= 0) {
                 return;
             }
+            
             // figure out a split +/- 1000 of the even split
-            $split = rand(($rounded_split - 1000), ($rounded_split + 1000));
+            $split = rand($rounded_split * 100 - 1000, $rounded_split * 100 + 1000) / 100;
 
             // create the share
             $share = Share::factory()->calcTotal()->create([

--- a/database/factories/DebtFactory.php
+++ b/database/factories/DebtFactory.php
@@ -55,9 +55,9 @@ class DebtFactory extends Factory
 
     private function splitEvenShares($debt, $group_users) {
         // figure out base share and round down
-        $rounded_split = floor(($debt->amount / $group_users->count()) * 100) / 100;
+        $floor_split = floor(($debt->amount / $group_users->count()) * 100) / 100;
         // total base shares 
-        $total_splits = $rounded_split * $group_users->count();
+        $total_splits = $floor_split * $group_users->count();
         // find remainder by removing total base shares from original amount
         $remainder = round($debt->amount - $total_splits, 2);
      
@@ -69,7 +69,7 @@ class DebtFactory extends Factory
                 'user_id' => $group_user->user->id,
                 'debt_id' => $debt->id,
                 // the first person in the loop gets the remainder, just like in AddDebt component
-                'amount' => $count === 0 ? $rounded_split + $remainder : $rounded_split,
+                'amount' => $count === 0 ? $floor_split + $remainder : $floor_split,
                 // debt owner shar automatically set to 'sent'
                 // 'sent' => $group_user->user_id === $debt->user_id ? 1 : rand(0, 1),
                 'sent' => 0,
@@ -86,7 +86,7 @@ class DebtFactory extends Factory
         // set the total of the debt
         $total = $debt->amount;
         // figure out base share and round down, same as in split even
-        $rounded_split = floor(($debt->amount / $group_users->count()) * 100) / 100;
+        $floor_split = floor(($debt->amount / $group_users->count()) * 100) / 100;
 
         // this way distributes shares until money runs out
         foreach ($group_users as $group_user) {
@@ -96,7 +96,7 @@ class DebtFactory extends Factory
             }
             
             // figure out a split +/- 1000 of the even split
-            $split = rand($rounded_split * 100 - 1000, $rounded_split * 100 + 1000) / 100;
+            $split = rand($floor_split * 100 - 1000, $floor_split * 100 + 1000) / 100;
 
             // create the share
             $share = Share::factory()->calcTotal()->create([

--- a/database/factories/DebtFactory.php
+++ b/database/factories/DebtFactory.php
@@ -32,7 +32,7 @@ class DebtFactory extends Factory
             'name' => $random_noun,
             // debts, balances etc are now stored in lowest denomination possible
             // e.g. 1000 = £10
-            'amount' => random_int(1000,100000),
+            'amount' => random_int(1000,100000) / 100,
             'split_even' => rand(0,1),
             'cleared' => 0,
             'currency' => 'GBP',
@@ -59,7 +59,7 @@ class DebtFactory extends Factory
         // total base shares 
         $total_splits = $rounded_split * $group_users->count();
         // find remainder by removing total base shares from original amount
-        $remainder = round($debt->amount - $total_splits);
+        $remainder = round($debt->amount - $total_splits, 2);
 
         // start a count
         $count = 0;

--- a/database/factories/DebtFactory.php
+++ b/database/factories/DebtFactory.php
@@ -30,7 +30,7 @@ class DebtFactory extends Factory
 
         return [
             'name' => $random_noun,
-            'amount' => random_int(100,999) + round(100/random_int(100,1000), 2),
+            'amount' => random_int(1000,100000),
             'split_even' => rand(0,1),
             'cleared' => 0,
             'currency' => 'GBP',
@@ -53,11 +53,13 @@ class DebtFactory extends Factory
 
     private function splitEvenShares($debt, $group_users) {
         // figure out base share and round down
-        $rounded_split = floor(($debt->amount / $group_users->count()) * 100) / 100;
+        $rounded_split = floor($debt->amount / $group_users->count());
         // total base shares 
         $total_splits = $rounded_split * $group_users->count();
         // find remainder by removing total base shares from original amount
-        $remainder = round($debt->amount - $total_splits, 2);
+        $remainder = round($debt->amount - $total_splits);
+
+        dump($rounded_split, $remainder);
         // start a count
         $count = 0;
         foreach ($group_users as $group_user) {
@@ -83,7 +85,7 @@ class DebtFactory extends Factory
         // set the total of the debt
         $total = $debt->amount;
         // figure out base share and round down, same as in split even
-        $rounded_split = floor(($debt->amount / $group_users->count()) * 100) / 100;
+        $rounded_split = floor($debt->amount / $group_users->count());
 
         // this way distributes shares until money runs out
         foreach ($group_users as $group_user) {
@@ -92,7 +94,7 @@ class DebtFactory extends Factory
                 return;
             }
             // figure out a split +/- 10 of the even split, add decimals to simulate realism
-            $split = rand(($rounded_split - 10) * 100, ($rounded_split + 10) * 100) / 100;
+            $split = rand(($rounded_split - 1000), ($rounded_split + 1000));
 
             // create the share
             $share = Share::factory()->calcTotal()->create([

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -26,7 +26,6 @@ class UserFactory extends Factory
         return [
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
-            'total_balance' => 00.00,
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),

--- a/database/migrations/2025_06_17_085529_change_balance_and_total_balance_column_types.php
+++ b/database/migrations/2025_06_17_085529_change_balance_and_total_balance_column_types.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->integer('total_balance')->default(0)->change();
+        });
+
+        Schema::table('group_users', function (Blueprint $table) {
+            $table->integer('balance')->default(0)->change();
+        });
+
+        Schema::table('debts', function (Blueprint $table) {
+            $table->integer('amount')->default(0)->change();
+        });
+
+        Schema::table('shares', function (Blueprint $table) {
+            $table->integer('amount')->default(0)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};

--- a/database/migrations/2025_06_17_085529_change_balance_and_total_balance_column_types.php
+++ b/database/migrations/2025_06_17_085529_change_balance_and_total_balance_column_types.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->integer('total_balance')->default(0)->change();
+            $table->dropColumn('total_balance');
         });
 
         Schema::table('group_users', function (Blueprint $table) {
@@ -33,6 +33,20 @@ return new class extends Migration
      */
     public function down(): void
     {
-        //
+        Schema::table('users', function (Blueprint $table) {
+            $table->decimal('total_balance', 10, 2)->default(00.00);
+        });
+
+        Schema::table('group_users', function (Blueprint $table) {
+            $table->decimal('balance', 10, 2)->change();
+        });
+
+        Schema::table('debts', function (Blueprint $table) {
+            $table->decimal('amount', 10, 2)->change();
+        });
+
+        Schema::table('shares', function (Blueprint $table) {
+            $table->decimal('amount', 10, 2)->change();
+        });
     }
 };

--- a/database/seeders/BasicLoginSeeder.php
+++ b/database/seeders/BasicLoginSeeder.php
@@ -19,7 +19,6 @@ class BasicLoginSeeder extends Seeder
             'name' => 'Dom Elves',
             'email' => 'dom_elves@hotmail.co.uk',
             'password' => 'password',
-            'total_balance' => 00.00,
         ]);
 
         User::factory(100)->create(); 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -34,7 +34,6 @@ class DatabaseSeeder extends Seeder
             'name' => 'Dom Elves',
             'email' => 'dom_elves@hotmail.co.uk',
             'password' => 'password',
-            'total_balance' => 00.00,
         ]);
 
         // now a bunch of users so a group can be created
@@ -99,7 +98,6 @@ class DatabaseSeeder extends Seeder
             'name' => 'gman',
             'email' => 'gman@gman.com',
             'password' => 'gman',
-            'total_balance' => 00.00,
         ]);
 
         $group = Group::factory()->withGroupUsers()->create([

--- a/resources/js/store.js
+++ b/resources/js/store.js
@@ -49,12 +49,10 @@ export const store = reactive({
         const remainder = ((this.addDebtForm.amount - shareTotal)).toFixed(2);
 
         // then tack it on to the first user, if someone is selected
-        try {
+        if (remainder) {
             this.addDebtForm.user_shares.find((share) => share.checked).amount += Number(remainder);
-        } catch (e) {
-            // set an error here later 
-        }   
-
+        }
+            
         console.log('form after split even', this.addDebtForm);
     },
 })

--- a/tests/Feature/Http/Controllers/DebtControllerTest.php
+++ b/tests/Feature/Http/Controllers/DebtControllerTest.php
@@ -268,7 +268,7 @@ test('user updating the amount on a regular debt returns a discrepancy error', f
         'group_id' => $this->group->id,
         'user_id' => $this->user->id,
         'name' => $debt->name,
-        'amount' => $debt->amount + 10,
+        'amount' => ($debt->amount + 10) * 100,
     ]);
 });
 

--- a/tests/Feature/Http/Controllers/ShareControllerTest.php
+++ b/tests/Feature/Http/Controllers/ShareControllerTest.php
@@ -159,7 +159,7 @@ test("user can delete a share for a debt they own", function() {
 
     $this->assertDatabaseHas('debts', [
         'id' => $debt->id,
-        'amount' => $debt->amount - $share->amount,
+        'amount' => ($debt->amount - $share->amount) * 100,
     ]);
 });
 
@@ -185,12 +185,12 @@ test("user can update the amount on a share for a debt they own", function() {
     $this->assertDatabaseHas('shares', [
         'id' => $share->id,
         'user_id' => $share->user_id,
-        'amount' => $share->amount + 500,
+        'amount' => ($share->amount + 500) * 100,
     ]);
 
     $this->assertDatabaseHas('debts', [
         'id' => $debt->id,
-        'amount' => $debt->amount + 500,
+        'amount' => ($debt->amount + 500) * 100,
     ]);
 });
 
@@ -263,7 +263,7 @@ test("user can add a share to a debt they are in", function() {
     $this->assertDatabaseHas('shares', [
         'debt_id' => $debt->id,
         'user_id' => $this->user->id,
-        'amount' => 500,
+        'amount' => 500 * 100,
     ]);
 });
 
@@ -310,6 +310,6 @@ test("user can not update the a amount on a share for a debt they do not own", f
 
     $this->assertDatabaseHas('shares', [
         'id' => $share->id,
-        'amount' => $share->amount,
+        'amount' => $share->amount * 100,
     ]);
 });


### PR DESCRIPTION
The aim of this PR is to rework the app so that monetary values are now stored as int rather than floats, as floating point precision was causing a lot of issues. In the long run, this should make a lot of things cleaner. Actions to be carried out:

- [x] Migration to change column types & remove `total_balance` from `User`
- [x] Rework factories to accommodate this (essential *100 everything and remove weird rounding instances)
- [x] Any potential frontend changes, not sure of consequences yet
- [x] get/set attribute on all relevant models to *|/ 100 for storage purposes
- [x] have a look over the services as there's a bunch of rounding related stuff in there, may no longer be required
- [x] fix tests

Not 100% sure on what else may be required off the top of my head, research was pointing me to use `brick/money` though what I wanted to achieve was equally doable with get/set attributes. May use `brick/money` when adding other currency support. 

Extras:

- Fixed bug for updating debt amount on split even debts not calcing correctly 
- Fixed bug for standard debt discrepancy error not firing 
- Removed some old code
- Change casts on models that have any balance/total attributes
- Improved wording on some variables

However, still experiencing floating point precision issues in the `TotalBalanceTest`. I think I will have to use `brick/money` to get around these problems. Plus, it has currency support. 