### PR TITLE
Update routes to use route resources & bit of code cleanup

### DIFF
--- a/app/Http/Controllers/GroupUserController.php
+++ b/app/Http/Controllers/GroupUserController.php
@@ -70,14 +70,14 @@ class GroupUserController extends Controller
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(Request $request, GroupUser $groupUser): RedirectResponse
+    public function destroy(Request $request, GroupUser $group_user): RedirectResponse
     {
-        $validated = Validator::make($request->all(), [
+        $validated = Validator::make($group_user->toArray(), [
             'group_id' => ['required', 'integer', 'exists:groups,id', new IsGroupOwner()],
-            'group_user_id' => ['required', 'integer', 'exists:group_users,id'],
+            'id' => ['required', 'integer', 'exists:group_users,id'],
         ])->validate();
         
-        $group_user = GroupUser::findOrFail($validated['group_user_id']);
+        $group_user = GroupUser::findOrFail($validated['id']);
         $group_user->delete();
 
         return redirect()->route('groups')->with('status', 'Group User deleted successfully.');

--- a/resources/js/Components/GroupUsers/GroupUser.vue
+++ b/resources/js/Components/GroupUsers/GroupUser.vue
@@ -45,17 +45,13 @@ onMounted(() => {
                 </h2>
                 <Form
                     class="mt-6 flex justify-end"
-                    :action="route('group-users.destroy')"
+                    :action="route('group-users.destroy', props.group_user.id)"
                     method="delete"
                     #default="{ errors }"
                     @success="confirmingGroupUserDeletion = false"
                     :options="{
                         preserveScroll: true,
                     }"
-                    :transform="data => ({ 
-                        ...data, 
-                        group_user_id: props.group_user.id,
-                    })"
                 >
                     <div>
                         <div class="flex justify-end">
@@ -65,11 +61,6 @@ onMounted(() => {
                             >
                                 Cancel
                             </button>
-                            <input
-                                type="hidden"
-                                name="group_id"
-                                :value="props.group.id"
-                            />
                             <button
                                 class="ms-3"
                             >

--- a/routes/web.php
+++ b/routes/web.php
@@ -95,10 +95,15 @@ Route::middleware('auth')->group(function () {
 });
 
 // group users
-Route::middleware('auth')->group(function () {
-    Route::post('/group-users', [GroupUserController::class, 'store'])->name('group-users.store');
-    Route::delete('/group-users', [GroupUserController::class, 'destroy'])->name('group-users.destroy');
-});
+// Route::middleware('auth')->group(function () {
+//     Route::post('/group-users', [GroupUserController::class, 'store'])->name('group-users.store');
+//     Route::delete('/group-users', [GroupUserController::class, 'destroy'])->name('group-users.destroy');
+// });
+Route::resource('group-users', GroupUserController::class)
+    ->middleware('auth')
+    ->only([
+        'store', 'destroy'
+    ]);
 
 // comments
 Route::middleware('auth')->group(function () {


### PR DESCRIPTION
The aim of this PR will be to update routes to use route resources, and bring the codebase better in line with best practices where applicable. Models that will need updated, but yet haven't been fully investigated:

- [ ] Users
- [x] Groups
- [x] Group Users
- [ ] Debts
- [ ] Shares
- [ ] Comments

For all I know it may not be applicable in some places, at least without some serious change, so we'll see. 

Scope creep:
- Updated `GroupController` destroy method to use `DebtService`
- Updated the following 'destroy' routes to use a param and not hidden input:
    - group user
    - group