### PR TITLE
Forge mail server

### DIFF
--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -62,8 +62,6 @@ class RegisteredUserController extends Controller
                 'accepted_at' => Carbon::now(),
             ]);
 
-            ExpireInvite::dispatch($invite);
-
             return redirect()->route('group.index')->with('status', "You have successfully joined {$invite->group->name}");
         } else {
             return redirect(route('debt.index', absolute: false));

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -15,6 +15,7 @@ use Illuminate\Validation\Rules;
 use Inertia\Inertia;
 use Inertia\Response;
 use Carbon\Carbon;
+use App\Jobs\ExpireInvite;
 
 class RegisteredUserController extends Controller
 {
@@ -60,6 +61,8 @@ class RegisteredUserController extends Controller
             $invite->update([
                 'accepted_at' => Carbon::now(),
             ]);
+
+            ExpireInvite::dispatch($invite);
 
             return redirect()->route('group.index')->with('status', "You have successfully joined {$invite->group->name}");
         } else {

--- a/app/Http/Controllers/InviteController.php
+++ b/app/Http/Controllers/InviteController.php
@@ -45,8 +45,8 @@ class InviteController extends Controller
             ]);
         
             Mail::to($recipient)->send(new InviteToGroup($invite));
-
-            ExpireInvite::dispatch($invite)->delay(Carbon::now()->addDays(1));
+            
+            ExpireInvite::dispatch($invite)->delay(Carbon::now()->addMinutes(1));
             
             $count++;
         }

--- a/app/Http/Controllers/InviteController.php
+++ b/app/Http/Controllers/InviteController.php
@@ -44,7 +44,7 @@ class InviteController extends Controller
                 'token' => Str::random(16),
             ]);
         
-            Mail::to($recipient)->send(new InviteToGroup($invite));
+            Mail::to($recipient)->queue(new InviteToGroup($invite));
             
             ExpireInvite::dispatch($invite)->delay(Carbon::now()->addMinutes(1));
             

--- a/app/Http/Controllers/InviteController.php
+++ b/app/Http/Controllers/InviteController.php
@@ -76,7 +76,7 @@ class InviteController extends Controller
             $invite->update(['accepted_at' => Carbon::now()]);
             ExpireInvite::dispatch($invite);
 
-            return redirect()->route('group.index')->with('status', "You have successfully joined {$group->name}");
+            return redirect()->route('group.index')->with('status', "You have successfully joined {$invite->group->name}");
         } else {
             // so if they're a new user, store the token in the session
             // and populate the register with their invite info (just email address)

--- a/app/Http/Controllers/InviteController.php
+++ b/app/Http/Controllers/InviteController.php
@@ -58,16 +58,12 @@ class InviteController extends Controller
 
     public function accept($token)
     {
+        // find invite & invited user
         $invite = Invite::where('token', $token)->first();
-     
-        // check if the user is already in the group 
-        if ($invite->accepted_at) {
-            return redirect()->route('debt.index')->with('status', "You are already a member of this group.");
-        }
-
-        $group = Group::findOrFail($invite->group_id);
         $user = User::where('email', $invite->recipient)->first();
 
+        // if they exist as a user but not in this group, add them to the group
+        // also updated accepted_at & expire the invite
         if ($user) {
             Auth::login($user);
 
@@ -78,9 +74,12 @@ class InviteController extends Controller
             ]);
 
             $invite->update(['accepted_at' => Carbon::now()]);
+            ExpireInvite::dispatch($invite);
 
             return redirect()->route('group.index')->with('status', "You have successfully joined {$group->name}");
         } else {
+            // so if they're a new user, store the token in the session
+            // and populate the register with their invite info (just email address)
             session(['token' => $invite->token]);
 
             return Inertia::render('Auth/Register', [

--- a/app/Http/Controllers/InviteController.php
+++ b/app/Http/Controllers/InviteController.php
@@ -46,7 +46,7 @@ class InviteController extends Controller
         
             Mail::to($recipient)->queue(new InviteToGroup($invite));
             
-            ExpireInvite::dispatch($invite)->delay(Carbon::now()->addMinutes(1));
+            ExpireInvite::dispatch($invite)->delay(Carbon::now()->addDays(1));
             
             $count++;
         }

--- a/app/Http/Controllers/InviteController.php
+++ b/app/Http/Controllers/InviteController.php
@@ -74,7 +74,6 @@ class InviteController extends Controller
             ]);
 
             $invite->update(['accepted_at' => Carbon::now()]);
-            ExpireInvite::dispatch($invite);
 
             return redirect()->route('group.index')->with('status', "You have successfully joined {$invite->group->name}");
         } else {

--- a/app/Http/Middleware/CheckInviteExpiry.php
+++ b/app/Http/Middleware/CheckInviteExpiry.php
@@ -20,23 +20,26 @@ class CheckInviteExpiry
     public function handle(Request $request, Closure $next): Response|\Inertia\Response
     {
         $invite = Invite::where('token', $request->route('token'))->first();
-
-        // if the invite isn't expired, proceed to controller accept method
-        if ($invite) {
-
-            if ($invite->accepted_at !== null) {
+  
+        switch ($invite) {
+            // invite already accepted, log in & redirect to groups
+            case $invite->accepted_at !== null:
                 $user = User::where('email', $invite->recipient)->first();
                 Auth::login($user);
 
                 return redirect()->route('group.index');
-            } else {
-                return $next($request);
-            }
-            
-        } else {
-            // otherwise, invite has expired, show message on registration page
-            return Inertia::render('Auth/Register', [
+            // invite is expired, redirect to registration w/message
+            case $invite->expired_at !== null:
+                return Inertia::render('Auth/Register', [
                 'status' => 'This invite link has expired. You may either sign up or ask the sender to resend the invite.',
+            ]);
+            // invite not accepted, proceed to controller
+            case $invite->accepted_at === null:
+                return $next($request);
+            // default case, just redirect to register
+            default:
+                return Inertia::render('Auth/Register', [
+                'status' => 'An error has occurred. ',
             ]);
         }
     }

--- a/app/Http/Middleware/CheckInviteExpiry.php
+++ b/app/Http/Middleware/CheckInviteExpiry.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use App\Models\Invite;
+use Inertia\Inertia;
+
+class CheckInviteExpiry
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response|\Inertia\Response
+    {
+        $invite = Invite::where('token', $request->route('token'))->first();
+
+        // if the invite isn't expired, proceed to controller accept method
+        if ($invite) {
+            return $next($request);
+        } else {
+            // otherwise, invite has expired, show message on registration page
+            return Inertia::render('Auth/Register', [
+                'status' => 'This invite link has expired. You may either sign up or ask the sender to resend the invite.',
+            ]);
+        }
+    }
+}

--- a/app/Http/Middleware/CheckInviteExpiry.php
+++ b/app/Http/Middleware/CheckInviteExpiry.php
@@ -6,7 +6,9 @@ use Closure;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 use App\Models\Invite;
+use App\Models\User;
 use Inertia\Inertia;
+use Illuminate\Support\Facades\Auth;
 
 class CheckInviteExpiry
 {
@@ -21,7 +23,16 @@ class CheckInviteExpiry
 
         // if the invite isn't expired, proceed to controller accept method
         if ($invite) {
-            return $next($request);
+
+            if ($invite->accepted_at !== null) {
+                $user = User::where('email', $invite->recipient)->first();
+                Auth::login($user);
+
+                return redirect()->route('group.index');
+            } else {
+                return $next($request);
+            }
+            
         } else {
             // otherwise, invite has expired, show message on registration page
             return Inertia::render('Auth/Register', [

--- a/app/Http/Middleware/CheckInviteExpiry.php
+++ b/app/Http/Middleware/CheckInviteExpiry.php
@@ -25,6 +25,10 @@ class CheckInviteExpiry
             // invite already accepted, log in & redirect to groups
             case $invite->accepted_at !== null:
                 $user = User::where('email', $invite->recipient)->first();
+                // todo: look into session tokens properly
+                // as currently this is a bit insecure
+                // if you send someone your link
+                // they can log in as you
                 Auth::login($user);
 
                 return redirect()->route('group.index');

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -46,10 +46,9 @@ class HandleInertiaRequests extends Middleware
                 'debts' => $user ? Debt::where('user_id', $user->id)->with('shares')->get() : [],
                 'comment_ids' => $user ? Comment::where('user_id', $user->id)->pluck('id')->toArray() : [],
             ],
-            // can put all sorts of messages here and just show with some js?
-            // 'flash' => [
-            //     'message' => fn () => $request->session()->get('message'),
-            // ],
+            'flash' => [
+                'status' => fn () => $request->session()->get('status'),
+            ],
         ]);
     }
 }

--- a/app/Jobs/ExpireInvite.php
+++ b/app/Jobs/ExpireInvite.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use App\Models\Invite;
+use Carbon\Carbon;
 
 class ExpireInvite implements ShouldQueue
 {
@@ -20,6 +21,8 @@ class ExpireInvite implements ShouldQueue
 
     public function handle(): void
     {
-        $this->invite->delete();
+        $this->invite->update([
+            'expired_at' => Carbon::now()
+        ]);
     }
 }

--- a/app/Mail/InviteToGroup.php
+++ b/app/Mail/InviteToGroup.php
@@ -17,6 +17,8 @@ class InviteToGroup extends Mailable
 {
     use Queueable, SerializesModels;
 
+    public bool $is_new_user;
+
     /**
      * Create a new message instance.
      */
@@ -44,7 +46,6 @@ class InviteToGroup extends Mailable
      */
     public function content(): Content
     {
-    
         return new Content(
             view: 'emails.invite-to-group',
             with: [

--- a/app/Mail/InviteToGroup.php
+++ b/app/Mail/InviteToGroup.php
@@ -33,9 +33,9 @@ class InviteToGroup extends Mailable
     public function envelope(): Envelope
     {
         return new Envelope(
-            from: new Address('hello@example.com', 'Chopr Admin'),
+            from: new Address('admin@chopr.co.uk', 'Chopr Admin'),
             replyTo:  [
-                new Address('hello@example.com', 'Chopr Admin'),
+                new Address('admin@chopr.co.uk', 'Chopr Admin'),
             ],
             subject: 'Invite To Group',
         );

--- a/app/Models/Invite.php
+++ b/app/Models/Invite.php
@@ -25,6 +25,7 @@ class Invite extends Model
         'group_id',
         'recipient',
         'accepted_at',
+        'expired_at',
         'body',
         'token',
     ];

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -85,13 +85,17 @@ class User extends Authenticatable
     protected function userBalance(): Attribute
     {
         return Attribute::get(function () {
-            return $this->group_users->reduce(function (?Money $carry, GroupUser $group_user) {
-                // sets the carry as the first group_user balance
-                if ($carry === null) {
-                    return $group_user->balance;
-                }
-                return $carry->plus($group_user->balance);
-            }, null);
+            if ($this->group_users->isEmpty()) {
+                return Money::of(0, 'GBP');
+            } else {
+                return $this->group_users->reduce(function (?Money $carry, GroupUser $group_user) {
+                    // sets the carry as the first group_user balance
+                    if ($carry === null) {
+                        return $group_user->balance;
+                    }
+                    return $carry->plus($group_user->balance);
+                }, null);
+            }
         });
     }
 

--- a/config/mail.php
+++ b/config/mail.php
@@ -116,7 +116,7 @@ return [
     */
 
     'from' => [
-        'address' => env('MAIL_FROM_ADDRESS', 'hello@example.com'),
+        'address' => env('MAIL_FROM_ADDRESS', 'admin@chopr.co.uk'),
         'name' => env('MAIL_FROM_NAME', 'Chopr Admin'),
     ],
 

--- a/database/migrations/2025_11_03_151841_add_expired_at_column_to_invites_table.php
+++ b/database/migrations/2025_11_03_151841_add_expired_at_column_to_invites_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('invites', function (Blueprint $table) {
+            $table->timestamp('expired_at')->nullable()->after('accepted_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('invites', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/resources/js/Components/Collapsible.vue
+++ b/resources/js/Components/Collapsible.vue
@@ -1,0 +1,46 @@
+<script setup>
+import { ref } from 'vue'
+
+const props = defineProps({
+    modelValue: {
+        type: Boolean,
+        required: true,
+    },
+    duration: {
+        type: Number,
+        default: 300,
+    },
+})
+
+const content = ref(null)
+
+// Transition hooks for smooth height animation
+const enter = (el) => {
+    el.style.height = '0'
+    el.style.transition = `height ${props.duration}ms ease`
+    el.offsetHeight // trigger reflow
+    el.style.height = el.scrollHeight + 'px'
+}
+
+const leave = (el) => {
+    el.style.height = el.scrollHeight + 'px'
+    el.offsetHeight
+    el.style.transition = `height ${props.duration}ms ease`
+    el.style.height = '0'
+}
+</script>
+
+<template>
+    <transition
+        @enter="enter"
+        @leave="leave"
+        >
+        <div
+            v-show="modelValue"
+            ref="content"
+            class="overflow-hidden transition-all duration-300 ease-in-out"
+        >
+            <slot />
+        </div>
+    </transition>
+</template>

--- a/resources/js/Components/Debts/AddDebt/Form/AddDebtForm.vue
+++ b/resources/js/Components/Debts/AddDebt/Form/AddDebtForm.vue
@@ -183,8 +183,8 @@ function addDebt() {
                     </AddDebtFormAmount>
                 </div>
                 <Slider
-                    label="Split even?"
-                    alignment="right"
+                    label="Split even"
+                    alignment="end"
                     size="xs"
                     @toggled="toggleSplitEven"
                 >

--- a/resources/js/Components/Debts/AddDebt/Form/AddDebtFormShare.vue
+++ b/resources/js/Components/Debts/AddDebt/Form/AddDebtFormShare.vue
@@ -15,8 +15,6 @@ const share = ref(store.addDebtForm.user_shares.find((userShare) =>
     userShare.user_id == props.group_user.user_id
 ));
 
-const focused = ref(false);
-
 function setShareAmount() {
     // checked is toggled so that if the user switches to split even mid-debt creation
     // the added users are retained
@@ -43,10 +41,7 @@ onMounted(() => {});
 
 </script>
 <template>
-    <div 
-        class="flex flex-col py-1 mt-2"
-        :class="focused ? 'bg-gray-200' : 'bg-white'"
-    >
+    <div class="flex flex-col py-1 mt-2 ">
         <p>
             {{ group_user.user.name }}
         </p>
@@ -64,8 +59,7 @@ onMounted(() => {});
                     :name="`share-name-${group_user.id}`"
                     v-model="share.name"
                     placeholder="Share name..."
-                    @focus="focused = true"
-                    @blur="focused = false"
+      
                     class="w-full"
                 >
                 </TextInput>
@@ -85,14 +79,14 @@ onMounted(() => {});
                     v-model="share.amount"
                     @change="setShareAmount"
                     :disabled="store.addDebtForm.split_even"
-                    @focus="focused = true"
-                    @blur="focused = false"
+           
                     class="w-1/2 md:w-24 ml-4 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 mr-2"
                 >
                 <div :class="store.addDebtForm.split_even ? '' : 'invisible'">
                     <Slider
                         @toggled="toggleShareChecked"
                         :checked="share.checked"
+                        alignment="end"
                     >
                     </Slider>
                 </div>
@@ -109,5 +103,4 @@ textarea {
 textarea:invalid {
   border: 2px solid red;
 }
-
 </style>

--- a/resources/js/Components/Debts/Debt.vue
+++ b/resources/js/Components/Debts/Debt.vue
@@ -14,6 +14,7 @@ import PrimaryButton from '@/Components/PrimaryButton.vue';
 import SecondaryButton from '@/Components/SecondaryButton.vue';
 import TextInput from '@/Components/TextInput.vue';
 import AddShare from '@/Components/Shares/AddShare.vue';
+import Collapsible from '@/Components/Collapsible.vue';
 
 const props = defineProps({
     debt: {
@@ -52,13 +53,22 @@ onMounted(() => {
 
 <template>
     <div class="card">
+        <!-- front facing card -->
         <div class="flex flex-row items-center">
-            <i 
-                class="fa-solid fa-chevron-up p-2"
-                @click="showShares = !showShares"
-                :class="showShares ? 'rotate180' : 'rotateback'"
-            >
-            </i>
+            <div class="flex flex-col items-center">
+                <p class="flex flex-row" @click="showComments = !showComments">
+                    <i class="fa-solid fa-comments"></i>
+                    <small>
+                        {{ debt.comments.length >= 1 ? '(' + debt.comments.length + ')' : ''}}
+                    </small>
+                </p>
+                <i 
+                    class="fa-solid fa-chevron-up p-2"
+                    @click="showShares = !showShares"
+                    :class="showShares ? 'rotate180' : 'rotateback'"
+                >
+                </i>
+            </div>
             <div v-if="!isEditing" class="flex flex-col w-full">
                 <h2 class="h3 bold text-center"> 
                     {{ props.debt.name }}
@@ -149,7 +159,8 @@ onMounted(() => {
             </Controls>
         </div>
         <!-- <InputError class="mt-2" :message="debtForm.errors.amount" /> -->
-        <div class="flex flex-col" v-show="showShares">
+         <!-- shares -->
+        <Collapsible v-model="showShares" class="flex-flex-col">
             <Share
                 v-for="share in debt.shares"
                 :share="share"
@@ -157,36 +168,29 @@ onMounted(() => {
                 :debt="debt"
             >
             </Share>
-            <AddShare
-                v-if="owns_debt"
+        </Collapsible>
+        <!-- add share-->
+        <AddShare
+            v-if="owns_debt && showShares"
+            :debt="debt"
+            :group_users="debt.group.group_users"
+        >
+        </AddShare>
+        <!-- comments -->
+        <Collapsible v-model="showComments" >
+            <div style="max-height:50vh;overflow-y:scroll;">
+                <Comment
+                    v-for="comment in debt.comments"
+                    :comment="comment"
+                >
+                </Comment>
+            </div>
+            <AddComment
                 :debt="debt"
-                :group_users="debt.group.group_users"
+                :user="usePage().props.auth.user"
             >
-            </AddShare>
-            <div class="flex flex-row items-center">
-                <p>View Comments {{ debt.comments.length >= 1 ? '(' + debt.comments.length + ')' : ''}}</p>
-                <i 
-                    class="fa-solid fa-chevron-up p-2"
-                    @click="showComments = !showComments"
-                    :class="showComments ? 'rotate180' : 'rotateback'"
-                >
-                </i>
-            </div>
-            <div v-show="showComments">
-                <div style="height:50vh;overflow-y:scroll;">
-                    <Comment
-                        v-for="comment in debt.comments"
-                        :comment="comment"
-                    >
-                    </Comment>
-                </div>
-                <AddComment
-                    :debt="debt"
-                    :user="usePage().props.auth.user"
-                >
-                </AddComment>
-            </div>
-        </div>
+            </AddComment>
+        </Collapsible>
         <Modal :show="confirmingDebtDeletion" @close="closeModal">
             <div class="p-6 flex flex-col">
                 <h2

--- a/resources/js/Components/Groups/Group.vue
+++ b/resources/js/Components/Groups/Group.vue
@@ -13,6 +13,7 @@ import DangerButton from '@/Components/DangerButton.vue';
 import SecondaryButton from '@/Components/SecondaryButton.vue';
 import PrimaryButton from '@/Components/PrimaryButton.vue';
 import TextInput from '@/Components/TextInput.vue';
+import Collapsible from '@/Components/Collapsible.vue'
 
 const props = defineProps({
     group: {
@@ -94,7 +95,7 @@ const confirmingGroupDeletion = ref(false);
             >
             </Controls>
         </div>
-        <div v-show="showGroupUsers" class="flex flex-col">
+        <Collapsible v-model="showGroupUsers" class="mt-3 flex-flex-col">
             <GroupUser 
                 v-for="group_user in group.group_users"
                 :group_user="group_user"
@@ -107,7 +108,7 @@ const confirmingGroupDeletion = ref(false);
                 :group="group"
             >
             </InviteToGroup>
-        </div>
+        </Collapsible>
         <Modal :show="confirmingGroupDeletion" @close="confirmingGroupDeletion = false;">
             <div class="p-6 flex flex-col">
                 <h2

--- a/resources/js/Components/Slider.vue
+++ b/resources/js/Components/Slider.vue
@@ -22,7 +22,7 @@ const sliderValue = ref(props.checked);
 
 </script>
 <template>
-    <div :class="`items-${props.alignment} flex flex-col`">
+    <div :class="`flex flex-col items-${props.alignment}`">
         <p :class="`text-${props.size}`">{{ label }}</p>
         <label class="switch">
             <input 

--- a/resources/js/Components/Toast.vue
+++ b/resources/js/Components/Toast.vue
@@ -1,11 +1,14 @@
 <script setup>
-import { ref, onMounted, watch } from 'vue';
+import { ref, onMounted, watch} from 'vue';
+import { usePage } from '@inertiajs/vue3';
 
 const props = defineProps({
     message: {
         type: String,
     },
 });
+
+const showToast = ref(false);
 
 /**
  * There's likely a better way of achieving this 
@@ -15,30 +18,75 @@ const props = defineProps({
  * So should be quite future-proof
  */
 onMounted(() => {
-    setTimeout(() => {
-        const toast = document.getElementById('toast');
-        toast.style.display = 'flex';
-    }, 1000)
-})
+
+});
 
 watch(
-    () => props.message,
+    () => usePage().props.flash.status,
     (newMessage) => {
-        if (newMessage) {
-            const toast = document.getElementById('toast');
-            toast.style.display = 'flex';
+        showToast.value = true;
 
-            setTimeout(() => {
-                toast.style.display = 'hidden';
-            }, 1000)
-        }
-    },
+        setTimeout(() => {
+            showToast.value = false;
+            usePage().props.flash.status = null;
+        }, 3000);
+    }
 );
 </script>
 <template>
-    <div id="toast" class="toast">
-        <p class="p-6 text-2xl text-green-300">
-            {{ props.message }}
-        </p>
+    <div class="toast-wrapper md:w-1/2 p-2">
+        <div v-show="showToast" id="toast" class="toast">
+            <p class="p-6 text-2xl text-green-300">
+                {{ usePage().props.flash.status }}
+            </p>
+        </div>
     </div>
 </template>
+<style>
+
+.toast-wrapper {
+    position:fixed;
+    display:flex;
+    justify-content:center;
+    align-items:center;
+    pointer-events:none;
+    z-index:1000;
+} 
+
+.toast {
+    display: flex;
+    height: 100px;
+    width: 100%;
+    top: 100px;
+    background-color: white;
+    border: #9cef60 2px solid;
+    border-radius: 15px;
+    position: sticky;
+    box-shadow: 0 4px 12px #9cef60;
+    animation: toastFade 3s ease-in-out forwards;
+}
+
+.toast > p {
+    color: #9cef60;
+    font-weight: bold;
+}
+
+@keyframes toastFade {
+  0% {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+  20% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  70% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+}
+</style>

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -232,13 +232,7 @@ const showingNavigationDropdown = ref(false);
             <!-- Page Content -->
             <main class="flex flex-col items-center bg-sky-500"> 
                 <!-- Toast for displaying messages after operations -->
-                <div class="toast-wrapper md:w-1/2 p-2">
-                    <Toast
-                        v-if="props.status"
-                        :message="props.status"
-                    >
-                    </Toast>
-                </div>
+                <Toast />
                 <div class="bg-sky-200 w-full md:w-1/2 p-2" style="min-height:calc(100vh - 65px)">
                     <slot />
                 </div>
@@ -246,51 +240,4 @@ const showingNavigationDropdown = ref(false);
         </div>
     </div>
 </template>
-<style>
 
-.toast-wrapper {
-    position:fixed;
-    display:flex;
-    justify-content:center;
-    align-items:center;
-    pointer-events:none;
-    z-index:1000;
-}
-
-.toast {
-    height: 100px;
-    width: 100%;
-    top: 100px;
-    background-color: white;
-    border: #9cef60 2px solid;
-    border-radius: 15px;
-    position: sticky;
-    box-shadow: 0 4px 12px #9cef60;
-    animation: toastFade 3s ease-in-out forwards;
-}
-
-.toast > p {
-    color: #9cef60;
-    font-weight: bold;
-}
-
-
-@keyframes toastFade {
-  0% {
-    opacity: 0;
-    transform: translateY(-20px);
-  }
-  20% {
-    opacity: 1;
-    transform: translateY(0);
-  }
-  70% {
-    opacity: 1;
-    transform: translateY(0);
-  }
-  100% {
-    opacity: 0;
-    transform: translateY(-20px);
-  }
-}
-</style>

--- a/resources/js/Pages/Auth/Register.vue
+++ b/resources/js/Pages/Auth/Register.vue
@@ -15,7 +15,12 @@ const props = defineProps({
             recipient: '',
             token: '',
         }),
-    }
+    },
+    status: {
+        type: String,
+        required: false,
+        default: '',
+    },
 });
 
 const form = useForm({
@@ -41,6 +46,10 @@ onMounted(() => {
 <template>
     <GuestLayout>
         <Head title="Register" />
+
+        <div v-if="status" class="mb-4 text-sm font-medium text-green-600 text-center">
+            {{ status }}
+        </div>
 
         <form @submit.prevent="submit">
             <div>

--- a/resources/views/playground.blade.php
+++ b/resources/views/playground.blade.php
@@ -1,5 +1,5 @@
 <h1>welcome to the playground!</h1>
 </br>
 <p>{{ $user->name }} is the first user in the db</p>
-</br>
-<p>{{ $auth_user }} is logged in</p>
+
+<p>{{ $invites }}</p>

--- a/routes/web.php
+++ b/routes/web.php
@@ -90,10 +90,12 @@ Route::get('/invite/accept/{token}', [InviteController::class, 'accept'])->name(
 // testing/playground
 Route::get('/playground', function() {
 
+    
     return view('playground', [
         'test_variable' => 'just some text',
         'auth_user' => Auth::user() ? Auth::user() : 'no user',
         'user' => User::first(),
+        'invites' => Invite::all(),
     ]);
 
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -90,7 +90,6 @@ Route::get('/invite/accept/{token}', [InviteController::class, 'accept'])->name(
 // testing/playground
 Route::get('/playground', function() {
 
-    
     return view('playground', [
         'test_variable' => 'just some text',
         'auth_user' => Auth::user() ? Auth::user() : 'no user',

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,6 +18,7 @@ use App\Models\Debt;
 use App\Models\Share;
 use Illuminate\Support\Facades\Auth;
 use App\Models\Invite;
+use App\Http\Middleware\CheckInviteExpiry;
 
 /*
 * OOTB routes
@@ -85,7 +86,9 @@ Route::middleware('auth')->group(function () {
 // mails
 Route::get('/invite', [InviteController::class, 'index'])->name('invite.index');
 Route::post('/invite', [InviteController::class, 'store'])->name('invite.send');
-Route::get('/invite/accept/{token}', [InviteController::class, 'accept'])->name('invite.accept');
+Route::get('/invite/accept/{token}', [InviteController::class, 'accept'])
+    ->middleware(CheckInviteExpiry::class)
+    ->name('invite.accept');
 
 // testing/playground
 Route::get('/playground', function() {

--- a/tests/Feature/Http/Controllers/InviteControllerTest.php
+++ b/tests/Feature/Http/Controllers/InviteControllerTest.php
@@ -238,7 +238,7 @@ test('a user can not send an invite link to a user who is already in the group',
         ]);
 });
 
-test('a user can not accept a group invite for a group they are already in', function() {
+test('user clicking on the invite link after accepting it logs them in and redirects them to groups', function() {
     $user = $this->group->users->first();
 
     $invite = Invite::factory()->create([
@@ -246,14 +246,16 @@ test('a user can not accept a group invite for a group they are already in', fun
         'user_id' => $this->user->id,
         'recipient' => $user->email,
         'accepted_at' => Carbon::now(),
-        'deleted_at' => Carbon::now(),
     ]);
 
     $this->actingAs($user);
 
     $response = $this->get('/invite/accept/' . $invite->token);
-    
-    $response->assertStatus(200);
+
+    $response->assertInertia(function (AssertableInertia $page) use ($invite) {
+        $page->component('Groups')
+                ->where('groups', $this->group);
+    });
 });
 
 test('invites are deleted after 24 hours', function() {

--- a/tests/Feature/Http/Controllers/InviteControllerTest.php
+++ b/tests/Feature/Http/Controllers/InviteControllerTest.php
@@ -246,14 +246,14 @@ test('a user can not accept a group invite for a group they are already in', fun
         'user_id' => $this->user->id,
         'recipient' => $user->email,
         'accepted_at' => Carbon::now(),
+        'deleted_at' => Carbon::now(),
     ]);
 
     $this->actingAs($user);
 
     $response = $this->get('/invite/accept/' . $invite->token);
     
-    $response->assertStatus(302)
-        ->assertSessionHas('status', "You are already a member of this group.");
+    $response->assertStatus(200);
 });
 
 test('invites are deleted after 24 hours', function() {

--- a/tests/Feature/Http/Controllers/InviteControllerTest.php
+++ b/tests/Feature/Http/Controllers/InviteControllerTest.php
@@ -48,8 +48,8 @@ test('user can invite someone to the group if they are the owner', function() {
         'body' => 'hey join this group',
     ]);
     
-    Mail::assertSent(InviteToGroup::class, 'randomguy@example.com');
-    Mail::assertSentCount(1);
+    Mail::assertQueued(InviteToGroup::class, 'randomguy@example.com');
+    Mail::assertQueuedCount(1);
 });
 
 test('user can invite multiple people to a group they own', function() {
@@ -80,8 +80,8 @@ test('user can invite multiple people to a group they own', function() {
         ]);
     }
 
-    Mail::assertSent(InviteToGroup::class, $recipients);
-    Mail::assertSentCount(count($recipients));
+    Mail::assertQueued(InviteToGroup::class, $recipients);
+    Mail::assertQueuedCount(count($recipients));
 });
 
 test('user can not invite someone to the group if they are not the owner', function() {
@@ -136,7 +136,7 @@ test('user can not invite anyone without adding at least one email address', fun
         'body' => 'this is going to no one',
     ]);
 
-    Mail::assertNothingSent();
+    Mail::assertNothingQueued();
 });
 
 test('invite accept link renders the register component if the user does not exist', function() {
@@ -146,7 +146,7 @@ test('invite accept link renders the register component if the user does not exi
     ]);
     
     $response = $this->get('/invite/accept/' . $invite->token);
-
+    
     $response->assertInertia(function (AssertableInertia $page) use ($invite) {
         $page->component('Auth/Register')
                 ->where('invite.token', $invite->token);


### PR DESCRIPTION
The aim of this PR is to set up Laravel Forge to send mails, what I have so far:

- Mail is now queued rather than sent, will possibly update queue to use redis in this PR
- Changed all previous "hello@example.com" placeholder 'from' addresses to "admin@chopr.co.uk" (got stuck on this for ages as the only place errors were showing was in Brevo)
- Change for invites to expire in 1min will remain for a while, just for testing purposes

Extras (these happened because I have to wait several days for laravel support/ionos/brevo to sort bits out):

- Moved a bunch of the toast CSS into the actual component as for some reason I had it in the authed layout
- Fixed a bug that caused the app to not load if a user was new (0 balance, no groups or active debts)
- `Collapsible` component added to make the UI more appealing
- Removed unnecessary CSS on `AddDebtFormShare`
- Reworked the layout of a debt card as a UI improvement
- Fixed a bug with the toast where it wouldn't pop if the same operation was done twice in a row, e.g. adding a comment. Fixed this by changing the watcher to be the flash message in middleware, rather than the toast prop. This is still a bit buggy, toast will only pop up again if the 3s animation has finished. This can *hopefully* be fixed with the eventBus in vue, but I have no idea how that will work with inertia. May have to take the toast *out* of inertia and return it in the blade, though that may screw with how success messages are currently returned in order for the toast to work. This will be a new PR entirely
- Invites now use a basic middleware to check token validity & passes a message to the registration page if the invite has already expired

Stuff not in the PR, but very relevant:

- Free SMTP server (300 mails/month) using Brevo
- Registered chopr.co.uk with Ionos & an email address, admin@chopr.co.uk
- Set up a redirect on Ionos from chopr.on-forge.com to chopr.co.uk
- `.env` updated on forge to use Brevo credentials