### PR TITLE
Improve currency storage

### DIFF
--- a/app/Casts/Cash.php
+++ b/app/Casts/Cash.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+use Brick\Money\Money;
+
+class Cash implements CastsAttributes
+{
+    /**
+     * Cast the given value.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function get(Model $model, string $key, mixed $value, array $attributes): mixed
+    {
+        // default everything to GBP for now
+        // far in the future, work out some way to support multiple currencies
+        // probably by calling an exchange rate API to addyour various balances together
+        // and convert to GBP
+        // todo: this^
+        return Money::ofMinor($value, 'GBP');
+    }
+
+    /**
+     * Prepare the given value for storage.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function set(Model $model, string $key, mixed $value, array $attributes): mixed
+    {
+        if (!$value instanceof Money) {
+            return $value;
+        }
+
+        return $value->getMinorAmount()->toInt();
+    }
+}

--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -85,8 +85,8 @@ class DebtController extends Controller
         
         // as mentioned in DebtService, discrepancy handling
         if ($original_amount != $updated->amount && !$updated->split_even) {
-            $discrepancy = $updated->amount - $original_amount;
-
+            $discrepancy = $updated->amount->minus($original_amount)->getAmount()->toInt();
+            
             return redirect()->route('dashboard')->withErrors([
                 'amount' => $discrepancy
             ]);

--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -52,7 +52,7 @@ class DebtController extends Controller
     public function store(StoreDebtRequest $request, DebtService $debtService): RedirectResponse
     {
         $validated = $request->validated();
-
+    
         $debtService->createDebt($validated);
 
         return redirect()->route('dashboard')->with('status', 'Debt created successfully.');

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -83,11 +83,16 @@ class GroupController extends Controller
     {
         $validated = $request->validated();
 
-        Group::where('id', $validated['id'])->delete();
         GroupUser::where('group_id', $validated['id'])->delete();
-        $debts = Debt::where('user_id', $validated['id'])->get();
+        Group::where('id', $validated['id'])->delete();
+        $debts = Debt::where('group_id', $validated['id'])->get();
         foreach ($debts as $debt) {
-            $debt->shares()->delete();
+            $shares = $debt->shares;
+
+            foreach ($shares as $share) {
+                $share->delete();
+            }
+
             $debt->delete();
         }
     }

--- a/app/Http/Controllers/ShareController.php
+++ b/app/Http/Controllers/ShareController.php
@@ -15,6 +15,7 @@ use App\Events\ShareUpdated;
 use App\Services\ShareService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
+use Brick\Money\Money;
 
 /**
  * Shares have observers, which fire events that perform operations for debt & user->total_balance
@@ -74,6 +75,14 @@ class ShareController extends Controller
         // validated data
         $validated = $request->validated();
 
+        $share = Share::findOrFail($validated['id']);
+
+        // the only keys in the request payload are share id & what has changed
+        // so make a money object if amount is present
+        if (array_key_exists('amount', $validated)) {
+            $validated['amount'] = Money::of($validated['amount'], $share->debt->currency)->minus($share->amount);
+        }
+        
         $shareService->updateShare($validated);
 
         // todo: if statement that on sends this on success

--- a/app/Models/Debt.php
+++ b/app/Models/Debt.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use App\Observers\DebtObserver;
 use Illuminate\Database\Eloquent\Casts\Attribute;
+use App\Casts\Cash;
 
 class Debt extends Model
 {
@@ -31,7 +32,7 @@ class Debt extends Model
     ];
 
     protected $casts = [
-        'amount' => 'integer',
+        'amount' => Cash::class,
     ];
 
     /**
@@ -93,16 +94,5 @@ class Debt extends Model
     public function comments(): HasMany
     {
         return $this->hasMany(Comment::class);
-    }
-
-    /**
-     * For storing values as lowest numeration, show as currency
-     */
-    protected function amount(): Attribute
-    {
-        return Attribute::make(
-            get: fn (mixed $value) => $value / 100,
-            set: fn (mixed $value) => $value * 100,
-        );
     }
 }

--- a/app/Models/GroupUser.php
+++ b/app/Models/GroupUser.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Casts\Attribute;
+use App\Casts\Cash;
 
 class GroupUser extends Model
 {
@@ -30,7 +31,7 @@ class GroupUser extends Model
     ];
 
     protected $casts = [
-        'balance' => 'integer',
+        'balance' => Cash::class,
     ];
 
     /**
@@ -61,16 +62,5 @@ class GroupUser extends Model
     public function group(): BelongsTo
     {
         return $this->belongsTo(Group::class);
-    }
-
-    /**
-     * For storing values as lowest numeration, show as currency
-     */
-    protected function balance(): Attribute
-    {
-        return Attribute::make(
-            get: fn (mixed $value) => $value / 100,
-            set: fn (mixed $value) => $value * 100,
-        );
     }
 }

--- a/app/Models/Share.php
+++ b/app/Models/Share.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use App\Observers\ShareObserver;
 use Illuminate\Database\Eloquent\Casts\Attribute;
+use App\Casts\Cash;
 
 class Share extends Model
 {
@@ -27,7 +28,7 @@ class Share extends Model
     ];
 
     protected $casts = [
-        'amount' => 'integer',
+        'amount' => Cash::class,
     ];
 
     /**
@@ -59,16 +60,5 @@ class Share extends Model
     {
         // takes the two foreign keys and figures out the relationship (laravel magic)
         return $this->hasOne(GroupUser::class, 'user_id', 'user_id'); 
-    }
-
-    /**
-     * For storing values as lowest numeration, show as currency
-     */
-    protected function amount(): Attribute
-    {
-        return Attribute::make(
-            get: fn (mixed $value) => $value / 100,
-            set: fn (mixed $value) => $value * 100,
-        );
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -13,6 +13,9 @@ use App\Models\Debt;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Casts\Attribute;
+use Brick\Money\MoneyBag;
+use Brick\Money\Money;
+use Brick\Money\CurrencyConverter;
 
 class User extends Authenticatable
 {
@@ -65,13 +68,19 @@ class User extends Authenticatable
 
     /**
      * This is how the total balance for a user is calced
-     * If this is ever changed, DebtFactory will need to have changes reverted
-     * Probably loads of other stuff too
+     * Currently defaulted to GBP for dev purposes
+     * But can/will be changed in the future when exchange is implemented
      */
     protected function userBalance(): Attribute
     {
         return Attribute::get(function () {
-            return $this->group_users->sum('balance');
+            return $this->group_users->reduce(function (?Money $carry, GroupUser $group_user) {
+                // sets the carry as the first group_user balance
+                if ($carry === null) {
+                    return $group_user->balance;
+                }
+                return $carry->plus($group_user->balance);
+            }, null);
         });
     }
 

--- a/app/Services/BalanceService.php
+++ b/app/Services/BalanceService.php
@@ -15,11 +15,11 @@ class BalanceService
     public function addToGroupUserBalance($share): void
     {
         [$share_group_user, $debt_group_user] = $this->getGroupUsers($share);
+        
+        $share_group_user->balance = $share_group_user->balance->minus($share->amount);
+        $share_group_user->save();
 
-        $share->group_user->balance -= $share->amount;
-        $share->group_user->save();
-
-        $debt_group_user->balance += $share->amount;
+        $debt_group_user->balance = $debt_group_user->balance->plus($share->amount);
         $debt_group_user->save();
     
     }
@@ -27,23 +27,22 @@ class BalanceService
     public function updateGroupUserBalance($share, $difference): void
     {
         [$share_group_user, $debt_group_user] = $this->getGroupUsers($share);
- 
-        $share_group_user->balance -= $difference;
+
+        $share_group_user->balance = $share_group_user->balance->minus($difference);
         $share_group_user->save();
 
-        $debt_group_user->balance += $difference;
+        $debt_group_user->balance = $debt_group_user->balance->plus($difference);
         $debt_group_user->save();
-       
     }
 
     public function subtractFromGroupUserBalance($share): void
     {
         [$share_group_user, $debt_group_user] = $this->getGroupUsers($share);
 
-        $share_group_user->balance += $share->amount;
+        $share_group_user->balance = $share_group_user->balance->plus($share->amount);
         $share_group_user->save();
 
-        $debt_group_user->balance -= $share->amount;
+        $debt_group_user->balance = $debt_group_user->balance->minus($share->amount);
         $debt_group_user->save();
       
     }

--- a/app/Services/DebtService.php
+++ b/app/Services/DebtService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Models\Debt;
 use App\Services\ShareService;
+use Brick\Money\Money;
 
 class DebtService
 {
@@ -27,7 +28,7 @@ class DebtService
             'group_id' => $data['group_id'],
             'user_id' => $data['user_id'],
             'name' => $data['name'],
-            'amount' => $data['amount'],
+            'amount' => Money::of($data['amount'], $data['currency']),
             'split_even' => $data['split_even'],
             'cleared' => 0,
             'currency' => $data['currency'],
@@ -42,49 +43,56 @@ class DebtService
     /**
      * Update an existing debt.
      *
-     * @param array $data
+     * @param array $data - the new data being passed in
      * @return Debt|mixed
      */
     public function updateDebt($data): mixed
     {
-        // store original values
         $debt = Debt::findOrFail($data['id']);
-        $original = $debt->getOriginal();
-        
-        // for updating the amount, we have to do quite a few things
-        if ($original['amount'] != $data['amount']) {
+        $debt_amount = $debt->amount;
+        $new_amount = Money::of($data['amount'], $debt->currency);
+
+        // first we check if we are updating the amount
+        if ($debt_amount != $new_amount) {
+
+            $difference = $new_amount->minus($debt_amount);
 
             // if it's split even, update everyone's shares
             if ($debt->split_even) {
-                $difference = $data['amount'] - $original['amount'];
-             
-                $floor_split = floor($difference / $debt->shares->count() * 100) / 100;
-                $total_splits = $floor_split * $debt->shares->count();
-                $remainder = $difference - $total_splits;
-
+                
+                // get the split amount as a money object
+                $split_difference = $difference->split($debt->shares->count());
+  
                 $count = 0;
 
                 foreach ($debt->shares as $share) {
+                    // build data object for updating the share
                     $data = [
                         'id' => $share->id,
-                        'amount' => $share->amount + ($count === 0 ? $floor_split + $remainder : $floor_split),
+                        'amount' => $split_difference[$count],
                         'user_id' => $share->user_id,
                     ];
-          
+
                     $this->shareService->updateShare($data);
                     $count++;
                 }
+
+                $debt->amount = $debt->amount->plus($difference);
+                $debt->save();
                 
             // if not split even, just update the amount
             // discrepancy is handled by the controller
             } else {
-                $debt->update($data);
+                $debt->amount = $debt->amount->plus($difference);
+                $debt->save();
             }
         // this is the condition for just updating the debt name    
         } else {
-            $debt->update($data);
+            
+            $debt->name = $data['name'];
+            $debt->save();
         }
-
+   
         return $debt;
     }
 

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
+        "brick/money": "^0.10.1",
         "inertiajs/inertia-laravel": "^2.0",
         "laravel/framework": "^11.31",
         "laravel/sanctum": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e748e4d221a3a5c5da33962b79a94c2e",
+    "content-hash": "f20b569f45631ee6f04456ea09c7470b",
     "packages": [
         {
             "name": "brick/math",
@@ -65,6 +65,63 @@
                 }
             ],
             "time": "2023-11-29T23:19:16+00:00"
+        },
+        {
+            "name": "brick/money",
+            "version": "0.10.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/brick/money.git",
+                "reference": "779c1d3b708e4dd37fe8a32a189b9f241b52f194"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/brick/money/zipball/779c1d3b708e4dd37fe8a32a189b9f241b52f194",
+                "reference": "779c1d3b708e4dd37fe8a32a189b9f241b52f194",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "~0.12.0|~0.13.0",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "brick/varexporter": "~0.5.0",
+                "ext-dom": "*",
+                "ext-pdo": "*",
+                "php-coveralls/php-coveralls": "^2.2",
+                "phpunit/phpunit": "^10.1",
+                "vimeo/psalm": "6.3.0"
+            },
+            "suggest": {
+                "ext-intl": "Required to format Money objects"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Brick\\Money\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Money and currency library",
+            "keywords": [
+                "brick",
+                "currency",
+                "money"
+            ],
+            "support": {
+                "issues": "https://github.com/brick/money/issues",
+                "source": "https://github.com/brick/money/tree/0.10.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/BenMorel",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-05T13:00:01+00:00"
         },
         {
             "name": "carbonphp/carbon-doctrine-types",

--- a/database/factories/DebtFactory.php
+++ b/database/factories/DebtFactory.php
@@ -33,7 +33,7 @@ class DebtFactory extends Factory
             'name' => $random_noun,
             // debts, balances etc are now stored in lowest denomination possible
             // e.g. 1000 = £10
-            'amount' => random_int(10000,100000) / 100,
+            'amount' => Money::of(rand(100, 1000), 'GBP'),
             'split_even' => rand(0,1),
             'cleared' => 0,
             'currency' => 'GBP',
@@ -55,46 +55,41 @@ class DebtFactory extends Factory
     }
 
     private function splitEvenShares($debt, $group_users) {
-        // having to using 100 multipliers again as at this point, $debt is being accessed
-        // so the accessor hits, which is necessary for users to add debts etc
-        $money = Money::ofMinor($debt->amount * 100, $debt->currency)->split($group_users->count()); 
-        // start a count
-        $count = 0;
-        foreach ($group_users as $group_user) {
+        // use brick/money split() to split debt evenly
+        $money = $debt->amount->split($group_users->count()); 
+
+        foreach ($group_users as $key => $group_user) {
             // create the share
             $share = Share::factory()->calcTotal()->create([
                 'user_id' => $group_user->user->id,
                 'debt_id' => $debt->id,
-                'amount' => $money[$count]->getAmount()->getUnscaledValue()->toBase(10) / 100,
+                'amount' => $money[$key],
                 // debt owner share automatically set to 'sent'
                 // 'sent' => $group_user->user_id === $debt->user_id ? 1 : rand(0, 1),
                 'sent' => 0,
                 'seen' => 0,
             ]);
-            
-            $count++;
         }
     }
 
     private function chunkSharesRandomly($debt, $group_users) {
-        // rough chunk amount
-        // operations are multiplied by 100 to simulate pennies
-        $total = $debt->amount * 100;
+        
+        $total = $debt->amount->getMinorAmount()->toInt();
         $count = $group_users->count();
         $chunk = intdiv($total, $count);
         
         foreach ($group_users as $group_user) {
-     
             // give some variance to chunks 
             $split = rand($chunk - 1000, $chunk + 1000);
+            // give the last user the remainder of the debt
             $share_amount = $count === 1 ? $total : $split;
+
             // create the share
             $share = Share::factory()->calcTotal()->create([
                 'user_id' => $group_user->user->id,
                 'debt_id' => $debt->id,
-                // give the last user the rest of the money
-                'amount' => $share_amount / 100,
-                // debt owner shar automatically set to 'sent'
+                'amount' => Money::ofMinor($share_amount, $debt->currency),
+                // debt owner share automatically set to 'sent'
                 // 'sent' => $group_user->user_id === $debt->user_id ? 1 : rand(0, 1),
                 'sent' => 0,
                 'seen' => 0,

--- a/database/factories/ShareFactory.php
+++ b/database/factories/ShareFactory.php
@@ -38,8 +38,9 @@ class ShareFactory extends Factory
             $debt_group_user = $share->debt->user->group_users->where('group_id', $share->debt->group_id)->first();
             
             if ($share_group_user->id != $debt_group_user->id) {
-                $share_group_user->balance -= $share->amount;
-                $debt_group_user->balance += $share->amount;
+                // same as in BalanceService, calc user balance depending on debt
+                $share_group_user->balance = $share_group_user->balance->minus($share->amount);
+                $debt_group_user->balance = $debt_group_user->balance->plus($share->amount);
 
                 $debt_group_user->save();
                 $share_group_user->save();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,12 @@
 {
-    "name": "chopr",
+    "name": "html",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
+            "dependencies": {
+                "dinero.js": "^1.9.1"
+            },
             "devDependencies": {
                 "@inertiajs/vue3": "^2.0.0",
                 "@tailwindcss/forms": "^0.5.3",
@@ -1590,6 +1593,15 @@
             "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
             "dev": true,
             "license": "Apache-2.0"
+        },
+        "node_modules/dinero.js": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/dinero.js/-/dinero.js-1.9.1.tgz",
+            "integrity": "sha512-1HXiF2vv3ZeRQ23yr+9lFxj/PbZqutuYWJnE0qfCB9xYBPnuaJ8lXtli1cJM0TvUXW1JTOaePldmqN5JVNxKSA==",
+            "license": "MIT",
+            "engines": {
+                "node": "*"
+            }
         },
         "node_modules/dlv": {
             "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
         "tailwindcss": "^3.2.1",
         "vite": "^6.0",
         "vue": "^3.4.0"
+    },
+    "dependencies": {
+        "dinero.js": "^1.9.1"
     }
 }

--- a/resources/js/Components/Debts/AddDebt/Form/AddDebtForm.vue
+++ b/resources/js/Components/Debts/AddDebt/Form/AddDebtForm.vue
@@ -125,7 +125,7 @@ function addDebt() {
     // empty string issue is sorted in the share component
     const filtered = store.addDebtForm.user_shares.filter((share) => share.amount != 0);
     addDebtForm.user_shares = filtered;
-    console.log('posting', addDebtForm);
+    
     addDebtForm.post(route('debt.store'), {
         preserveScroll: true,
         onSuccess: (response) => {

--- a/resources/js/Components/Debts/Debt.vue
+++ b/resources/js/Components/Debts/Debt.vue
@@ -28,7 +28,7 @@ const displayControls = usePage().props.auth.user.id === props.debt.user_id ? tr
 const debtForm = useForm({
     id: props.debt.id,
     name: props.debt.name,
-    amount: props.debt.amount,
+    amount: props.debt.amount.amount,
 });
 
 function updateDebt() {
@@ -91,7 +91,8 @@ const debtCurrency = computed(() => {
 });
 
 const debtDiscrepancy = computed(() => {
-    return props.debt.shares.reduce((total, share) => total + share.amount, 0).toFixed(2);
+    console.log(props.debt.shares[0].amount.amount);
+    return props.debt.shares.reduce((total, share) => total + Number(share.amount.amount), 0);
 });
 
 const closeModal = () => {
@@ -99,8 +100,8 @@ const closeModal = () => {
 };
 
 onMounted(() => {
-    if (debtDiscrepancy.value != props.debt.amount) {
-        const discrepancy = props.debt.amount - debtDiscrepancy.value;
+    if (debtDiscrepancy.value != props.debt.amount.amount) {
+        const discrepancy = props.debt.amount.amount - debtDiscrepancy.value;
         debtForm.errors.amount = `There is a discrepancy of ${debtCurrency.value.symbol}${discrepancy.toFixed(2)}.`;
     }
 });
@@ -122,7 +123,7 @@ onMounted(() => {
                     class="p-2 text-xl w-full text-center w-full"
                 > 
                     {{ props.debt.name }}
-                    {{ debtCurrency.symbol }}{{ props.debt.amount }} 
+                    {{ debtCurrency.symbol }}{{ props.debt.amount.amount }} 
                     <small class="text-xs">
                         {{  debtCurrency.code }}
                     </small>

--- a/resources/js/Components/Shares/Share.vue
+++ b/resources/js/Components/Shares/Share.vue
@@ -72,7 +72,7 @@ function seenShare() {
 const updateShareForm = useForm({
     id: props.share.id,
     debt_id: props.share.debt_id,
-    amount: props.share.amount,
+    amount: props.share.amount.amount,
     name: props.share.name,
 });
 
@@ -144,7 +144,7 @@ const closeModal = () => {
                     </small>
                 </p>
                 <p>{{  share.name }}</p>
-                <p>{{ debtCurrency.symbol }}{{ share.amount }}</p>
+                <p>{{ debtCurrency.symbol }}{{ share.amount.amount }}</p>
             </div>
             <form 
                 v-else

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -21,7 +21,7 @@ const props = defineProps({
 const showAddDebt = ref(false);
 
 onMounted(() => {
-    console.log(props);
+    console.log(props.groups[0].debts);
 });
 </script>
 

--- a/resources/js/store.js
+++ b/resources/js/store.js
@@ -17,8 +17,13 @@ export const store = reactive({
      * Adds share amounts together on input change for non split even debts
      */
     calcTotalAmount() {
-        this.addDebtForm.amount = this.addDebtForm.user_shares.map(share => share.amount)
-            .reduce((acc, value) => acc + value, 0).toFixed(2);
+        const amount = Dinero({
+            amount: this.addDebtForm.user_shares.map(share => share.amount)
+                .reduce((acc, value) => acc + value, 0),
+            currency: this.addDebtForm.currency,
+        })
+
+        this.addDebtForm.amount = amount.getAmount();
 
         console.log('form after calc total', this.addDebtForm);
     },

--- a/resources/js/store.js
+++ b/resources/js/store.js
@@ -1,5 +1,6 @@
 import { reactive } from 'vue';
 import { router, useForm, usePage } from '@inertiajs/vue3';
+import Dinero from 'dinero.js'
 
 export const store = reactive({
     addDebtForm: {
@@ -29,30 +30,31 @@ export const store = reactive({
     splitEven() {
         // total users being added 
         const selectedUsersLength = this.addDebtForm.user_shares.filter((share) => share.checked == true).length;
-    
-        // rounded share to 2 dp
-        const amount = (Math.floor((this.addDebtForm.amount / selectedUsersLength) * 100) / 100);
-
-        // set as share amount for the user if they are selected
-        this.addDebtForm.user_shares.forEach((share) => {
-            share.amount = 0;
-            if (share.checked) {
-                share.amount = amount;
-            }
+        
+        const amount = Dinero({
+            amount: this.addDebtForm.amount * 100,
+            currency: this.addDebtForm.currency,
         });
 
-        // add the rounded shares together 
-        const shareTotal = this.addDebtForm.user_shares.map((share) => share.amount)
-                .reduce((acc, value) => acc + value, 0);
+        const splits = [];
 
-        // subtract from amount to find remainder
-        const remainder = ((this.addDebtForm.amount - shareTotal)).toFixed(2);
-
-        // then tack it on to the first user, if someone is selected
-        if (remainder) {
-            this.addDebtForm.user_shares.find((share) => share.checked).amount += Number(remainder);
+        // this is how Dinero.js wants the splits to be defined
+        // e.g. a 3 person split is [1, 1, 1]
+        for (let i = selectedUsersLength; i > 0; i--) {
+            splits.push(1);
         }
-            
-        console.log('form after split even', this.addDebtForm);
+
+        // handling the allocation of splits
+        const shares = amount.allocate(splits).map(s => s.getAmount());
+
+        // set as share amount for the user if they are selected
+        // by default, give the first user the slightly larger share
+        this.addDebtForm.user_shares.forEach((share) => {
+            share.amount = 0;
+
+            if (share.checked) {
+                share.amount = shares.shift() / 100;
+            }
+        });
     },
 })

--- a/tests/Feature/Http/Controllers/DebtControllerTest.php
+++ b/tests/Feature/Http/Controllers/DebtControllerTest.php
@@ -253,10 +253,12 @@ test('user updating the amount on a regular debt returns a discrepancy error', f
         'split_even' => 0,
     ]);
 
+    $new_amount = $debt->amount->plus(10);
+   
     $response = $this->patch(route('debt.update'), [
         'id' => $debt->id,
         'name' => $debt->name,
-        'amount' => $debt->amount + 10,
+        'amount' => $new_amount->getAmount()->toInt(),
     ]);
 
     $response->assertStatus(302)
@@ -268,7 +270,7 @@ test('user updating the amount on a regular debt returns a discrepancy error', f
         'group_id' => $this->group->id,
         'user_id' => $this->user->id,
         'name' => $debt->name,
-        'amount' => ($debt->amount + 10) * 100,
+        'amount' => $new_amount->getMinorAmount()->toInt(),
     ]);
 });
 
@@ -278,15 +280,17 @@ test('updating the amount on a split even debt updates the shares', function() {
         'group_id' => $this->group->id,
         'split_even' => 1,
     ]);
-    dump($debt);
+
     $shares = $debt->shares;
+  
+    $new_amount = $debt->amount->plus(10);
 
-    $addition = $shares->count();
-
+    $split = $new_amount->split($shares->count());
+  
     $response = $this->patch(route('debt.update'), [
         'id' => $debt->id,
         'name' => $debt->name,
-        'amount' => $debt->amount + $addition,
+        'amount' => $new_amount->getAmount()->toInt(),
     ]);
 
     $response->assertStatus(302)
@@ -299,15 +303,15 @@ test('updating the amount on a split even debt updates the shares', function() {
         'group_id' => $this->group->id,
         'user_id' => $this->user->id,
         'name' => $debt->name,
-        'amount' => ($debt->amount + $addition) * 100,
+        'amount' => $new_amount->getMinorAmount()->toInt(),
     ]);
 
-    foreach ($shares as $share) {
+    foreach ($shares as $key => $share) {
         $this->assertDatabaseHas('shares', [
             'id' => $share->id,
             'user_id' => $share->user_id,
             'debt_id' => $debt->id,
-            'amount' => ($share->amount + ($addition / $shares->count())) * 100,
+            'amount' => $split[$key]->getMinorAmount()->toInt(),
         ]);
     }
 });
@@ -316,25 +320,26 @@ test('user can update the name of a debt', function() {
     $debt = Debt::factory()->withShares()->create([
         'user_id' => $this->user->id,
         'group_id' => $this->group->id,
+        'split_even' => 0,
     ]);
 
     $response = $this->patch(route('debt.update'), [
         'id' => $debt->id,
         'name' => 'i have been changed',
-        'amount' => $debt->amount,
+        'amount' => $debt->amount->getAmount()->toInt(),
     ]);
 
     $response->assertStatus(302)
         ->assertSessionHasNoErrors()
         ->assertSessionHas('status', 'Debt updated successfully.')
         ->assertRedirect('/dashboard');
-  
+
     $this->assertDatabaseHas('debts', [
         'id' => $debt->id,
         'group_id' => $this->group->id,
         'user_id' => $this->user->id,
         'name' => 'i have been changed',
-        'amount' => $debt->amount * 100,
+        'amount' => $debt->amount->getMinorAmount()->toInt(),
     ]);
 });
 
@@ -361,7 +366,7 @@ test('user can not change the name of a debt they do not own', function() {
         'group_id' => $debt->group_id,
         'user_id' => $debt->user_id,
         'name' => $debt->name,
-        'amount' => $debt->amount * 100,
+        'amount' => $debt->amount->getMinorAmount()->toInt(),
     ]);
 });
 
@@ -388,7 +393,7 @@ test('user can not change the amount of a debt they do not own', function() {
         'group_id' => $debt->group_id,
         'user_id' => $debt->user_id,
         'name' => $debt->name,
-        'amount' => $debt->amount * 100,
+        'amount' => $debt->amount->getMinorAmount()->toInt(),
     ]);
 });
 
@@ -413,7 +418,7 @@ test('user can not delete a debt they do not own', function() {
         'id' => $debt->id,
         'group_id' => $debt->group_id,
         'user_id' => $debt->user_id,
-        'amount' => $debt->amount * 100,
+        'amount' => $debt->amount->getMinorAmount()->toInt(),
     ]);
 });
 

--- a/tests/Feature/Http/Controllers/GroupControllerTest.php
+++ b/tests/Feature/Http/Controllers/GroupControllerTest.php
@@ -101,7 +101,7 @@ test('deleting a group deletes the relevant group users', function() {
     } 
 });
 
-test('deleting a group deletes the relevant debts', function() {
+test('deleting a group deletes the relevant debts and shares', function() {
     $debts = Debt::factory(5)->withShares()->create([
         'user_id' => $this->user->id,
         'group_id' => $this->group->id,
@@ -119,27 +119,37 @@ test('deleting a group deletes the relevant debts', function() {
             'group_id' => $this->group->id,
             'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
         ]);
-    } 
-});
 
-test('deleting a group deletes the relevant shares', function() {
-    $group = Group::where('user_id', $this->user->id)->first();
-    $shares = $group->debts->first()->shares;
+        $shares = $debt->shares;
 
-    $response = $this->delete(route('group.destroy'), [
-        'id' => $group->id,
-        'name' => $group->name,
-        'user_id' => $this->user->id,
-    ]);
-
-    foreach ($shares as $share) {
-        $this->assertDatabaseHas('shares', [
+        foreach ($shares as $share) {
+             $this->assertDatabaseHas('shares', [
             'id' => $share->id,
             'debt_id' => $group->debts->first()->id,
             'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
-        ]);
+            ]);
+        }
     } 
 });
+
+// test('deleting a group deletes the relevant shares', function() {
+//     $group = Group::where('user_id', $this->user->id)->first();
+//     $shares = $group->debts->first()->shares;
+
+//     $response = $this->delete(route('group.destroy'), [
+//         'id' => $group->id,
+//         'name' => $group->name,
+//         'user_id' => $this->user->id,
+//     ]);
+
+//     foreach ($shares as $share) {
+//         $this->assertDatabaseHas('shares', [
+//             'id' => $share->id,
+//             'debt_id' => $group->debts->first()->id,
+//             'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
+//         ]);
+//     } 
+// });
 
 test('user can not delete a group they do not own', function() {
     $not_group_owner = $this->users->last();

--- a/tests/Feature/TotalBalanceTest.php
+++ b/tests/Feature/TotalBalanceTest.php
@@ -12,12 +12,14 @@ beforeEach(function () {
     $this->actingAs($this->self);
 });
 
+// $user_balance is x100 as it is accessed, therefore is /100 for user benefit
+// $sum, however is just a sum of the db values, therefore isn't hit by the
+// accessor in the same way
 test("the seeded db calculates all user's user balance correctly", function() {
     foreach ($this->users as $user) {
         $group_users = GroupUser::where('user_id', $user->id);
         $sum = $group_users->sum('balance');
-        $user_balance = $user->user_balance;
-  
+        $user_balance = $user->user_balance * 100;
         $this->assertTrue($sum == strval($user_balance));
     }
 });


### PR DESCRIPTION
The aim of this PR is to improve currency storage in chopr, as mentioned in the previous PR.

- [x] Add `brick/money` php package
- [x] update seeder to use `brick/money`
- [ ] update services to use `brick/money`
    - [ ] add debt standard
    - [ ] update debt standard
    - [ ] remove debt standard
    - [ ] add share standard
    - [ ] update share standard
    - [ ] remove share standard
    - [ ] add debt split even
    - [ ] update debt split even
    - [ ] remove debt split even
    - [ ] add share split even
    - [ ] update share split even
    - [ ] remove share split even
- [x] Add `Dinero.js` library
- [ ] update add debt functions
- [ ] update update debt functions
- [ ] Update tests

Extra:

- Fixed issue with debts & shares not deleting following group deletion. Turns out `onCascadeDelete()` doesn't work with soft deletes