### PR TITLE
Bug fixes following previous PR

### DIFF
--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -28,9 +28,6 @@ class GroupController extends Controller
             ->with(['group_users.user', 'group_users.aliases'])
             ->get();
 
-        // $group = $groups[0];
-        // $user = Auth::user();
-        // dd($group->users->contains('id', $user->id));
         return Inertia::render('Groups', [
             'groups' => $groups,
             'status' => $request->session()->get('status') ?? null,

--- a/app/Http/Controllers/InviteController.php
+++ b/app/Http/Controllers/InviteController.php
@@ -74,7 +74,7 @@ class InviteController extends Controller
             ]);
 
             $invite->update(['accepted_at' => Carbon::now()]);
-
+            
             return redirect()->route('group.index')->with('status', "You have successfully joined {$invite->group->name}");
         } else {
             // so if they're a new user, store the token in the session

--- a/app/Http/Requests/InviteToGroupRequest.php
+++ b/app/Http/Requests/InviteToGroupRequest.php
@@ -25,7 +25,7 @@ class InviteToGroupRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'group_id' => ['exists:groups,id', new IsGroupOwner],
+            'group_id' => ['exists:groups,id'],
             'user_id' => ['exists:users,id'],
             'recipients' => ['required', 'array', 'min:1'],
             'recipients.*' => [new IsUserInGroup($this->all()), function ($attribute, $value, $fail) {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -110,7 +110,8 @@ class User extends Authenticatable
         // user_id as key for user
         // group_id as key for group
         // essentially works as a 'link'
-        return $this->belongsToMany(Group::class, 'group_users', 'user_id', 'group_id');
+        return $this->belongsToMany(Group::class, 'group_users', 'user_id', 'group_id')
+            ->wherePivotNull('deleted_at');
     }
 
     /**

--- a/tests/Feature/Http/Controllers/InviteControllerTest.php
+++ b/tests/Feature/Http/Controllers/InviteControllerTest.php
@@ -52,6 +52,33 @@ test('user can invite someone to the group if they are the owner', function() {
     Mail::assertQueuedCount(1);
 });
 
+test('user can invite someone to the group if they are not the owner', function() {
+    Mail::fake();
+    $not_owner = $this->users->reject(fn($user) => $user->id !== $this->user->id)->first();
+    $this->actingAs($not_owner);
+
+    $response = $this->post(route('invite.send'), [
+        'group_id' => $this->group->id,
+        'user_id' => $this->user->id,
+        'recipients' => ['randomguy@example.com'],
+        'body' => 'hey join this group',
+    ]);
+
+    $response->assertStatus(302)
+        ->assertSessionHas('status', '1 invite sent successfully.')
+        ->assertSessionHasNoErrors();
+
+    $this->assertDatabaseHas('invites', [
+        'group_id' => $this->group->id,
+        'user_id' => $this->user->id,
+        'recipient'=> 'randomguy@example.com',
+        'body' => 'hey join this group',
+    ]);
+    
+    Mail::assertQueued(InviteToGroup::class, 'randomguy@example.com');
+    Mail::assertQueuedCount(1);
+});
+
 test('user can invite multiple people to a group they own', function() {
     Mail::fake();
     $this->actingAs($this->user);
@@ -82,35 +109,6 @@ test('user can invite multiple people to a group they own', function() {
 
     Mail::assertQueued(InviteToGroup::class, $recipients);
     Mail::assertQueuedCount(count($recipients));
-});
-
-test('user can not invite someone to the group if they are not the owner', function() {
-    Mail::fake();
-    $other_user = $this->group->users->reject(fn($user) =>
-        $user->id === $this->user->id)->first();
-  
-    $this->actingAs($other_user);
-
-    $response = $this->post(route('invite.send'), [
-        'group_id' => $this->group->id,
-        'user_id' => $other_user->id,
-        'recipients' => ['dontaddme@example.com'],
-        'body' => 'not you',
-    ]);
-
-    $response->assertStatus(302)
-        ->assertSessionHasErrors([
-            'group_id' => 'You do not have permission to edit or delete this group'
-    ]);
-
-    $this->assertDatabaseMissing('invites', [
-        'group_id' => $this->group->id,
-        'user_id' => $other_user->id,
-        'recipient' => 'dontaddme@example.com',
-        'body' => 'not you',
-    ]);
-
-    Mail::assertNothingSent();
 });
 
 test('user can not invite anyone without adding at least one email address', function() {

--- a/tests/Feature/Http/Controllers/InviteControllerTest.php
+++ b/tests/Feature/Http/Controllers/InviteControllerTest.php
@@ -239,9 +239,13 @@ test('a user can not send an invite link to a user who is already in the group',
 test('user clicking on the invite link after accepting it logs them in and redirects them to groups', function() {
     $user = $this->group->users->first();
 
+    $group = Group::factory()->withGroupUsers()->create([
+                'user_id' => $user,
+            ]);
+
     $invite = Invite::factory()->create([
-        'group_id' => $this->group->id,
-        'user_id' => $this->user->id,
+        'group_id' => $group->id,
+        'user_id' => $user->id,
         'recipient' => $user->email,
         'accepted_at' => Carbon::now(),
     ]);
@@ -250,10 +254,8 @@ test('user clicking on the invite link after accepting it logs them in and redir
 
     $response = $this->get('/invite/accept/' . $invite->token);
 
-    $response->assertInertia(function (AssertableInertia $page) use ($invite) {
-        $page->component('Groups')
-                ->where('groups', $this->group);
-    });
+    $response->assertRedirect(route('group.index'))
+        ->assertSessionHas('status', "You have successfully joined {$this->group->name}");
 });
 
 test('invites are expired after 24 hours', function() {


### PR DESCRIPTION
Few bugs fixes following previous [PR](https://github.com/dom-elves/chopr/pull/19)

- Removal of `IsGroupOwner` rule application in `InviteToGroup` request as that permission is now handled by policies
- Add `->wherePivotNull` to user->groups() relationship as it was causing groups to appear multiple times if the group user had been deleted and a new one for the same user added
- Should have fixed broken invite test but turns out it's also not working in practice.. not sure why, will be tackled in a later PR as it's very minor (toast not appearing when joining a group, but the user being directed to the groups page should be enough of an indication that something has happened) 