### PR TITLE
Policies and controls

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -68,7 +68,6 @@ class CommentController extends Controller
     {
         $validated = $request->validated();
 
-        $comment = Comment::find($validated['id']);
         $comment->update([
             'content' => $validated['content'],
             'edited' => true,

--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -99,9 +99,10 @@ class DebtController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(UpdateDebtRequest $request, DebtService $debtService): RedirectResponse
+    public function update(UpdateDebtRequest $request, Debt $debt, DebtService $debtService): RedirectResponse
     {
         $validated = $request->validated();
+        
         $original_amount = Debt::findOrFail($validated['id'])->amount;
         $updated = $debtService->updateDebt($validated);
         

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -14,6 +14,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Validator;
 use App\Rules\IsGroupOwner;
 use Inertia\Inertia;
+use Illuminate\Support\Facades\Auth;
 
 class GroupController extends Controller
 {
@@ -27,7 +28,9 @@ class GroupController extends Controller
             ->with(['group_users.user', 'group_users.aliases'])
             ->get();
 
-        
+        // $group = $groups[0];
+        // $user = Auth::user();
+        // dd($group->users->contains('id', $user->id));
         return Inertia::render('Groups', [
             'groups' => $groups,
             'status' => $request->session()->get('status') ?? null,

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -88,7 +88,7 @@ class GroupController extends Controller
     {
         $validated = $request->validated();
  
-        Group::where('id', $validated['id'])->update(['name' => $validated['name']]);
+        $group->update(['name' => $validated['name']]);
 
         return redirect()->route('group.index')->with('status', 'Group updated successfully.');
     }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -39,10 +39,6 @@ class HandleInertiaRequests extends Middleware
             'auth' => [
                 'user' => $user ? $user->append('user_balance') : null,
             ],
-            'ownership' => [
-                // debts & shares owned by the logged in user
-                'debts' => $user ? Debt::where('user_id', $user->id)->with('shares')->get() : [],
-            ],
             'flash' => [
                 'status' => fn () => $request->session()->get('status'),
             ],

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -42,7 +42,6 @@ class HandleInertiaRequests extends Middleware
             'ownership' => [
                 // debts & shares owned by the logged in user
                 'debts' => $user ? Debt::where('user_id', $user->id)->with('shares')->get() : [],
-                'comment_ids' => $user ? Comment::where('user_id', $user->id)->pluck('id')->toArray() : [],
             ],
             'flash' => [
                 'status' => fn () => $request->session()->get('status'),

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -40,8 +40,6 @@ class HandleInertiaRequests extends Middleware
                 'user' => $user ? $user->append('user_balance') : null,
             ],
             'ownership' => [
-                // groups that the logged in user owns
-                'group_ids' => $user ? Group::where('user_id', $user->id)->pluck('id')->toArray() : [],
                 // debts & shares owned by the logged in user
                 'debts' => $user ? Debt::where('user_id', $user->id)->with('shares')->get() : [],
                 'comment_ids' => $user ? Comment::where('user_id', $user->id)->pluck('id')->toArray() : [],

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use App\Models\Debt;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Auth;
 
 class Comment extends Model
 {

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -22,6 +22,11 @@ class Comment extends Model
         'edited',
     ];
 
+    protected $appends = [
+        'can_update',
+        'can_delete',
+    ];
+
     /**
      * Debt the comment is on.
      * 
@@ -40,5 +45,29 @@ class Comment extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Append can_update policy to model
+     * 
+     * @return bool
+     */
+    public function getCanUpdateAttribute(): bool
+    {
+        $user = Auth::user();
+
+        return $user->can('update', $this);
+    }
+
+    /**
+     * Append can_delete policy to model
+     * 
+     * @return bool
+     */
+    public function getCanDeleteAttribute(): bool
+    {
+        $user = Auth::user();
+
+        return $user->can('delete', $this);
     }
 }

--- a/app/Models/Debt.php
+++ b/app/Models/Debt.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use App\Observers\DebtObserver;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use App\Casts\Cash;
+use Illuminate\Support\Facades\Auth;
 
 class Debt extends Model
 {
@@ -33,6 +34,11 @@ class Debt extends Model
 
     protected $casts = [
         'amount' => Cash::class,
+    ];
+
+    protected $appends = [
+        'can_update',
+        'can_delete',
     ];
 
     /**
@@ -94,5 +100,29 @@ class Debt extends Model
     public function comments(): HasMany
     {
         return $this->hasMany(Comment::class);
+    }
+
+    /**
+     * Append can_update policy to model
+     * 
+     * @return bool
+     */
+    public function getCanUpdateAttribute(): bool
+    {
+        $user = Auth::user();
+
+        return $user->can('update', $this);
+    }
+
+    /**
+     * Append can_delete policy to model
+     * 
+     * @return bool
+     */
+    public function getCanDeleteAttribute(): bool
+    {
+        $user = Auth::user();
+
+        return $user->can('delete', $this);
     }
 }

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use App\Models\Invite;
+use Illuminate\Support\Facades\Auth;
 
 class Group extends Model
 {
@@ -27,6 +28,11 @@ class Group extends Model
     protected $fillable = [
         'name',
         'user_id'
+    ];
+
+    protected $appends = [
+        'can_update',
+        'can_delete',
     ];
 
     /**
@@ -84,5 +90,19 @@ class Group extends Model
     public function invites(): HasMany
     {
         return $this->hasMany(Debt::class);
+    }
+
+    public function getCanUpdateAttribute(): bool
+    {
+        $user = Auth::user();
+
+        return $user->can('update', $this);
+    }
+
+    public function getCanDeleteAttribute(): bool
+    {
+        $user = Auth::user();
+
+        return $user->can('delete', $this);
     }
 }

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -92,6 +92,11 @@ class Group extends Model
         return $this->hasMany(Debt::class);
     }
 
+    /**
+     * Append can_update policy to model
+     * 
+     * @return bool
+     */
     public function getCanUpdateAttribute(): bool
     {
         $user = Auth::user();
@@ -99,6 +104,11 @@ class Group extends Model
         return $user->can('update', $this);
     }
 
+    /**
+     * Append can_delete policy to model
+     * 
+     * @return bool
+     */
     public function getCanDeleteAttribute(): bool
     {
         $user = Auth::user();

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -33,6 +33,7 @@ class Group extends Model
     protected $appends = [
         'can_update',
         'can_delete',
+        'can_invite',
     ];
 
     /**
@@ -114,5 +115,17 @@ class Group extends Model
         $user = Auth::user();
 
         return $user->can('delete', $this);
+    }
+
+    /**
+     * Append can_invite policy to model
+     * 
+     * @return bool
+     */
+    public function getCanInviteAttribute(): bool
+    {
+        $user = Auth::user();
+
+        return $user->can('invite', $this);
     }
 }

--- a/app/Models/GroupUser.php
+++ b/app/Models/GroupUser.php
@@ -82,6 +82,11 @@ class GroupUser extends Model
         return $this->hasMany(Alias::class);
     }
 
+    /**
+     * Append can_update policy to model
+     * 
+     * @return bool
+     */
     public function getCanUpdateAttribute(): bool
     {
         $user = Auth::user();
@@ -89,6 +94,11 @@ class GroupUser extends Model
         return $user->can('update', $this);
     }
 
+    /**
+     * Append can_delete policy to model
+     * 
+     * @return bool
+     */
     public function getCanDeleteAttribute(): bool
     {
         $user = Auth::user();

--- a/app/Policies/CommentPolicy.php
+++ b/app/Policies/CommentPolicy.php
@@ -29,7 +29,7 @@ class CommentPolicy
      */
     public function create(User $user): bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -37,7 +37,7 @@ class CommentPolicy
      */
     public function update(User $user, Comment $comment): bool
     {
-        return false;
+        return $user->id === $comment->user_id;
     }
 
     /**
@@ -45,7 +45,7 @@ class CommentPolicy
      */
     public function delete(User $user, Comment $comment): bool
     {
-        return false;
+        return $user->id === $comment->user_id;
     }
 
     /**

--- a/app/Policies/DebtPolicy.php
+++ b/app/Policies/DebtPolicy.php
@@ -29,7 +29,7 @@ class DebtPolicy
      */
     public function create(User $user): bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -37,8 +37,7 @@ class DebtPolicy
      */
     public function update(User $user, Debt $debt): bool
     {
-        return false;
-        // return $user->id === $debt->group_user->user->id ? true : false;
+        return $user->id === $debt->user_id;
     }
 
     /**
@@ -46,8 +45,7 @@ class DebtPolicy
      */
     public function delete(User $user, Debt $debt): bool
     {
-        return false;
-        // return $user->group_user->id === $debt->collector_group_user_id; 
+        return $user->id === $debt->user_id;
     }
 
     /**

--- a/app/Policies/GroupPolicy.php
+++ b/app/Policies/GroupPolicy.php
@@ -29,7 +29,7 @@ class GroupPolicy
      */
     public function create(User $user): bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -37,7 +37,7 @@ class GroupPolicy
      */
     public function update(User $user, Group $group): bool
     {
-        return $user->id === $group->owner_id ? true : false;
+        return $user->id === $group->user_id;
     }
 
     /**
@@ -45,7 +45,7 @@ class GroupPolicy
      */
     public function delete(User $user, Group $group): bool
     {
-        return false;
+        return $user->id === $group->user_id;;
     }
 
     /**

--- a/app/Policies/GroupPolicy.php
+++ b/app/Policies/GroupPolicy.php
@@ -49,6 +49,19 @@ class GroupPolicy
     }
 
     /**
+     * Determine whether or not the user can invite others to the group.
+     */
+    public function invite(User $user, Group $group): bool
+    {
+        // can't simply call group->users as it causes infinite recursion
+        // by calling the collection it triggers the policy
+        // ...which then calls the collection... etc
+        return $group->users()
+            ->where('users.id', $user->id)
+            ->exists();
+    }
+
+    /**
      * Determine whether the user can restore the model.
      */
     public function restore(User $user, Group $group): bool

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,21 +8,24 @@ use Illuminate\Support\Facades\Gate;
 use App\Models\Group;
 use App\Models\GroupUser;
 use App\Models\Alias;
+use App\Models\Debt;
 use App\Models\Comment;
 use App\Policies\SharePolicy;
 use Illuminate\Support\Facades\Event;
 use App\Policies\GroupPolicy;
 use App\Policies\GroupUserPolicy;
 use App\Policies\AliasPolicy;
+use App\Policies\DebtPolicy;
 use App\Policies\CommentPolicy;
 
 
 class AppServiceProvider extends ServiceProvider
 {
     protected $policies = [
-        Alias::class => AliasPolicy::class,
         Group::class => GroupPolicy::class,
         GroupUser::class => GroupUserPolicy::class,
+        Alias::class => AliasPolicy::class,
+        Debt::class => DebtPolicy::class,
         Comment::class => CommentPolicy::class,
     ];
     

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,14 +5,16 @@ namespace App\Providers;
 use Illuminate\Support\Facades\Vite;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Gate;
+use App\Models\Group;
 use App\Models\GroupUser;
+use App\Models\Alias;
+use App\Models\Comment;
 use App\Policies\SharePolicy;
 use Illuminate\Support\Facades\Event;
-use App\Observers\GroupUserObserver;
-use App\Models\Alias;
-use App\Policies\AliasPolicy;
 use App\Policies\GroupPolicy;
 use App\Policies\GroupUserPolicy;
+use App\Policies\AliasPolicy;
+use App\Policies\CommentPolicy;
 
 
 class AppServiceProvider extends ServiceProvider
@@ -21,6 +23,7 @@ class AppServiceProvider extends ServiceProvider
         Alias::class => AliasPolicy::class,
         Group::class => GroupPolicy::class,
         GroupUser::class => GroupUserPolicy::class,
+        Comment::class => CommentPolicy::class,
     ];
     
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Event;
 use App\Observers\GroupUserObserver;
 use App\Models\Alias;
 use App\Policies\AliasPolicy;
+use App\Policies\GroupPolicy;
 use App\Policies\GroupUserPolicy;
 
 
@@ -18,6 +19,7 @@ class AppServiceProvider extends ServiceProvider
 {
     protected $policies = [
         Alias::class => AliasPolicy::class,
+        Group::class => GroupPolicy::class,
         GroupUser::class => GroupUserPolicy::class,
     ];
     

--- a/resources/js/Components/Comments/Comment.vue
+++ b/resources/js/Components/Comments/Comment.vue
@@ -56,8 +56,10 @@ onMounted(() => {
                 </div>
             </div>
             <Controls
-                v-if="usePage().props.ownership.comment_ids.includes(props.comment.id)"
                 item="Comment"
+                :visible="props.comment.can_update || props.comment.can_delete"
+                :updatable="props.comment.can_update"
+                :deletable="props.comment.can_delete"
                 @edit="isEditing = !isEditing"
                 @destroy="confirmingCommentDeletion = true"
             >
@@ -68,7 +70,7 @@ onMounted(() => {
             <p  v-if="!isEditing"class="p-2">{{ comment.content }}</p>
             <Form
                 v-else
-                :action="route('comment.update')"
+                :action="route('comment.update', props.comment)"
                 method="patch"
                 resetOnSuccess
                 :transform="data => ({ 
@@ -87,6 +89,7 @@ onMounted(() => {
                     class="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
                     id="edit_comment"
                     name="content"
+                    :value="comment.content"
                 >
                 </textarea>
                 <div class="flex flex-row mt-2 sm:justify-end">

--- a/resources/js/Components/Debts/Debt.vue
+++ b/resources/js/Components/Debts/Debt.vue
@@ -47,6 +47,7 @@ onMounted(() => {
     //     const discrepancy = props.debt.amount.amount - debtDiscrepancy.value;
     //     debtForm.errors.amount = `There is a discrepancy of ${debtCurrency.value.symbol}${discrepancy.toFixed(2)}.`;
     // }
+    console.log(props.debt);
 });
 
 </script>
@@ -80,7 +81,7 @@ onMounted(() => {
             </div>
             <div v-else class="w-full">
                 <Form
-                    :action="route('debt.update')" 
+                    :action="route('debt.update', props.debt)" 
                     method="patch" 
                     #default="{ errors }"
                     :transform="data => ({
@@ -151,8 +152,10 @@ onMounted(() => {
                 </Form>
             </div>
             <Controls
-                :class="owns_debt && !isEditing ? '' : 'invisible'"
                 item="Debt"
+                :visible="props.debt.can_update || props.debt.can_delete"
+                :updatable="props.debt.can_update"
+                :deletable="props.debt.can_delete"
                 class="p-2 flex flex-row justify-between"
                 @edit="isEditing = !isEditing"
                 @destroy="confirmingDebtDeletion = true"

--- a/resources/js/Components/Debts/Debt.vue
+++ b/resources/js/Components/Debts/Debt.vue
@@ -103,6 +103,7 @@ onMounted(() => {
                                 New Name
                             </label>
                             <TextInput
+                                v-model="props.debt.name"
                                 name="name"
                                 type="text"
                                 id="newDebtName"
@@ -121,7 +122,8 @@ onMounted(() => {
                             >
                                 New Amount
                             </label>
-                            <TextInput 
+                            <TextInput
+                                v-model="props.debt.amount.amount" 
                                 name="amount"
                                 type="number"
                                 step="0.01"

--- a/resources/js/Components/GroupUsers/GroupUser.vue
+++ b/resources/js/Components/GroupUsers/GroupUser.vue
@@ -72,6 +72,7 @@ onMounted(() => {
                     New Alias
                     </label>
                     <TextInput
+                        v-model="visibleAlias.alias"
                         name="alias"
                         type="text"
                         id="newGroupUserAlias"

--- a/resources/js/Components/GroupUsers/GroupUser.vue
+++ b/resources/js/Components/GroupUsers/GroupUser.vue
@@ -16,9 +16,6 @@ const props = defineProps({
     group_user: {
         type: Object,
     },
-    owns_group: {
-        type: Boolean,
-    },
     group: {
         type: Object,
     }
@@ -36,7 +33,7 @@ const visibleAlias = computed(() =>
 );
 
 onMounted(() => {
-    console.log(props.group_user.user.name, props.group_user);
+
 })
 </script>
 

--- a/resources/js/Components/GroupUsers/GroupUser.vue
+++ b/resources/js/Components/GroupUsers/GroupUser.vue
@@ -16,6 +16,7 @@ const props = defineProps({
     group_user: {
         type: Object,
     },
+
     group: {
         type: Object,
     }
@@ -100,6 +101,7 @@ onMounted(() => {
         <div class="flex justify-end" style="width:50px">
             <Controls
                 item="Group User"
+                :visible="true"
                 :updatable="true"
                 :deletable="props.group_user.can_delete"
                 @edit="isEditing = !isEditing;refresh & refresh()"

--- a/resources/js/Components/Groups/Group.vue
+++ b/resources/js/Components/Groups/Group.vue
@@ -21,10 +21,13 @@ const props = defineProps({
     },
 });
 
-const owns_group = ref(usePage().props.ownership.group_ids.includes(props.group.id));
 const showGroupUsers = ref(false);
 const isEditing = ref(false);
 const confirmingGroupDeletion = ref(false);
+
+onMounted(() => {
+
+})
 
 </script>
 
@@ -42,7 +45,7 @@ const confirmingGroupDeletion = ref(false);
             </h2>
             <div v-else class="w-full">
                 <Form
-                    :action="route('group.update')" 
+                    :action="route('group.update', props.group)" 
                     method="patch" 
                     #default="{ errors }"
                     :transform="data => ({
@@ -87,9 +90,11 @@ const confirmingGroupDeletion = ref(false);
                 </Form>
             </div>
             <Controls
-                :class="owns_group && !isEditing ? '' : 'invisible'"
                 class="p-2 flex flex-row justify-between"
+                :class="props.group.can_update || props.group.can_delete ? '' : 'invisible'"
                 item="Group"
+                :updatable="props.group.can_update"
+                :deletable="props.group.can_delete"
                 @edit="isEditing = !isEditing"
                 @destroy="confirmingGroupDeletion = true"
             >
@@ -99,12 +104,11 @@ const confirmingGroupDeletion = ref(false);
             <GroupUser 
                 v-for="group_user in group.group_users"
                 :group_user="group_user"
-                :owns_group="owns_group"
                 :group="group"
             >
             </GroupUser>
             <InviteToGroup
-                v-if="owns_group"
+                v-if="props.group.can_delete"
                 :group="group"
             >
             </InviteToGroup>

--- a/resources/js/Components/Groups/Group.vue
+++ b/resources/js/Components/Groups/Group.vue
@@ -64,6 +64,7 @@ onMounted(() => {
                         New Name
                         </label>
                         <TextInput
+                            v-model="props.group.name"
                             name="name"
                             type="text"
                             id="newgroupName"

--- a/resources/js/Components/Groups/Group.vue
+++ b/resources/js/Components/Groups/Group.vue
@@ -91,8 +91,8 @@ onMounted(() => {
             </div>
             <Controls
                 class="p-2 flex flex-row justify-between"
-                :class="props.group.can_update || props.group.can_delete ? '' : 'invisible'"
                 item="Group"
+                :visible="props.group.can_update"
                 :updatable="props.group.can_update"
                 :deletable="props.group.can_delete"
                 @edit="isEditing = !isEditing"

--- a/resources/js/Components/Groups/Group.vue
+++ b/resources/js/Components/Groups/Group.vue
@@ -109,7 +109,7 @@ onMounted(() => {
             >
             </GroupUser>
             <InviteToGroup
-                v-if="props.group.can_delete"
+                v-if="props.group.can_invite"
                 :group="group"
             >
             </InviteToGroup>

--- a/resources/js/Components/Misc/Controls.vue
+++ b/resources/js/Components/Misc/Controls.vue
@@ -8,6 +8,9 @@ const props = defineProps({
     item: {
         type: String,
     },
+    visible: {
+        type: Boolean,
+    },
     updatable: {
         type: Boolean,
     },
@@ -29,12 +32,12 @@ function destroy() {
 
 // todo: figure out why popover isn't closing on esc like docs say it should do
 onMounted(() => {
-    
+
 });
 
 </script>
 <template>
-    <div class="flex flex-col pb-2 pl-2">
+    <div class="flex flex-col pb-2 pl-2" :class="visible ? '' : 'invisible'">
         <button :popovertarget="popoverId" style="position:relative"><i class="fa-solid fa-ellipsis-vertical"></i></button>
         <ul popover="auto" :id="popoverId" class="popover">
             <li v-if="updatable" @click="edit" style="border-bottom:1px solid grey">Edit {{ props.item }}</li>

--- a/resources/js/Components/Misc/DangerButton.vue
+++ b/resources/js/Components/Misc/DangerButton.vue
@@ -5,7 +5,7 @@
             px-4 py-2 text-xs font-semibold uppercase tracking-widest text-white 
             transition duration-150 ease-in-out hover:bg-red-500 focus:outline-none 
             focus:ring-2 focus:ring-red-500 focus:ring-offset-2 active:bg-red-700
-            w-1/2 md:w-1/4
+            w-1/2 lg:w-1/4
             "
     >
         <slot />

--- a/resources/js/Pages/Groups.vue
+++ b/resources/js/Pages/Groups.vue
@@ -15,7 +15,7 @@ const props = defineProps({
 });
 
 onMounted(() => {
-    console.log(props.groups);
+
 });
 
 </script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -39,7 +39,7 @@ Route::get('/', function () {
 Route::middleware('auth')->group(function () {
     Route::get('/debts', [DebtController::class, 'index'])->name('debt.index');
     Route::post('/debts', [DebtController::class, 'store'])->name('debt.store');
-    Route::patch('/debts', [DebtController::class, 'update'])->name('debt.update');
+    Route::patch('/debts/{debt}', [DebtController::class, 'update'])->name('debt.update');
     Route::delete('/debts', [DebtController::class, 'destroy'])->name('debt.destroy');
 });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -86,7 +86,7 @@ Route::middleware('auth')->group(function () {
 // comments
 Route::middleware('auth')->group(function () {
     Route::post('/comment', [CommentController::class, 'store'])->name('comment.store');
-    Route::patch('/comment', [CommentController::class, 'update'])->name('comment.update');
+    Route::patch('/comment/{comment}', [CommentController::class, 'update'])->name('comment.update');
     Route::delete('/comment', [CommentController::class, 'destroy'])->name('comment.destroy');
 });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -47,7 +47,7 @@ Route::middleware('auth')->group(function () {
 Route::middleware('auth')->group(function () {
     Route::get('/groups', [GroupController::class, 'index'])->name('group.index');
     Route::post('/groups', [GroupController::class, 'store'])->name('group.store');
-    Route::patch('/groups', [GroupController::class, 'update'])->name('group.update');
+    Route::patch('/groups/{group}', [GroupController::class, 'update'])->name('group.update');
     Route::delete('/groups', [GroupController::class, 'destroy'])->name('group.destroy');
 });
 

--- a/tests/Feature/Http/Controllers/CommentControllerTest.php
+++ b/tests/Feature/Http/Controllers/CommentControllerTest.php
@@ -67,7 +67,7 @@ test('user can edit their comment on a debt', function () {
         'content' => 'I am a comment on a debt',
     ]);
 
-    $response = $this->patch(route('comment.update'), [
+    $response = $this->patch(route('comment.update', $comment), [
         'id' => $comment->id,
         'debt_id' => $comment->debt_id,
         'content' => 'I have now been updated',
@@ -111,7 +111,7 @@ test('user can not edit another user comment on a debt', function () {
     ]);
 
     // try and edit it
-    $response = $this->patch(route('comment.update'), [
+    $response = $this->patch(route('comment.update', $other_user_comment), [
         'id' => $other_user_comment->id,
         'debt_id' => $other_user_comment->debt_id,
         'content' => 'I have now been updated',

--- a/tests/Feature/Http/Controllers/GroupControllerTest.php
+++ b/tests/Feature/Http/Controllers/GroupControllerTest.php
@@ -56,7 +56,7 @@ test('user groups appear', function() {
 });
 
 test('user can change the name of a group they own', function() {
-    $response = $this->patch(route('group.update'), [
+    $response = $this->patch(route('group.update', $this->group), [
         'id' => $this->group->id,
         'name' => $this->group->name . '-edited',
         'user_id' => $this->user->id,
@@ -75,7 +75,7 @@ test('user can change the name of a group they own', function() {
 test('user can not change the name of a group they do not own', function() {
     $this->actingAs($this->users->last());
 
-    $response = $this->patch(route('group.update'), [
+    $response = $this->patch(route('group.update', $this->group), [
         'id' => $this->group->id,
         'name' => $this->group->name . '-edited',
         'user_id' => $this->users->last()->id,


### PR DESCRIPTION
The aim of this PR is to update models to have policies where appropriate, as well as the use of the `Controls` component on the frontend to avoid the, currently quite messy, use of things like `owns_group` etc. 

This will be done by appending attributes onto models in their respective model class, e.g. `getCanUpdateAttrbiute` which will then make it available in the frontend, allowing the property to be passed in as a prop to `Controls`, as tested in the previous [PR](https://github.com/dom-elves/chopr/pull/17). This will result in cleaner, more readable & consistent frontend code as well as the removal of the 'permissions' part of the inertia middleware. Additionally, route model binding will be applied where possible, most notably in `update` methods, as currently a lot of these methods contain an extra, pointless query. Checklist of operations to go through:

Simple ones, as anyone can update/delete models of these that they have ownership. E.g. if you post a comment you can delete/edit that comment, but no one else can. 

- Groups
    - [x] Update
    - [x] Delete
- Comments
    - [x] Update
    - [x] Delete
- Invites
    - [x] Send

After looking into the code more & figuring out the scope, I'll raise a separate PR for Debt & Share changes



Extras:
- Modified `Controls` to have a `visibility` prop to save having the same ternary on every instance of `Controls`
- Route/model binding added for update routes
- Breakpoint fix on `DangerButton` to bring it in line with the rest of the buttons 
- Adding `v-model` to some text inputs so the original value appears when in edit mode, long overdue  