### PR TITLE
Add administrators

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -34,7 +34,7 @@ class AuthenticatedSessionController extends Controller
     public function store(LoginRequest $request): RedirectResponse
     {
         $request->authenticate();
-
+   
         $request->session()->regenerate();
 
         return redirect()->intended(route('dashboard', ['status' => session('status')]));

--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -40,9 +40,11 @@ class LoginRequest extends FormRequest
     public function authenticate(): void
     {
         $this->ensureIsNotRateLimited();
-
+        
         if (! Auth::attempt($this->only('email', 'password'), $this->boolean('remember'))) {
             RateLimiter::hit($this->throttleKey());
+
+            // maybe this is where custom auth goes?
 
             throw ValidationException::withMessages([
                 'email' => trans('auth.failed'),

--- a/app/Models/Administrator.php
+++ b/app/Models/Administrator.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class Administrator extends Model
+{
+    /** @use HasFactory<\Database\Factories\UserFactory> */
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+    ];
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var list<string>
+     */
+    protected $hidden = [
+        'password',
+        'remember_token',
+    ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'email_verified_at' => 'datetime',
+            'password' => 'hashed',
+        ];
+    }
+}

--- a/database/factories/AdministratorFactory.php
+++ b/database/factories/AdministratorFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Administrator>
+ */
+class AdministratorFactory extends Factory
+{
+    /**
+     * The current password being used by the factory.
+     */
+    protected static ?string $password;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->name(),
+            'email' => fake()->unique()->safeEmail(),
+            'password' => static::$password ??= Hash::make('password'),
+            'remember_token' => Str::random(10),
+        ];
+    }
+}

--- a/database/migrations/2025_09_10_101134_create_administrators_table.php
+++ b/database/migrations/2025_09_10_101134_create_administrators_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('administrators', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->rememberToken();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('administrators');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -9,6 +9,7 @@ use App\Models\Group;
 use App\Models\GroupUser;
 use App\Models\Debt;
 use App\Models\Share;
+use App\Models\Administrator;
 use Illuminate\Database\Eloquent\Model;
 
 use Faker\Factory as Faker;
@@ -25,6 +26,12 @@ class DatabaseSeeder extends Seeder
         $this->createGroupsWithGroupUsers();
         $this->createDebtsWithShares();
         // $this->withGman();
+
+        Administrator::factory()->create([
+            'name' => 'Dom Admin',
+            'email' => 'dom_admin@hotmail.co.uk',
+            'password' => 'password',
+        ]);
     }
 
     public function createUsers()

--- a/resources/js/Pages/InertiaPlayground.vue
+++ b/resources/js/Pages/InertiaPlayground.vue
@@ -1,6 +1,9 @@
 <script setup>
 
 import { Head } from '@inertiajs/vue3';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import SecondaryButton from '@/Components/SecondaryButton.vue';
+import { Form } from '@inertiajs/vue3';
 
 defineProps({
     inertiaVariable: {
@@ -11,7 +14,14 @@ defineProps({
 
 <template>
     <Head title="Dashboard" />
-</br>
-    I wonder if this works
-    {{  inertiaVariable }}
+    <p>I wonder if this works</p>
+    <p>{{  inertiaVariable }}</p>
+    <div class="flex flex-col p-2">
+        <PrimaryButton>Primary Button</PrimaryButton>
+        <SecondaryButton>Secondary Button</SecondaryButton>
+        <Form>
+            <label for="test">Test</label>
+            <input type="text" name="test">
+        </Form>
+    </div>
 </template>

--- a/resources/views/playground.blade.php
+++ b/resources/views/playground.blade.php
@@ -1,4 +1,4 @@
 welcome to the playground
 </br>
-{{ $test_variable}}
+{{ $test_variable }}
 {{ app()->environment() }}


### PR DESCRIPTION
Looking into the idea of this, it very quickly grew arms & legs and would need a lot more dedicated time to planning and deciding actually what is required vs what is useful, some initial thoughts:

- Simply having an `is_admin` property on `Users` would likely be a lot easier than adding an entirely new `Administrator` model. 
    - This would save a lot of code duplication (things like password reset, middleware), unless I can figure out a way to make admins just extend users without being messy. Maybe just be a case of creating an admin migration & model with a single attribute of `user_id`... though in theory isn't that the same as just having `is_admin` on a `User`?

- Total separation is always handy, though I'm not entirely sure it's necessary at this stage, is there even a need for admins?
- 