### PR TITLE
Debts & Shares rework

### DIFF
--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -115,7 +115,15 @@ class DebtController extends Controller
     {
         // validate data and set original aount
         $validated = $request->validated();
-        $original_amount = $debt->amount;
+
+        // calculate from shares rather than debt->amount
+        // as user can, in theory, keep editing the amount over and over
+        $original_amount = $debt->shares->reduce(function (?Money $carry, Share $share) {
+            if ($carry === null) {
+                return $share->amount;
+            }
+            return $carry->plus($share->amount);
+        }, null);
 
         // update data
         $debt->update([
@@ -128,25 +136,20 @@ class DebtController extends Controller
             // the new amount minus the original
             $discrepancy = $debt->amount->minus($original_amount);
 
-            // if the debt is split even, shares must be updated
+            // update split even debt shares if needed
             if ($debt->split_even) {
-
                 $shareService->updateDebtShares($debt, $discrepancy);
-
-                return redirect()->route('debt.index')->with('status', 'Debt & shares updated successfully.');
-                
-            } else {
-                // otherwise, return with discrepancy
-                return redirect()->route('debt.index')->withErrors([
-                    'amount' => $discrepancy->getAmount()->toInt(),
-                ]);
             }
+
+            // no use returning the discrepancy on update
+            // as we always need to see it on the frontend at any given time
+            return redirect()->route('debt.index')->with('status', 'Debt & shares updated successfully.');
         }
-        
+
         // if just the name has been changed, just return
         return redirect()->route('debt.index')->with('status', 'Debt updated successfully.');
     }
-
+        
     /**
      * Remove the specified resource from storage.
      */

--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -111,24 +111,40 @@ class DebtController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(UpdateDebtRequest $request, Debt $debt, DebtService $debtService): RedirectResponse
+    public function update(UpdateDebtRequest $request, Debt $debt, ShareService $shareService): RedirectResponse
     {
+        // validate data and set original aount
         $validated = $request->validated();
-        
-        $original_amount = Debt::findOrFail($validated['id'])->amount;
-        $updated = $debtService->updateDebt($validated);
-        
-        // as mentioned in DebtService, discrepancy handling
-        if ($original_amount != $updated->amount && !$updated->split_even) {
-            $discrepancy = $updated->amount->minus($original_amount)->getAmount()->toInt();
-            
-            return redirect()->route('debt.index')->withErrors([
-                'amount' => $discrepancy
-            ]);
+        $original_amount = $debt->amount;
 
-        } else {
-            return redirect()->route('debt.index')->with('status', 'Debt updated successfully.');
+        // update data
+        $debt->update([
+            'name' => $validated['name'],
+            'amount' => Money::of($validated['amount'], $debt->currency),
+        ]);
+        
+        // extra bits to do if the amount was changed
+        if ($debt->wasChanged('amount')) {
+            // the new amount minus the original
+            $discrepancy = $debt->amount->minus($original_amount);
+
+            // if the debt is split even, shares must be updated
+            if ($debt->split_even) {
+
+                $shareService->updateDebtShares($debt, $discrepancy);
+
+                return redirect()->route('debt.index')->with('status', 'Debt & shares updated successfully.');
+                
+            } else {
+                // otherwise, return with discrepancy
+                return redirect()->route('debt.index')->withErrors([
+                    'amount' => $discrepancy->getAmount()->toInt(),
+                ]);
+            }
         }
+        
+        // if just the name has been changed, just return
+        return redirect()->route('debt.index')->with('status', 'Debt updated successfully.');
     }
 
     /**

--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -17,6 +17,8 @@ use App\Rules\IsDebtOwner;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\RedirectResponse;
 use App\Services\DebtService;
+use App\Services\ShareService;
+use Brick\Money\Money;
 
 class DebtController extends Controller
 {
@@ -65,17 +67,27 @@ class DebtController extends Controller
      */
     public function create()
     {
-        dump('test');
+        //
     }
 
     /**
      * Store a newly created resource in storage.
      */
-    public function store(StoreDebtRequest $request, DebtService $debtService): RedirectResponse
+    public function store(StoreDebtRequest $request, ShareService $shareService): RedirectResponse
     {
         $validated = $request->validated();
     
-        $debtService->createDebt($validated);
+        $debt = Debt::create([
+            'group_id' => $validated['group_id'],
+            'user_id' => $validated['user_id'],
+            'name' => $validated['name'],
+            'amount' => Money::of($validated['amount'], $validated['currency']),
+            'split_even' => $validated['split_even'],
+            'cleared' => 0,
+            'currency' => $validated['currency'],
+        ]);
+
+        $shareService->createDebtShares($validated['user_shares'], $debt);
 
         return redirect()->route('debt.index')->with('status', 'Debt created successfully.');
     }

--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -150,14 +150,16 @@ class DebtController extends Controller
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(Request $request, DebtService $debtService): RedirectResponse
+    public function destroy(Request $request, Debt $debt, ShareService $shareService): RedirectResponse
     {
         $validated = Validator::make($request->all(), [
             'id' => ['required', 'numeric', 'exists:debts,id', new IsDebtOwner],
         ])->validate();
- 
-        $debtService->deleteDebt($validated);
 
-        return redirect()->route('debt.index')->with('status', 'Debt deleted successfully.');;
+        $shareService->deleteDebtShares($debt);
+
+        $debt->delete();
+
+        return redirect()->route('debt.index')->with('status', "Debt deleted successfully.");;
     }
 }

--- a/app/Http/Controllers/ShareController.php
+++ b/app/Http/Controllers/ShareController.php
@@ -85,20 +85,32 @@ class ShareController extends Controller
         // validated data
         $validated = $request->validated();
         
-        $original_amount = $share->amount;
-        // update data
-        $share->update([
-            'name' => $validated['name'],
-            'amount' => Money::of($validated['amount'], $share->debt->currency),
-        ]);
+        $user = Auth::user();
 
-        // similar to updating a debt, extra stuff to do if a share amount is updated
-        if ($share->wasChanged('amount')) {
-            $discrepancy = $share->amount->minus($original_amount);
-            $shareService->updateShareDebt($share, $discrepancy);
+        // switch case to handle share policy checks
+        switch ($user) {
+            case !$user->can('updateName', $share) && !$user->can('updateAmount', $share):
+                 return redirect()->route('debt.index')->withErrors(['share' => "You do not have permission to update this share."]);
+            case !$user->can('updateName', $share):
+                 return redirect()->route('debt.index')->withErrors(['name' => "You do not have permission to update the name of this share."]);
+            case !$user->can('updateAmount', $share):
+                 return redirect()->route('debt.index')->withErrors(['amount' => "You do not have permission to update the amount of this share."]);
+            default:
+                $original_amount = $share->amount;
+        
+                $share->update([
+                    'name' => $validated['name'],
+                    'amount' => Money::of($validated['amount'], $share->debt->currency),
+                ]);
+
+                // similar to updating a debt, extra stuff to do if a share amount is updated
+                if ($share->wasChanged('amount')) {
+                    $discrepancy = $share->amount->minus($original_amount);
+                    $shareService->updateShareDebt($share, $discrepancy);
+                }
+
+                return redirect()->route('debt.index')->with('status', 'Share updated successfully.');
         }
-
-        return redirect()->route('debt.index')->with('status', 'Share updated successfully.');
     }
 
     /**

--- a/app/Http/Controllers/ShareController.php
+++ b/app/Http/Controllers/ShareController.php
@@ -118,9 +118,7 @@ class ShareController extends Controller
      */
     public function sent(UpdateShareRequest $request, Share $share, BalanceService $balanceService)
     {
-        if (!Auth::user()->can('updateSent', $share)) {
-            return redirect()->route('debt.index')->withErrors(['sent' => "You do not have permission to update the 'sent' status of this share"]);
-        } else {
+        if (Auth::user()->can('updateSent', $share)) {
             $validated = $request->validated();
 
             $share->update([
@@ -137,6 +135,8 @@ class ShareController extends Controller
             }
             
             return redirect()->route('debt.index');
+        } else {
+            return redirect()->route('debt.index')->withErrors(['sent' => "You do not have permission to update the 'sent' status of this share"]);
         }
     }
 
@@ -145,16 +145,20 @@ class ShareController extends Controller
      */
     public function seen(UpdateShareRequest $request, Share $share)
     {
-        if (!Auth::user()->can('updateSeen', $share)) {
-            return redirect()->route('debt.index')->withErrors(['seen' => "You do not have permission to update the 'seen' status of this share"]);
+        if (Auth::user()->can('updateSeen', $share)) {
+            if ($share->sent == 0) {
+                return redirect()->route('debt.index')->withErrors(['seen' => "You can not mark this share as seen becase it has not been sent yet"]);
+            } else {
+                $validated = $request->validated();
+
+                $share->update([
+                    'seen' => $validated['seen'],
+                ]);
+
+                return redirect()->route('debt.index');
+            }
         } else {
-            $validated = $request->validated();
-
-            $share->update([
-                'seen' => $validated['seen'],
-            ]);
-
-            return redirect()->route('debt.index');
+            return redirect()->route('debt.index')->withErrors(['seen' => "You do not have permission to update the 'seen' status of this share"]);
         }
     }
 

--- a/app/Http/Controllers/ShareController.php
+++ b/app/Http/Controllers/ShareController.php
@@ -84,7 +84,7 @@ class ShareController extends Controller
     {
         // validated data
         $validated = $request->validated();
-
+        
         $original_amount = $share->amount;
         // update data
         $share->update([
@@ -107,7 +107,7 @@ class ShareController extends Controller
     public function sent(UpdateShareRequest $request, Share $share, BalanceService $balanceService)
     {
         if (!Auth::user()->can('updateSent', $share)) {
-            return redirect()->route('debt.index')->withErrors("You do not have permission to update the 'sent' status of this share");
+            return redirect()->route('debt.index')->withErrors(['sent' => "You do not have permission to update the 'sent' status of this share"]);
         } else {
             $validated = $request->validated();
 
@@ -134,7 +134,7 @@ class ShareController extends Controller
     public function seen(UpdateShareRequest $request, Share $share)
     {
         if (!Auth::user()->can('updateSeen', $share)) {
-            return redirect()->route('debt.index')->withErrors("You do not have permission to update the 'seen' status of this share");
+            return redirect()->route('debt.index')->withErrors(['seen' => "You do not have permission to update the 'seen' status of this share"]);
         } else {
             $validated = $request->validated();
 

--- a/app/Http/Controllers/ShareController.php
+++ b/app/Http/Controllers/ShareController.php
@@ -87,7 +87,7 @@ class ShareController extends Controller
         // similar to updating a debt, extra stuff to do if a share amount is updated
         if ($share->wasChanged('amount')) {
             $discrepancy = $share->amount->minus($original_amount);
-            $shareService->updateDebtShare($share, $discrepancy);
+            $shareService->updateShareDebt($share, $discrepancy);
         }
 
         return redirect()->route('debt.index')->with('status', 'Share updated successfully.');
@@ -96,21 +96,24 @@ class ShareController extends Controller
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(Request $request, ShareService $shareService): RedirectResponse
+    public function destroy(Request $request, Share $share, ShareService $shareService): RedirectResponse
     {
-  
         $validated = Validator::make($request->all(), [
             'id' => ['required', 'integer', 'exists:shares,id'],
             // could use IsShareDebtOwner but the wording on $fail is totally different
-            'debt_id' => ['required', 'integer', 'exists:debts,id', function($attribute, $value, $fail) {
-                $debt = Debt::findOrFail($value);
-                if ($debt->user_id !== Auth::user()->id) {
+            'debt_id' => ['required', 'integer', 'exists:debts,id', function($attribute, $value, $fail) use ($share) {
+                if ($share->debt->user_id !== Auth::user()->id) {
                     $fail('You do not have permission to delete this share');
                 }
             }],
         ])->validate();
-           
-        $shareService->deleteShare($validated);
+
+        // delete the share
+        $share->delete();
+        
+        // mentioned in docblock, function name makes no sense
+        // but it's for updating debt & user balance
+        $shareService->deleteShareDebt($share);
 
         return redirect()->route('debt.index')->with('status', 'Share deleted successfully.');
     }

--- a/app/Http/Controllers/ShareController.php
+++ b/app/Http/Controllers/ShareController.php
@@ -86,7 +86,6 @@ class ShareController extends Controller
         $validated = $request->validated();
 
         $original_amount = $share->amount;
-
         // update data
         $share->update([
             'name' => $validated['name'],
@@ -102,7 +101,10 @@ class ShareController extends Controller
         return redirect()->route('debt.index')->with('status', 'Share updated successfully.');
     }
 
-    public function sent(UpdateShareRequest $request, Share $share)
+    /**
+     * Update the 'sent' status of the specified resource in storage.
+     */
+    public function sent(UpdateShareRequest $request, Share $share, BalanceService $balanceService)
     {
         if (!Auth::user()->can('updateSent', $share)) {
             return redirect()->route('debt.index')->withErrors("You do not have permission to update the 'sent' status of this share");
@@ -113,10 +115,22 @@ class ShareController extends Controller
                 'sent' => $validated['sent'],
             ]);
 
+            // only change user balances on sent status update
+            // 'seen' is merely cosmetic, jsut for user clarity
+            // maybe one day can expand balance into having a pending/unconfirmed status
+            if ($validated['sent'] == 1) {
+                $balanceService->subtractFromGroupUserBalance($share, $share->amount);
+            } else {
+                $balanceService->addToGroupUserBalance($share, $share->amount);
+            }
+            
             return redirect()->route('debt.index');
         }
     }
 
+    /**
+     * Update the 'seen' status of the specified resource in storage.
+     */
     public function seen(UpdateShareRequest $request, Share $share)
     {
         if (!Auth::user()->can('updateSeen', $share)) {

--- a/app/Http/Controllers/ShareController.php
+++ b/app/Http/Controllers/ShareController.php
@@ -102,6 +102,36 @@ class ShareController extends Controller
         return redirect()->route('debt.index')->with('status', 'Share updated successfully.');
     }
 
+    public function sent(UpdateShareRequest $request, Share $share)
+    {
+        if (!Auth::user()->can('updateSent', $share)) {
+            return redirect()->route('debt.index')->withErrors("You do not have permission to update the 'sent' status of this share");
+        } else {
+            $validated = $request->validated();
+
+            $share->update([
+                'sent' => $validated['sent'],
+            ]);
+
+            return redirect()->route('debt.index');
+        }
+    }
+
+    public function seen(UpdateShareRequest $request, Share $share)
+    {
+        if (!Auth::user()->can('updateSeen', $share)) {
+            return redirect()->route('debt.index')->withErrors("You do not have permission to update the 'seen' status of this share");
+        } else {
+            $validated = $request->validated();
+
+            $share->update([
+                'seen' => $validated['seen'],
+            ]);
+
+            return redirect()->route('debt.index');
+        }
+    }
+
     /**
      * Remove the specified resource from storage.
      */

--- a/app/Http/Controllers/ShareController.php
+++ b/app/Http/Controllers/ShareController.php
@@ -13,6 +13,7 @@ use App\Rules\IsShareOwner;
 use App\Rules\IsShareDebtOwner;
 use App\Events\ShareUpdated;
 use App\Services\ShareService;
+use App\Services\BalanceService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
 use Brick\Money\Money;
@@ -70,23 +71,25 @@ class ShareController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(UpdateShareRequest $request, ShareService $shareService): RedirectResponse
+    public function update(UpdateShareRequest $request, Share $share, ShareService $shareService): RedirectResponse
     {
         // validated data
         $validated = $request->validated();
 
-        $share = Share::findOrFail($validated['id']);
+        $original_amount = $share->amount;
 
-        // the only keys in the request payload are share id & what has changed
-        // so make a money object if amount is present
-        if (array_key_exists('amount', $validated)) {
-            $validated['amount'] = Money::of($validated['amount'], $share->debt->currency)->minus($share->amount);
+        // update data
+        $share->update([
+            'name' => $validated['name'],
+            'amount' => Money::of($validated['amount'], $share->debt->currency),
+        ]);
+
+        // similar to updating a debt, extra stuff to do if a share amount is updated
+        if ($share->wasChanged('amount')) {
+            $discrepancy = $share->amount->minus($original_amount);
+            $shareService->updateDebtShare($share, $discrepancy);
         }
-        
-        $shareService->updateShare($validated);
 
-        // todo: if statement that on sends this on success
-        // with alternative for discrepancy
         return redirect()->route('debt.index')->with('status', 'Share updated successfully.');
     }
 

--- a/app/Http/Controllers/ShareController.php
+++ b/app/Http/Controllers/ShareController.php
@@ -47,13 +47,15 @@ class ShareController extends Controller
     {
         $validated = $request->validated();
 
+        $debt = Debt::findOrFail($validated['debt_id']);
+
         $share = Share::create([
             'debt_id' => $validated['debt_id'],
             'user_id' => $validated['user_id'],
             'name' => $validated['name'],
             'amount' => Money::of($validated['amount'], $validated['currency']),
-            'sent' => 0,
-            'seen' => 0,
+            'sent' => $debt->user_id === $validated['user_id'] ? 1 : 0,
+            'seen' => $debt->user_id === $validated['user_id'] ? 1 : 0,
         ]);
 
         $shareService->addToDebt($share);

--- a/app/Http/Controllers/ShareController.php
+++ b/app/Http/Controllers/ShareController.php
@@ -47,7 +47,16 @@ class ShareController extends Controller
     {
         $validated = $request->validated();
 
-        $shareService->createShare($validated);
+        $share = Share::create([
+            'debt_id' => $validated['debt_id'],
+            'user_id' => $validated['user_id'],
+            'name' => $validated['name'],
+            'amount' => Money::of($validated['amount'], $validated['currency']),
+            'sent' => 0,
+            'seen' => 0,
+        ]);
+
+        $shareService->addToDebt($share);
         
         return redirect()->route('debt.index')->with('status', 'Share created successfully.');
     }
@@ -113,7 +122,7 @@ class ShareController extends Controller
         
         // mentioned in docblock, function name makes no sense
         // but it's for updating debt & user balance
-        $shareService->deleteShareDebt($share);
+        $shareService->subtractFromDebt($share);
 
         return redirect()->route('debt.index')->with('status', 'Share deleted successfully.');
     }

--- a/app/Http/Requests/StoreShareRequest.php
+++ b/app/Http/Requests/StoreShareRequest.php
@@ -27,6 +27,7 @@ class StoreShareRequest extends FormRequest
             'name' => ['sometimes', 'string'],
             'amount' => ['required', 'numeric', 'min:0.01'],
             'name' => ['nullable', 'string'],
+            'currency' => ['required', 'string', 'size:3'],
         ];
     }
 

--- a/app/Http/Requests/UpdateShareRequest.php
+++ b/app/Http/Requests/UpdateShareRequest.php
@@ -3,9 +3,6 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
-use App\Rules\IsShareOwner;
-use App\Rules\IsDebtOwner;
-use App\Rules\IsShareDebtOwner;
 use App\Models\Share;
 use App\Models\Debt;
 use Illuminate\Support\Facades\Auth;
@@ -29,10 +26,10 @@ class UpdateShareRequest extends FormRequest
     { 
         return [
             'id' => ['required', 'integer', 'exists:shares,id'],
-            'sent' => ['sometimes', 'boolean', new IsShareOwner()],
-            'seen' => ['sometimes', 'boolean', new IsShareDebtOwner()],
-            'amount' => ['sometimes', 'numeric', new IsShareDebtOwner()],
-            'name' => ['nullable', 'string', 'max:255', new IsShareDebtOwner()],
+            'sent' => ['sometimes', 'boolean'],
+            'seen' => ['sometimes', 'boolean'],
+            'amount' => ['sometimes', 'numeric'],
+            'name' => ['sometimes', 'nullable', 'string', 'max:255'],
         ];
     }
 }

--- a/app/Models/Share.php
+++ b/app/Models/Share.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use App\Observers\ShareObserver;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use App\Casts\Cash;
+use Illuminate\Support\Facades\Auth;
 
 class Share extends Model
 {
@@ -29,6 +30,14 @@ class Share extends Model
 
     protected $casts = [
         'amount' => Cash::class,
+    ];
+
+    protected $appends = [
+        'can_update_name',
+        'can_update_amount',
+        'can_update_sent',
+        'can_update_seen',
+        'can_delete',
     ];
 
     /**
@@ -60,5 +69,65 @@ class Share extends Model
     {
         // takes the two foreign keys and figures out the relationship (laravel magic)
         return $this->hasOne(GroupUser::class, 'user_id', 'user_id'); 
+    }
+
+    /**
+     * Append can_update policy to model
+     * 
+     * @return bool
+     */
+    public function getCanUpdateNameAttribute(): bool
+    {
+        $user = Auth::user();
+
+        return $user->can('updateName', $this);
+    }
+
+    /**
+     * Append can_update policy to model
+     * 
+     * @return bool
+     */
+    public function getCanUpdateAmountAttribute(): bool
+    {
+        $user = Auth::user();
+
+        return $user->can('updateAmount', $this);
+    }
+
+    /**
+     * Append can_update policy to model
+     * 
+     * @return bool
+     */
+    public function getCanUpdateSentAttribute(): bool
+    {
+        $user = Auth::user();
+
+        return $user->can('updateSent', $this);
+    }
+
+    /**
+     * Append can_update policy to model
+     * 
+     * @return bool
+     */
+    public function getCanUpdateSeenAttribute(): bool
+    {
+        $user = Auth::user();
+
+        return $user->can('updateSeen', $this);
+    }
+
+    /**
+     * Append can_delete policy to model
+     * 
+     * @return bool
+     */
+    public function getCanDeleteAttribute(): bool
+    {
+        $user = Auth::user();
+
+        return $user->can('delete', $this);
     }
 }

--- a/app/Policies/SharePolicy.php
+++ b/app/Policies/SharePolicy.php
@@ -34,25 +34,48 @@ class SharePolicy
     }
 
     /**
-     * Determine whether the user can update the model.
+     * Determine whether the user can update the share name
+     * Can be done by debt/share owner
      */
-    public function update(User $user, Share $share): bool
+    public function updateName(User $user, Share $share): bool
     {
-        return false;
+        return $user->id === $share->user_id || $user->id === $share->debt->user_id;
+    }
+
+    /**
+     * Determine whether the user can update the share amount
+     * Can be done by debt owner
+     */
+    public function updateAmount(User $user, Share $share): bool
+    {
+        return $user->id === $share->debt->user_id;
+    }
+
+    /**
+     * Determine whether the user can update the share amount
+     * Can be done by share owner
+     */
+    public function updateSent(User $user, Share $share): bool
+    {
+        return $user->id === $share->user_id;
+    }
+
+    /**
+     * Determine whether the user can update the share amount
+     * Can be done by debt owner
+     */
+    public function updateSeen(User $user, Share $share): bool
+    {
+        return $user->id === $share->debt->user_id;
     }
 
     /**
      * Determine whether the user can delete the model.
+     * Only the debt owner can delete a share.
      */
     public function delete(User $user, Share $share): bool
     {
-        $group_user_ids = GroupUser::where('user_id', $user->id)->get()->pluck('id')->toArray();
-
-        if (!in_array($share->group_user_id, $group_user_ids)) {
-            return false;
-        } else {
-            return true;
-        }
+        return $user->id === $share->debt->user_id;
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -9,6 +9,7 @@ use App\Models\Group;
 use App\Models\GroupUser;
 use App\Models\Alias;
 use App\Models\Debt;
+use App\Models\Share;
 use App\Models\Comment;
 use App\Policies\SharePolicy;
 use Illuminate\Support\Facades\Event;
@@ -26,6 +27,7 @@ class AppServiceProvider extends ServiceProvider
         GroupUser::class => GroupUserPolicy::class,
         Alias::class => AliasPolicy::class,
         Debt::class => DebtPolicy::class,
+        Share::class => SharePolicy::class,
         Comment::class => CommentPolicy::class,
     ];
     

--- a/app/Services/BalanceService.php
+++ b/app/Services/BalanceService.php
@@ -15,14 +15,17 @@ class BalanceService
      */
     public function addToGroupUserBalance($share): void
     {
-        [$share_group_user, $debt_group_user] = $this->getGroupUsers($share);
+        if ($share->user_id === $share->debt->user_id) {
+            return;
+        } else {
+            $debt_owner = GroupUser::where('user_id', $share->debt->user_id)->first();
         
-        $share_group_user->balance = $share_group_user->balance->minus($share->amount);
-        $share_group_user->save();
+            $debt_owner->balance = $debt_owner->balance->plus($share->amount);
+            $debt_owner->save();
 
-        $debt_group_user->balance = $debt_group_user->balance->plus($share->amount);
-        $debt_group_user->save();
-    
+            $share->group_user->balance = $share->group_user->balance->minus($share->amount);
+            $share->group_user->save();
+        }
     }
 
     /**
@@ -55,6 +58,7 @@ class BalanceService
      * 
      * @param Share $share
      * @param Money $difference
+     * @return void
      */
     public function subtractFromGroupUserBalance($share, $difference): void
     {

--- a/app/Services/BalanceService.php
+++ b/app/Services/BalanceService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Models\Share;
+use App\Models\GroupUser;
 
 class BalanceService
 
@@ -24,15 +25,28 @@ class BalanceService
     
     }
 
+    /**
+     * Update the group user balance based on the change in value of a single share
+     * We call the method on any share where amount is updated
+     * but only actually update balances when it's not the owner being updated
+     *
+     * @param Share $share
+     * @param Money $difference
+     * @return void
+     */
     public function updateGroupUserBalance($share, $difference): void
     {
-        [$share_group_user, $debt_group_user] = $this->getGroupUsers($share);
+        if ($share->user_id === $share->debt->user_id) {
+            return;
+        } else {
+            $debt_owner = GroupUser::where('user_id', $share->debt->user_id)->first();
 
-        $share_group_user->balance = $share_group_user->balance->minus($difference);
-        $share_group_user->save();
+            $debt_owner->balance = $debt_owner->balance->plus($difference);
+            $debt_owner->save();
 
-        $debt_group_user->balance = $debt_group_user->balance->plus($difference);
-        $debt_group_user->save();
+            $share->group_user->balance = $share->group_user->balance->minus($difference);
+            $share->group_user->save();
+        }
     }
 
     public function subtractFromGroupUserBalance($share): void

--- a/app/Services/BalanceService.php
+++ b/app/Services/BalanceService.php
@@ -49,16 +49,26 @@ class BalanceService
         }
     }
 
-    public function subtractFromGroupUserBalance($share): void
+    /**
+     * Subtract debt shares from user balance, used in delete process
+     * Basically same code from updateGroupUserBalance, just inverted operations
+     * 
+     * @param Share $share
+     * @param Money $difference
+     */
+    public function subtractFromGroupUserBalance($share, $difference): void
     {
-        [$share_group_user, $debt_group_user] = $this->getGroupUsers($share);
+        if ($share->user_id === $share->debt->user_id) {
+            return;
+        } else {
+            $debt_owner = GroupUser::where('user_id', $share->debt->user_id)->first();
 
-        $share_group_user->balance = $share_group_user->balance->plus($share->amount);
-        $share_group_user->save();
+            $debt_owner->balance = $debt_owner->balance->minus($difference);
+            $debt_owner->save();
 
-        $debt_group_user->balance = $debt_group_user->balance->minus($share->amount);
-        $debt_group_user->save();
-      
+            $share->group_user->balance = $share->group_user->balance->plus($difference);
+            $share->group_user->save();
+        }
     }
 
     private function getGroupUsers(Share $share)

--- a/app/Services/DebtService.php
+++ b/app/Services/DebtService.php
@@ -15,58 +15,6 @@ class DebtService
         $this->shareService = $shareService;
     }
 
-    /**
-     * Update an existing debt.
-     *
-     * @param array $data - the new data being passed in
-     * @return Debt|mixed
-     */
-    public function updateDebt($data): mixed
-    {
-        $debt = Debt::findOrFail($data['id']);
-        $debt_amount = $debt->amount;
-        $new_amount = Money::of($data['amount'], $debt->currency);
-        
-        // todo: this is a mess, clean it 
-
-        if ($debt_amount != $new_amount) {
-
-            $difference = $new_amount->minus($debt_amount);
-
-            // if it's split even, update everyone's shares
-            if ($debt->split_even) {
-                
-                // get the split amount as a money object
-                $split_difference = $difference->split($debt->shares->count());
-  
-                $count = 0;
-
-                foreach ($debt->shares as $share) {
-                    // build data object for updating the share
-                    $data = [
-                        'id' => $share->id,
-                        'amount' => $split_difference[$count],
-                        'user_id' => $share->user_id,
-                    ];
-
-                    $this->shareService->updateShare($data);
-                    $count++;
-                }
-
-                $debt->amount = $debt->amount->plus($difference);
-                $debt->save();
-                
-            // if not split even, just update the amount
-            // discrepancy is handled by the controller
-            } else {
-                $debt->amount = $debt->amount->plus($difference);
-                $debt->save();
-            }  
-        } 
-   
-        return $debt;
-    }
-
     public function deleteDebt($data): void
     {
         // find the debt

--- a/app/Services/DebtService.php
+++ b/app/Services/DebtService.php
@@ -14,18 +14,4 @@ class DebtService
     {
         $this->shareService = $shareService;
     }
-
-    public function deleteDebt($data): void
-    {
-        // find the debt
-        $debt = Debt::findOrFail($data['id']);
-
-        // delete the shares
-        $this->shareService->deleteDebtShares($debt->shares);
-
-        // and finally the debt
-        $debt->delete();
-
-        return;
-    }
 }

--- a/app/Services/DebtService.php
+++ b/app/Services/DebtService.php
@@ -28,10 +28,6 @@ class DebtService
         $new_amount = Money::of($data['amount'], $debt->currency);
         
         // todo: this is a mess, clean it 
-        
-        if ($debt->name != $data['name']) {
-            $debt->update(['name' => $data['name']]);
-        }
 
         if ($debt_amount != $new_amount) {
 

--- a/app/Services/DebtService.php
+++ b/app/Services/DebtService.php
@@ -16,31 +16,6 @@ class DebtService
     }
 
     /**
-     * Create a new debt.
-     *
-     * @param array $data
-     * @return Debt|mixed
-     */
-    public function createDebt($data): Debt 
-    {
-        // create the debt with validated data
-        $debt = Debt::create([
-            'group_id' => $data['group_id'],
-            'user_id' => $data['user_id'],
-            'name' => $data['name'],
-            'amount' => Money::of($data['amount'], $data['currency']),
-            'split_even' => $data['split_even'],
-            'cleared' => 0,
-            'currency' => $data['currency'],
-        ]);
-
-        // create the relative shares
-        $this->shareService->createDebtShares($data['user_shares'], $debt);
-
-        return $debt;
-    }
-
-    /**
      * Update an existing debt.
      *
      * @param array $data - the new data being passed in

--- a/app/Services/ShareService.php
+++ b/app/Services/ShareService.php
@@ -76,7 +76,7 @@ class ShareService
      * @param Money $discrepancy
      * @return void
      */
-    public function updateDebtShare($share, $discrepancy): void
+    public function updateShareDebt($share, $discrepancy): void
     {
         $debt = $share->debt;
  
@@ -133,17 +133,15 @@ class ShareService
     }
 
     /**
-     * For deleting a single share
+     * I know the naming doesn't actually make sense but i'm just following my convention
+     * This is for updating debt & balance after deleting a single share
+     * 
+     * @param Share $share
+     * @return void
      */
-    public function deleteShare($data): void
+    public function deleteShareDebt($share): void
     {
-        // just delete the share
-        $share = Share::findOrFail($data['id']);
-        $share->delete();
-
-        if ($share->user_id != $share->debt->user_id) {
-            $this->balanceService->subtractFromGroupUserBalance($share);
-        }
+        $this->balanceService->subtractFromGroupUserBalance($share, $share->amount);
 
         // and adjust the debt amount
         $debt = $share->debt;

--- a/app/Services/ShareService.php
+++ b/app/Services/ShareService.php
@@ -69,42 +69,29 @@ class ShareService
     }
 
     /**
-     * Generic updating existing share
-     * $data['amount] is a Money object from DebtService & ShareController
+     * After an individual share is updated in the controller, debt must be updated
+     * And total balance recalced
+     *
+     * @param Share $share
+     * @param Money $discrepancy
+     * @return void
      */
-    public function updateShare($data): Share
+    public function updateDebtShare($share, $discrepancy): void
     {
-        $share = Share::findOrFail($data['id']);
+        $debt = $share->debt;
+ 
+        $debt->amount = $debt->amount->plus($discrepancy);
+        $debt->save();
 
-        // if we're not updating the amout, just put in the data
-        // this is a temporary workaround
-        // todo: actually do something with sent/seen
-        if (!array_key_exists('amount', $data)) {
-            
-            $share->update($data);
-
-            return $share;
-        } else {
-            
-            $debt = $share->debt;
-            $difference = $data['amount'];
-            
-            $share->amount = $share->amount->plus($difference);
-            $share->save();
-
-            $debt->amount = $debt->amount->plus($difference);
-            $debt->save();
-
-            if ($share->user_id != $share->debt->user_id) {
-                $this->balanceService->updateGroupUserBalance($share, $difference);
-            }
-
-            return $share;
-        }
+        $this->balanceService->updateGroupUserBalance($share, $discrepancy);    
+      
+        return;
     }
 
+
     /**
-     * Update shares equally, currerntly only used on a split even debt
+     * Update shares equally, currerntly only used as a part of updating
+     * a split even debt
      *
      * @param Debt $debt
      * @param Money $discrepancy

--- a/app/Services/ShareService.php
+++ b/app/Services/ShareService.php
@@ -130,15 +130,16 @@ class ShareService
 
     /**
      * Specific to when shares are deleted during debt deletion
+     * 
+     * @param Debt $debt
+     * @return void
      */
-    public function deleteDebtShares($data): void
+    public function deleteDebtShares($debt): void
     {
-        foreach ($data as $share) {
-            $share->delete();
+        foreach ($debt->shares as $share) {
+            $this->balanceService->subtractFromGroupUserBalance($share, $share->amount);
 
-            if ($share->user_id != $share->debt->user_id) {
-                $this->balanceService->subtractFromGroupUserBalance($share);
-            }
+            $share->delete();
         }
 
         return; 

--- a/app/Services/ShareService.php
+++ b/app/Services/ShareService.php
@@ -18,6 +18,9 @@ class ShareService
 
     /**
      * Specific to when shares are created during debt creation
+     * @param $data array of share data from form request
+     * @param Debt $debt
+     * @return void
      */
     public function createDebtShares($data, $debt): void
     {

--- a/app/Services/ShareService.php
+++ b/app/Services/ShareService.php
@@ -32,40 +32,27 @@ class ShareService
                 'seen' => 0,
             ]);
 
-            if ($share->user_id != $share->debt->user_id) {
-                $this->balanceService->addToGroupUserBalance($share);
-            }
+            $this->balanceService->addToGroupUserBalance($share);    
         }
         
         return;
     }
 
     /**
-     * For adding a single share
-     */
-    public function createShare($data): Share
+     * After a single share has been added, the debt & user balance must be updated
+     * @param Share $share
+     * @return void 
+    */
+    public function addToDebt($share): void
     {
-        $debt = Debt::findOrFail($data['debt_id']);
-
-        // create the share
-        $share = Share::create([
-            'debt_id' => $data['debt_id'],
-            'user_id' => $data['user_id'],
-            'name' => $data['name'],
-            'amount' => Money::of($data['amount'], $debt->currency),
-            'sent' => 0,
-            'seen' => 0,
-        ]);
-
-        if ($share->user_id != $share->debt->user_id) {
-            $this->balanceService->addToGroupUserBalance($share);
-        }
-        
-        // update debt amount
+        $debt = $share->debt;
+ 
         $debt->amount = $debt->amount->plus($share->amount);
         $debt->save();
 
-        return $share;
+        $this->balanceService->addToGroupUserBalance($share);
+
+        return;
     }
 
     /**
@@ -139,7 +126,7 @@ class ShareService
      * @param Share $share
      * @return void
      */
-    public function deleteShareDebt($share): void
+    public function subtractFromDebt($share): void
     {
         $this->balanceService->subtractFromGroupUserBalance($share, $share->amount);
 

--- a/app/Services/ShareService.php
+++ b/app/Services/ShareService.php
@@ -104,6 +104,31 @@ class ShareService
     }
 
     /**
+     * Update shares equally, currerntly only used on a split even debt
+     *
+     * @param Debt $debt
+     * @param Money $discrepancy
+     * @return void
+     */
+    public function updateDebtShares($debt, $discrepancy): void
+    {
+        // the discrepancy between new and old debt amount, 
+        // split between the amount of shares
+        $discrepancy_shares = $discrepancy->split($debt->shares->count());
+
+        foreach ($debt->shares as $index => $share) {
+            $difference = $discrepancy_shares[$index];
+
+            $share->amount = $share->amount->plus($difference);
+            $share->save();
+
+            $this->balanceService->updateGroupUserBalance($share, $difference);    
+        }
+
+        return;
+    }
+
+    /**
      * Specific to when shares are deleted during debt deletion
      */
     public function deleteDebtShares($data): void

--- a/app/Services/ShareService.php
+++ b/app/Services/ShareService.php
@@ -31,8 +31,8 @@ class ShareService
                 'user_id' => $share['user_id'],
                 'name' => $share['name'],
                 'amount' => Money::of($share['amount'], $debt->currency),
-                'sent' => 0,
-                'seen' => 0,
+                'sent' => $debt->user_id === $share['user_id'] ? 1 : 0,
+                'seen' => $debt->user_id === $share['user_id'] ? 1 : 0,
             ]);
 
             $this->balanceService->addToGroupUserBalance($share);    

--- a/database/factories/CommentFactory.php
+++ b/database/factories/CommentFactory.php
@@ -17,7 +17,7 @@ class CommentFactory extends Factory
     public function definition(): array
     {
         return [
-            
+            'content' => $this->faker->sentence(),
         ];
     }
 }

--- a/database/factories/DebtFactory.php
+++ b/database/factories/DebtFactory.php
@@ -9,7 +9,6 @@ use App\Models\User;
 use App\Models\Share;
 use Illuminate\Database\Eloquent\Model;
 use Brick\Money\Money;
-
 use Faker\Factory as Faker;
 
 /**
@@ -66,7 +65,7 @@ class DebtFactory extends Factory
                 'amount' => $money[$key],
                 // debt owner share automatically set to 'sent'
                 // 'sent' => $group_user->user_id === $debt->user_id ? 1 : rand(0, 1),
-                'sent' => 0,
+                'sent' => rand(0,1),
                 'seen' => 0,
             ]);
         }

--- a/database/factories/ShareFactory.php
+++ b/database/factories/ShareFactory.php
@@ -45,6 +45,13 @@ class ShareFactory extends Factory
                 $debt_group_user->save();
                 $share_group_user->save();
             }   
+
+            // as 'seen' is just cosmetic, randomise whether or not
+            // as 'sent' share is also seen
+            if ($share->sent) {
+                $share->seen =  $share->user_id === $share->debt->user_id ? 1 : rand(0,1);
+                $share->save();
+            }
         });
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -9,6 +9,7 @@ use App\Models\Group;
 use App\Models\GroupUser;
 use App\Models\Debt;
 use App\Models\Share;
+use App\Models\Comment;
 use Illuminate\Database\Eloquent\Model;
 
 use Faker\Factory as Faker;
@@ -24,7 +25,7 @@ class DatabaseSeeder extends Seeder
         $this->createUsers();
         $this->createGroupsWithGroupUsers();
         $this->createDebtsWithShares();
-        // $this->withGman();
+        $this->createComments();
     }
 
     public function createUsers()
@@ -95,27 +96,28 @@ class DatabaseSeeder extends Seeder
         } 
     }
 
-    public function withGman()
+    public function createComments()
     {
-        $gman = User::factory()->create([
-            'name' => 'gman',
-            'email' => 'gman@gman.com',
-            'password' => 'gman',
-        ]);
+        $debts = Debt::all();
 
-        $group = Group::factory()->withGroupUsers()->create([
-            'user_id' => $gman->id,
-        ]);
+        foreach ($debts as $debt) {
+            // 50/50 on whether or not we add a comment
+            $add_comments = random_int(0,1);
+            
+            if ($add_comments) {
+                // random number of comments
+                $num_comments = random_int(1, 5);
 
-        $self = User::findOrFail(1);
-       
-        $my_group = Group::factory()->withGroupUsers()->create([
-            'user_id' => $self->id,
-        ]);
+                for ($i = 0; $i < $num_comments; $i++) {
+                    Comment::factory()->create([
+                        'debt_id' => $debt->id,
+                        'user_id' => Arr::random($debt->group->group_users->pluck('user_id')->toArray()),
+                    ]);
+                }
 
-        GroupUser::factory()->create([
-            'user_id' => $gman->id,
-            'group_id' => $my_group->id,
-        ]);
+                $this->command->info("{$num_comments} comments added for debt {$debt->id}");
+            }
+        }
     }
+
 }

--- a/resources/js/Components/Debts/Debt.vue
+++ b/resources/js/Components/Debts/Debt.vue
@@ -26,8 +26,6 @@ const confirmingDebtDeletion = ref(false);
 const showShares = ref(false);
 const showComments = ref(false);
 const isEditing = ref(false);
-// if the logged in user owners the debt, display the controls
-const owns_debt = usePage().props.auth.user.id === props.debt.user_id ? true : false;
 
 // misc
 const debtCurrency = computed(() => {
@@ -35,7 +33,7 @@ const debtCurrency = computed(() => {
 });
 
 const debtDiscrepancy = computed(() => {
-    return props.debt.shares.reduce((total, share) => total + Number(share.amount.amount), 0);
+    return props.debt.amount.amount - props.debt.shares.reduce((total, share) => total + Number(share.amount.amount), 0);
 });
 
 const closeModal = () => {
@@ -43,11 +41,7 @@ const closeModal = () => {
 };
 
 onMounted(() => {
-    // if (debtDiscrepancy.value != props.debt.amount.amount) {
-    //     const discrepancy = props.debt.amount.amount - debtDiscrepancy.value;
-    //     debtForm.errors.amount = `There is a discrepancy of ${debtCurrency.value.symbol}${discrepancy.toFixed(2)}.`;
-    // }
-
+    console.log('debtDiscrepancy', debtDiscrepancy.value);
 });
 
 </script>
@@ -77,6 +71,9 @@ onMounted(() => {
                 <h2 class="h3 text-center">
                     {{ debtCurrency.symbol }}{{ props.debt.amount.amount }}
                 </h2>
+                <h3 v-if="debtDiscrepancy" class="text-center text-red-600">
+                    Discrepancy: {{ debtCurrency.symbol }}{{ debtDiscrepancy }}
+                </h3>
                 <h3 class="h4 text-center">{{ props.debt.group.name }}</h3>
             </div>
             <div v-else class="w-full">
@@ -174,7 +171,7 @@ onMounted(() => {
             >
             </Share>
             <AddShare
-                v-if="owns_debt && showShares"
+                v-if="props.debt.can_delete && showShares"
                 :debt="debt"
                 :group_users="debt.group.group_users"
             >

--- a/resources/js/Components/Debts/Debt.vue
+++ b/resources/js/Components/Debts/Debt.vue
@@ -204,7 +204,7 @@ onMounted(() => {
                 </h2>   
                 <Form
                     class="mt-6 flex justify-end"
-                    :action="route('debt.destroy')"
+                    :action="route('debt.destroy', props.debt)"
                     method="delete"
                     #default="{ errors }"
                     @success="closeModal"

--- a/resources/js/Components/Debts/Debt.vue
+++ b/resources/js/Components/Debts/Debt.vue
@@ -47,7 +47,7 @@ onMounted(() => {
     //     const discrepancy = props.debt.amount.amount - debtDiscrepancy.value;
     //     debtForm.errors.amount = `There is a discrepancy of ${debtCurrency.value.symbol}${discrepancy.toFixed(2)}.`;
     // }
-    console.log(props.debt);
+
 });
 
 </script>

--- a/resources/js/Components/Forms/CurrencyPicker.vue
+++ b/resources/js/Components/Forms/CurrencyPicker.vue
@@ -16,7 +16,6 @@ const emit = defineEmits(['currencySelected']);
 
 function setSelectedCurrency(currencyCode) {
     const selected = currencies.find((currency) => currency.code = currencyCode);
-    console.log(selected);
     emit('currencySelected', selected);
 }
 

--- a/resources/js/Components/GroupUsers/GroupUser.vue
+++ b/resources/js/Components/GroupUsers/GroupUser.vue
@@ -33,6 +33,11 @@ const visibleAlias = computed(() =>
     )
 );
 
+// for some weird reason, v-model doesn't like visibleAlias?.alias
+// or any sort of ternary involving it
+// so this is a temporary fix until i figure out the 'correct' fix
+const loggedInUserAlias = visibleAlias ? visibleAlias.alias : '';
+
 onMounted(() => {
 
 })
@@ -72,7 +77,7 @@ onMounted(() => {
                     New Alias
                     </label>
                     <TextInput
-                        v-model="visibleAlias.alias"
+                        v-model="loggedInUserAlias"
                         name="alias"
                         type="text"
                         id="newGroupUserAlias"

--- a/resources/js/Components/Misc/Collapsible.vue
+++ b/resources/js/Components/Misc/Collapsible.vue
@@ -45,6 +45,8 @@ const refresh = async () => {
     el.style.height = el.scrollHeight + 'px'
 }
 
+// key/signal to provide, content that is being provided
+// so this essentially provides the entire function
 provide('collapsibleRefresh', refresh);
 </script>
 

--- a/resources/js/Components/Shares/AddShare.vue
+++ b/resources/js/Components/Shares/AddShare.vue
@@ -36,6 +36,7 @@ onMounted(() => {
             :transform="data => ({ 
                 ...data, 
                 debt_id: props.debt.id,
+                currency: props.debt.currency,
             })"
             class="mt-4"
             @success="refresh & refresh()"

--- a/resources/js/Components/Shares/SentSeenButton.vue
+++ b/resources/js/Components/Shares/SentSeenButton.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { Form } from '@inertiajs/vue3';
 import { onMounted } from 'vue';
+import InputError from '@/Components/Forms/InputError.vue';
 
 const props = defineProps({
     operation: {
@@ -16,6 +17,8 @@ const props = defineProps({
         required: true,
     },
 })
+
+const emit = defineEmits(['seenError', 'sentError']);
 
 onMounted(() => {
     console.log(props.share, props.type);
@@ -36,6 +39,7 @@ onMounted(() => {
             id: props.share.id,
             [operation]: !props.share[operation],
         })"
+        @error="(errors) => emit(operation + 'Error', errors)"
     >
         <label :for="operation" class="text-xs font-semibold">
             {{ operation.toUpperCase() }}

--- a/resources/js/Components/Shares/SentSeenButton.vue
+++ b/resources/js/Components/Shares/SentSeenButton.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { Form } from '@inertiajs/vue3';
-import { onMounted, computed, guardReactiveProps } from 'vue';
+import { onMounted, computed } from 'vue';
 
 const props = defineProps({
     operation: {

--- a/resources/js/Components/Shares/SentSeenButton.vue
+++ b/resources/js/Components/Shares/SentSeenButton.vue
@@ -63,7 +63,7 @@ onMounted(() => {
             <i
                 :id="props.operation + '-tick-' + share.id" 
                 class="fa-solid fa-check"
-                :class="share[operation] ? '' : 'hidden'"
+                :class="share[operation] ? '' : 'invisible'"
             >
             </i>
         </button>

--- a/resources/js/Components/Shares/SentSeenButton.vue
+++ b/resources/js/Components/Shares/SentSeenButton.vue
@@ -1,0 +1,61 @@
+<script setup>
+import { Form } from '@inertiajs/vue3';
+import { onMounted } from 'vue';
+
+const props = defineProps({
+    operation: {
+        type: String,
+        required: true,
+    },
+    type: {
+        type: String,
+        required: true,
+    },
+    share: {
+        type: Object,
+        required: true,
+    },
+})
+
+onMounted(() => {
+    console.log(props.share, props.type);
+})
+
+</script>
+<template>
+    <Form
+        class=" flex flex-col mx-2"
+        :action="route('share.' + operation, share)"
+        method="patch"
+        #default="{ errors }"
+        :options="{
+            preserveScroll: true,
+        }"
+        :transform="data => ({ 
+            ...data, 
+            id: props.share.id,
+            [operation]: !props.share[operation],
+        })"
+    >
+        <label :for="operation" class="text-xs font-semibold">
+            {{ operation.toUpperCase() }}
+        </label>
+        <input 
+            type="checkbox"
+            :id="operation + share.id" 
+            class="hidden"
+            :name="operation"
+            :value="share[operation]"
+        >
+        <button
+            class="border-2 bg-gray-100 rounded border-black"
+            style="height:35px;width:35px"
+        >
+            <i 
+                class="fa-solid fa-check"
+                :class="share[operation] ? '' : 'hidden'"
+            >
+            </i>
+        </button>
+    </Form>
+</template>

--- a/resources/js/Components/Shares/SentSeenButton.vue
+++ b/resources/js/Components/Shares/SentSeenButton.vue
@@ -1,7 +1,6 @@
 <script setup>
 import { Form } from '@inertiajs/vue3';
-import { onMounted } from 'vue';
-import InputError from '@/Components/Forms/InputError.vue';
+import { onMounted, computed, guardReactiveProps } from 'vue';
 
 const props = defineProps({
     operation: {
@@ -20,8 +19,12 @@ const props = defineProps({
 
 const emit = defineEmits(['seenError', 'sentError']);
 
+const sentAndSeenClasses = computed(() => {
+
+})
+
 onMounted(() => {
-    console.log(props.share, props.type);
+
 })
 
 </script>
@@ -41,7 +44,7 @@ onMounted(() => {
         })"
         @error="(errors) => emit(operation + 'Error', errors)"
     >
-        <label :for="operation" class="text-xs font-semibold">
+        <label :for="operation + share.id" class="text-xs font-semibold">
             {{ operation.toUpperCase() }}
         </label>
         <input 
@@ -52,10 +55,13 @@ onMounted(() => {
             :value="share[operation]"
         >
         <button
+            :disabled="props.share.sent && props.share.seen"
+            :id="props.operation + '-button-' + share.id"
             class="border-2 bg-gray-100 rounded border-black"
             style="height:35px;width:35px"
         >
-            <i 
+            <i
+                :id="props.operation + '-tick-' + share.id" 
                 class="fa-solid fa-check"
                 :class="share[operation] ? '' : 'hidden'"
             >

--- a/resources/js/Components/Shares/Share.vue
+++ b/resources/js/Components/Shares/Share.vue
@@ -159,7 +159,7 @@ onMounted(() => {
         </div>
         <div v-else class="w-full">
             <Form
-                :action="route('share.update')" 
+                :action="route('share.update', props.share)" 
                 method="patch" 
                 #default="{ errors }"
                 :transform="data => ({
@@ -183,6 +183,7 @@ onMounted(() => {
                         </label>
                         <TextInput
                             name="name"
+                            v-model="props.share.name"
                             type="text"
                             id="newShareName"
                             aria-labelledby="newShareNameLabel"
@@ -202,6 +203,7 @@ onMounted(() => {
                         </label>
                         <TextInput 
                             name="amount"
+                            v-model="props.share.amount.amount"
                             type="number"
                             step="0.01"
                             id="newShareAmount"

--- a/resources/js/Components/Shares/Share.vue
+++ b/resources/js/Components/Shares/Share.vue
@@ -63,7 +63,7 @@ onMounted(() => {
                 <!-- sent & seen -->
                 <div class="flex flex-row items-center">
                     <SentSeenButton
-                    operation="sent"
+                        operation="sent"
                         type="submit"
                         :share="share"
                         @sentError="setSentSeenMessage($event)"

--- a/resources/js/Components/Shares/Share.vue
+++ b/resources/js/Components/Shares/Share.vue
@@ -47,21 +47,18 @@ onMounted(() => {
 </script>
 
 <template>
-    <div class="plate flex flex-col" :style="props.share.user_id === props.debt.user_id ? 'box-shadow: 2px 2px green' : ''">
+    <div class="plate flex flex-col">
         <div v-if="!isEditing" class="flex flex-row justify-between w-full">
             <!-- group user, share name, amount -->
             <div class="flex flex-col">
-                <p class="font-semibold">{{ share.group_user.user.name }}</p>
+                <p class="font-semibold text-lg mr-2">{{ share.group_user.user.name }}</p>
                 <p>{{ debtCurrency.symbol }}{{ share.amount.amount }}</p>
                 <p>{{ share.name ? share.name : ' ' }}</p>
             </div>
-            <!-- sent/seen/controls container -->
-            <div 
-                class="flex flex-row items-center" 
-                :class="props.share.user_id === props.debt.user_id ? 'hidden' : ''"
-            >
+            <!-- sent/seen/controls/owner badge container -->
+            <div class="flex flex-row items-center" >
                 <!-- sent & seen -->
-                <div class="flex flex-row items-center">
+                <div v-if="props.share.user_id !== props.debt.user_id" class="flex flex-row items-center">
                     <SentSeenButton
                         operation="sent"
                         type="submit"
@@ -74,6 +71,12 @@ onMounted(() => {
                         :share="share"
                         @seenError="setSentSeenMessage($event)"
                     />
+                </div>
+                <!-- owner badge -->
+                <div v-else class="flex flex-col items-center" style="width:103px">
+                    <p class="text-xs font-semibold bg-black text-white p-1 border rounded">
+                        OWNER
+                    </p>
                 </div>
                 <Controls
                     item="Share"

--- a/resources/js/Components/Shares/Share.vue
+++ b/resources/js/Components/Shares/Share.vue
@@ -79,6 +79,10 @@ const debtCurrency = computed(() => {
     return currencies.find((currency) => currency.code === props.currency)
 });
 
+onMounted(() => {
+    console.log('share', props.share);
+})
+
 </script>
 
 <template>

--- a/resources/js/Components/Shares/Share.vue
+++ b/resources/js/Components/Shares/Share.vue
@@ -250,7 +250,6 @@ onMounted(() => {
                     :transform="data => ({ 
                         ...data, 
                         debt_id: props.share.debt_id,
-                        currency: props.currency,
                     })"
                 >
                     <div class="flex flex-row mt-4 justify-center sm:justify-end w-full">

--- a/resources/js/Components/Shares/Share.vue
+++ b/resources/js/Components/Shares/Share.vue
@@ -250,6 +250,7 @@ onMounted(() => {
                     :transform="data => ({ 
                         ...data, 
                         debt_id: props.share.debt_id,
+                        currency: props.currency,
                     })"
                 >
                     <div class="flex flex-row mt-4 justify-center sm:justify-end w-full">

--- a/resources/js/Components/Shares/Share.vue
+++ b/resources/js/Components/Shares/Share.vue
@@ -26,54 +26,8 @@ const props = defineProps({
 
 
 const confirmingShareDeletion = ref(false);
-// if the logged in user owners the debt, display the controls
-const displayControls = usePage().props.auth.user.id === props.debt.user_id ? true : false;
-// if the share on display is for the owner of the debt, highlight it
-const isDebtOwner = props.share.user_id === props.debt.user_id;
 const isEditing = ref(false);
 const refresh = inject('collapsibleRefresh');
-
-// send share
-const sendShareForm = useForm({
-    id: props.share.id,
-    debt_id: props.share.debt_id,
-    sent: props.share.sent,
-});
-
-function sendShare() {
-    // change the status of the checkbox, post it
-    sendShareForm.sent = !sendShareForm.sent;
-    sendShareForm.patch(route('share.update'), {
-        preserveScroll: true,
-        onSuccess: () => {
-            
-        },
-        onError: (error) => {
-   
-        },
-    });
-}
-
-// seen share
-const seenShareForm = useForm({
-    id: props.share.id,
-    debt_id: props.share.debt_id,
-    seen: props.share.seen,
-});
-
-function seenShare() {
-    // change the status of the checkbox, post it
-    seenShareForm.seen = !seenShareForm.seen;
-    seenShareForm.patch(route('share.update'), {
-        preserveScroll: true,
-        onSuccess: () => {
-            
-        },
-        onError: (error) => {
-
-        },
-    });
-}
 
 // todo: figure out a way to stop having to use this function in multiple places
 const debtCurrency = computed(() => {
@@ -87,7 +41,7 @@ onMounted(() => {
 </script>
 
 <template>
-    <div class="plate" :style="isDebtOwner ? 'box-shadow: 2px 2px green' : ''">
+    <div class="plate" :style="props.share.user_id === props.debt.user_id ? 'box-shadow: 2px 2px green' : ''">
         <div v-if="!isEditing" class="flex flex-row justify-between w-full">
             <!-- group user, share name, amount -->
             <div class="flex flex-col">
@@ -109,52 +63,6 @@ onMounted(() => {
                         type="submit"
                         :share="share"
                      />
-                    <!-- <form class="flex flex-col items-center p-1" @submit.prevent="sendShare">
-                        <small>Sent</small>
-                        <label 
-                            class="hidden"
-                            :for="'sent-' + share.id"
-                        >
-                            Send share
-                        </label>
-                        <input 
-                            type="checkbox" 
-                            :id="'sent-' + share.id" 
-                            class="hidden"
-                            v-model="sendShareForm.sent"
-                        >
-                        <button
-                            style="height:40px;width:40px;border-radius:50%" 
-                            class="border-solid border-2 flex justify-center items-center"
-                            :class="props.share.sent ? 'border-green-400' : 'border-red-400'"
-                        >
-                            <i class="fa-solid fa-check"></i>
-                        </button>
-                        <InputError class="mt-2" :message="sendShareForm.errors.sent" />
-                    </form>
-                    <form class="flex flex-col items-center p-1" @submit.prevent="seenShare">
-                        <small>Seen</small>
-                        <label 
-                            class="hidden"
-                            :for="'seen-' + share.id"
-                        >
-                            Seen share
-                        </label>
-                        <input 
-                            type="checkbox" 
-                            :id="'seen-' + share.id" 
-                            class="hidden"
-                            v-model="seenShareForm.seen"
-                        >
-                        <button
-                            style="height:40px;width:40px;border-radius:50%" 
-                            class="border-solid border-2 flex justify-center items-center"
-                            :class="props.share.seen ? 'border-green-400' : 'border-red-400'"
-                        >
-                            <i class="fa-solid fa-check"></i>
-                        </button>
-                        <InputError class="mt-2" :message="seenShareForm.errors.seen" />
-                    </form> -->
                 </div>
                 <Controls
                     item="Share"

--- a/resources/js/Components/Shares/Share.vue
+++ b/resources/js/Components/Shares/Share.vue
@@ -36,7 +36,8 @@ const debtCurrency = computed(() => {
 });
 
 function setSentSeenMessage(message) {
-    sentSeenMessage.value = message[0];
+    console.log(message);
+    sentSeenMessage.value = message.sent ?? message.seen;
     refresh & refresh();
 }
 
@@ -99,7 +100,8 @@ onMounted(() => {
                 :transform="data => ({
                     ...data,
                     id: props.share.id,
-                    debt_id: props.debt.id, 
+                    name: props.share.name,
+                    amount: props.share.amount.amount,
                 })"
                 @success="isEditing = false"
                 :options="{

--- a/resources/js/Components/Shares/Share.vue
+++ b/resources/js/Components/Shares/Share.vue
@@ -240,7 +240,7 @@ onMounted(() => {
                 </h2>
                 <Form
                     class="mt-6 flex justify-end"
-                    :action="route('share.destroy')"
+                    :action="route('share.destroy', props.share)"
                     method="delete"
                     #default="{ errors }"
                     @success="confirmingShareDeletion = false;refresh & refresh()"

--- a/resources/js/Components/Shares/Share.vue
+++ b/resources/js/Components/Shares/Share.vue
@@ -28,20 +28,26 @@ const props = defineProps({
 const confirmingShareDeletion = ref(false);
 const isEditing = ref(false);
 const refresh = inject('collapsibleRefresh');
+const sentSeenMessage = ref(null);
 
 // todo: figure out a way to stop having to use this function in multiple places
 const debtCurrency = computed(() => {
     return currencies.find((currency) => currency.code === props.currency)
 });
 
+function setSentSeenMessage(message) {
+    sentSeenMessage.value = message[0];
+    refresh & refresh();
+}
+
 onMounted(() => {
-    console.log('share', props.share);
+    console.log('share', props.errors);
 })
 
 </script>
 
 <template>
-    <div class="plate" :style="props.share.user_id === props.debt.user_id ? 'box-shadow: 2px 2px green' : ''">
+    <div class="plate flex flex-col" :style="props.share.user_id === props.debt.user_id ? 'box-shadow: 2px 2px green' : ''">
         <div v-if="!isEditing" class="flex flex-row justify-between w-full">
             <!-- group user, share name, amount -->
             <div class="flex flex-col">
@@ -50,19 +56,24 @@ onMounted(() => {
                 <p>{{ share.name ? share.name : ' ' }}</p>
             </div>
             <!-- sent/seen/controls container -->
-            <div class="flex flex-row items-center">
+            <div 
+                class="flex flex-row items-center" 
+                :class="props.share.user_id === props.debt.user_id ? 'hidden' : ''"
+            >
                 <!-- sent & seen -->
                 <div class="flex flex-row items-center">
                     <SentSeenButton
                     operation="sent"
                         type="submit"
                         :share="share"
+                        @sentError="setSentSeenMessage($event)"
                     />
                     <SentSeenButton
                         operation="seen"
                         type="submit"
                         :share="share"
-                     />
+                        @seenError="setSentSeenMessage($event)"
+                    />
                 </div>
                 <Controls
                     item="Share"
@@ -76,6 +87,7 @@ onMounted(() => {
                 </Controls>
             </div>
         </div>
+        <!-- editing form -->
         <div v-else class="w-full">
             <Form
                 :action="route('share.update', props.share)" 
@@ -150,6 +162,7 @@ onMounted(() => {
                 </div>
             </Form>
         </div>
+        <InputError v-if="sentSeenMessage" class="mt-2" :message="sentSeenMessage" />
         <Modal :show="confirmingShareDeletion">
             <div class="p-6">
                 <h2

--- a/resources/js/Components/Shares/Share.vue
+++ b/resources/js/Components/Shares/Share.vue
@@ -10,6 +10,7 @@ import DangerButton from '@/Components/Misc/DangerButton.vue';
 import PrimaryButton from '@/Components/Misc/PrimaryButton.vue';
 import SecondaryButton from '@/Components/Misc/SecondaryButton.vue';
 import TextInput from '@/Components/Forms/TextInput.vue';
+import SentSeenButton from '@/Components/Shares/SentSeenButton.vue';
 
 const props = defineProps({
     share: {
@@ -94,11 +95,21 @@ onMounted(() => {
                 <p>{{ debtCurrency.symbol }}{{ share.amount.amount }}</p>
                 <p>{{ share.name ? share.name : ' ' }}</p>
             </div>
+            <!-- sent/seen/controls container -->
             <div class="flex flex-row items-center">
                 <!-- sent & seen -->
-                 <div class="flex flex-row items-center invisible">
-                <!-- <div class="flex flex-row items-center" :class="!isDebtOwner ? 'visible' : 'invisible'"> -->
-                    <form class="flex flex-col items-center p-1" @submit.prevent="sendShare">
+                <div class="flex flex-row items-center">
+                    <SentSeenButton
+                    operation="sent"
+                        type="submit"
+                        :share="share"
+                    />
+                    <SentSeenButton
+                        operation="seen"
+                        type="submit"
+                        :share="share"
+                     />
+                    <!-- <form class="flex flex-col items-center p-1" @submit.prevent="sendShare">
                         <small>Sent</small>
                         <label 
                             class="hidden"
@@ -143,7 +154,7 @@ onMounted(() => {
                             <i class="fa-solid fa-check"></i>
                         </button>
                         <InputError class="mt-2" :message="seenShareForm.errors.seen" />
-                    </form>
+                    </form> -->
                 </div>
                 <Controls
                     item="Share"

--- a/resources/js/Components/Shares/Share.vue
+++ b/resources/js/Components/Shares/Share.vue
@@ -36,13 +36,12 @@ const debtCurrency = computed(() => {
 });
 
 function setSentSeenMessage(message) {
-    console.log(message);
     sentSeenMessage.value = message.sent ?? message.seen;
     refresh & refresh();
 }
 
 onMounted(() => {
-    console.log('share', props.errors);
+
 })
 
 </script>

--- a/resources/js/Components/Shares/Share.vue
+++ b/resources/js/Components/Shares/Share.vue
@@ -146,10 +146,12 @@ onMounted(() => {
                     </form>
                 </div>
                 <Controls
-                    :class="displayControls && !isEditing ? '' : 'invisible'"
-                    :key="props.share.id"
                     item="Share"
-                    @edit="isEditing = !isEditing"
+                    :key="props.share.id"
+                    :visible="props.share.can_update_name || props.share.can_delete"
+                    :updatable="props.share.can_update_name"
+                    :deletable="props.share.can_delete"
+                    @edit="isEditing = !isEditing;refresh & refresh()"
                     @destroy="confirmingShareDeletion = true"
                 >
                 </Controls>
@@ -171,7 +173,7 @@ onMounted(() => {
                 }"
             >
                 <div class="flex flex-col">
-                    <div class="flex flex-row">
+                    <div v-if="props.share.can_update_name" class="flex flex-row">
                         <label 
                             for="newShareName" 
                             style="display:none;"
@@ -190,7 +192,7 @@ onMounted(() => {
                         />
                     </div>
                     <InputError class="mt-2" :message="errors.name" />
-                    <div class="flex flex-row">
+                    <div v-if="props.share.can_update_amount" class="flex flex-row">
                         <label 
                             for="ShareAmount"
                             style="display:none;"

--- a/routes/web.php
+++ b/routes/web.php
@@ -40,7 +40,7 @@ Route::middleware('auth')->group(function () {
     Route::get('/debts', [DebtController::class, 'index'])->name('debt.index');
     Route::post('/debts', [DebtController::class, 'store'])->name('debt.store');
     Route::patch('/debts/{debt}', [DebtController::class, 'update'])->name('debt.update');
-    Route::delete('/debts', [DebtController::class, 'destroy'])->name('debt.destroy');
+    Route::delete('/debts/{debt}', [DebtController::class, 'destroy'])->name('debt.destroy');
 });
 
 // groups

--- a/routes/web.php
+++ b/routes/web.php
@@ -61,7 +61,7 @@ Route::middleware('auth')->group(function () {
 // shares
 Route::middleware('auth')->group(function () {
     Route::post('/share', [ShareController::class, 'store'])->name('share.store');
-    Route::delete('/share', [ShareController::class, 'destroy'])->name('share.destroy');
+    Route::delete('/share/{share}', [ShareController::class, 'destroy'])->name('share.destroy');
     Route::patch('/share/{share}', [ShareController::class, 'update'])->name('share.update');
 });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -62,7 +62,7 @@ Route::middleware('auth')->group(function () {
 Route::middleware('auth')->group(function () {
     Route::post('/share', [ShareController::class, 'store'])->name('share.store');
     Route::delete('/share', [ShareController::class, 'destroy'])->name('share.destroy');
-    Route::patch('/share', [ShareController::class, 'update'])->name('share.update');
+    Route::patch('/share/{share}', [ShareController::class, 'update'])->name('share.update');
 });
 
 // users

--- a/routes/web.php
+++ b/routes/web.php
@@ -62,6 +62,8 @@ Route::middleware('auth')->group(function () {
 Route::middleware('auth')->group(function () {
     Route::post('/share', [ShareController::class, 'store'])->name('share.store');
     Route::delete('/share/{share}', [ShareController::class, 'destroy'])->name('share.destroy');
+    Route::patch('/share/sent/{share}', [ShareController::class, 'sent'])->name('share.sent');
+    Route::patch('/share/seen/{share}', [ShareController::class, 'seen'])->name('share.seen');
     Route::patch('/share/{share}', [ShareController::class, 'update'])->name('share.update');
 });
 

--- a/tests/Feature/Http/Controllers/DebtControllerTest.php
+++ b/tests/Feature/Http/Controllers/DebtControllerTest.php
@@ -255,7 +255,7 @@ test('user updating the amount on a regular debt returns a discrepancy error', f
 
     $new_amount = $debt->amount->plus(10);
    
-    $response = $this->patch(route('debt.update'), [
+    $response = $this->patch(route('debt.update', $debt), [
         'id' => $debt->id,
         'name' => $debt->name,
         'amount' => $new_amount->getAmount()->toInt(),
@@ -287,7 +287,7 @@ test('updating the amount on a split even debt updates the shares', function() {
 
     $split = $new_amount->split($shares->count());
   
-    $response = $this->patch(route('debt.update'), [
+    $response = $this->patch(route('debt.update', $debt), [
         'id' => $debt->id,
         'name' => $debt->name,
         'amount' => $new_amount->getAmount()->toInt(),
@@ -295,7 +295,7 @@ test('updating the amount on a split even debt updates the shares', function() {
 
     $response->assertStatus(302)
         ->assertSessionHasNoErrors()
-        ->assertSessionHas('status', 'Debt updated successfully.')
+        ->assertSessionHas('status', 'Debt & shares updated successfully.')
         ->assertRedirect('/debts');
 
     $this->assertDatabaseHas('debts', [
@@ -323,7 +323,7 @@ test('user can update the name of a debt', function() {
         'split_even' => 0,
     ]);
 
-    $response = $this->patch(route('debt.update'), [
+    $response = $this->patch(route('debt.update', $debt), [
         'id' => $debt->id,
         'name' => 'i have been changed',
         'amount' => $debt->amount->getAmount()->toInt(),
@@ -351,7 +351,7 @@ test('user can not change the name of a debt they do not own', function() {
         'group_id' => $this->group->id,
     ]);
     
-    $response = $this->patch(route('debt.update'), [
+    $response = $this->patch(route('debt.update', $debt), [
         'id' => $debt->id,
         'amount' => $debt->amount,
         'name' => 'i have been changed',
@@ -378,7 +378,7 @@ test('user can not change the amount of a debt they do not own', function() {
         'group_id' => $this->group->id,
     ]);
 
-    $response = $this->patch(route('debt.update'), [
+    $response = $this->patch(route('debt.update', $debt), [
         'id' => $debt->id,
         'amount' => $debt->amount,
         'name' => 'change me',

--- a/tests/Feature/Http/Controllers/DebtControllerTest.php
+++ b/tests/Feature/Http/Controllers/DebtControllerTest.php
@@ -202,7 +202,7 @@ test('user can delete a debt they own', function() {
         'group_id' => $this->group->id,
     ]);
 
-    $response = $this->delete(route('debt.destroy'), [
+    $response = $this->delete(route('debt.destroy', $debt), [
         'id' => $debt->id,
     ]);
 
@@ -227,7 +227,7 @@ test('deleting a debt deletes the relevant shares', function() {
 
     $shares = $debt->shares;
 
-    $response = $this->delete(route('debt.destroy'), [
+    $response = $this->delete(route('debt.destroy', $debt), [
         'id' => $debt->id,
     ]);
 
@@ -405,7 +405,7 @@ test('user can not delete a debt they do not own', function() {
         'group_id' => $this->group->id,
     ]);
     
-    $response = $this->delete(route('debt.destroy'), [
+    $response = $this->delete(route('debt.destroy', $debt), [
         'id' => $debt->id,
     ]);
 

--- a/tests/Feature/Http/Controllers/DebtControllerTest.php
+++ b/tests/Feature/Http/Controllers/DebtControllerTest.php
@@ -246,34 +246,6 @@ test('deleting a debt deletes the relevant shares', function() {
     }
 });
 
-test('user updating the amount on a regular debt returns a discrepancy error', function() {
-    $debt = Debt::factory()->withShares()->create([
-        'user_id' => $this->user->id,
-        'group_id' => $this->group->id,
-        'split_even' => 0,
-    ]);
-
-    $new_amount = $debt->amount->plus(10);
-   
-    $response = $this->patch(route('debt.update', $debt), [
-        'id' => $debt->id,
-        'name' => $debt->name,
-        'amount' => $new_amount->getAmount()->toInt(),
-    ]);
-
-    $response->assertStatus(302)
-        ->assertSessionHasErrors('amount', 10)
-        ->assertRedirect('/debts');
-
-    $this->assertDatabaseHas('debts', [
-        'id' => $debt->id,
-        'group_id' => $this->group->id,
-        'user_id' => $this->user->id,
-        'name' => $debt->name,
-        'amount' => $new_amount->getMinorAmount()->toInt(),
-    ]);
-});
-
 test('updating the amount on a split even debt updates the shares', function() {
     $debt = Debt::factory()->withShares()->create([
         'user_id' => $this->user->id,

--- a/tests/Feature/Http/Controllers/ShareControllerTest.php
+++ b/tests/Feature/Http/Controllers/ShareControllerTest.php
@@ -209,7 +209,7 @@ test("user can update the name on a share for a debt they own", function() {
     ]);
 });
 
-test("user can update the amount on a share for a standard debt they own", function() {
+test("user can update the amount on a share for a debt they own", function() {
     $debt = Debt::factory()->withShares()->create([
         'user_id' => $this->user->id,
         'group_id' => $this->group->id,
@@ -251,11 +251,7 @@ test("user can update the amount on a share for a standard debt they own", funct
     ]);
 });
 
-test("user can update the amount on a share for a split even debt they own", function() {
-    // todo: implement this feature
-});
-
-test("user can add a share to a standard debt they own", function() {
+test("user can add a share for themselves for a debt they own", function() {
     $debt = Debt::factory()->withShares()->create([
         'user_id' => $this->user->id,
         'group_id' => $this->group->id,
@@ -267,9 +263,12 @@ test("user can add a share to a standard debt they own", function() {
         'user_id' => $this->user->id,
         'amount' => 500,
         'name' => 'new share',
+        'currency' => 'GBP',
     ]);
 
-    $response->assertStatus(302);
+    $response->assertStatus(302)
+        ->assertSessionHas('status', 'Share created successfully.')
+        ->assertSessionHasNoErrors();
 
     $this->assertDatabaseHas('shares', [
         'debt_id' => $debt->id,
@@ -278,10 +277,33 @@ test("user can add a share to a standard debt they own", function() {
     ]);
 });
 
-test("user can add a share to a split even debt they own", function() {
-    // todo: implement this feature 
-    // if the debt is split even, it will have to include an option to recalc the debt
-    // or add it as a separate share e.g. 4 even shares, then +1 share at whatever value
+test("user can add a share for another user for a debt they own", function() {
+    $debt = Debt::factory()->withShares()->create([
+        'user_id' => $this->user->id,
+        'group_id' => $this->group->id,
+        'split_even' => 0,
+    ]);
+
+    $other_user = $debt->users->reject(fn($user) => 
+        $user->id === $this->user->id)->first();
+
+    $response = $this->post(route('share.store'), [
+        'debt_id' => $debt->id,
+        'user_id' => $other_user->id,
+        'amount' => 750,
+        'name' => 'new share for other user',
+        'currency' => 'GBP',
+    ]);
+
+    $response->assertStatus(302)
+        ->assertSessionHas('status', 'Share created successfully.')
+        ->assertSessionHasNoErrors();
+
+    $this->assertDatabaseHas('shares', [
+        'debt_id' => $debt->id,
+        'user_id' => $other_user->id,
+        'amount' => 750 * 100,
+    ]);
 });
 
 /**
@@ -309,23 +331,25 @@ test("user can not delete a share for a debt they do not own", function() {
     ]);
 });
 
-test("user can not update the a amount on a share for a debt they do not own", function() {
+test("user can not update the name or amount on a share for a debt they do not own", function() {
     $debt = Debt::factory()->withShares()->create([
         'user_id' => $this->users->last()->id,
         'group_id' => $this->group->id,
     ]);
     
     $share = $debt->shares->first();
-    $new_amount = $share->amount->plus(100);
+ 
+    $new = $share->amount->plus(Money::of(10, 'GBP'));
 
     $response = $this->patch(route('share.update', $share), [
         'id' => $share->id,
         'debt_id' => $debt->id,
-        'amount' => $new_amount->getAmount()->toInt(),
+        'amount' => $new->getMinorAmount()->toInt(),
+        'name' => 'new share name'
     ]);
-
-    $response->assertSessionHasErrors('amount', 'You do not have permission to update the amount of this share.');
-
+    
+    $response->assertSessionHasErrors('share', 'You do not have permission to update this share.');
+    
     $this->assertDatabaseHas('shares', [
         'id' => $share->id,
         'amount' => $share->amount->getMinorAmount()->toInt(),

--- a/tests/Feature/Http/Controllers/ShareControllerTest.php
+++ b/tests/Feature/Http/Controllers/ShareControllerTest.php
@@ -35,15 +35,12 @@ test("user can select 'sent' on their own share", function () {
 
     $share = $debt->shares->where('user_id', $this->user->id)->first();
     
-    $response = $this->patch(route('share.update'), [
+    $response = $this->patch(route('share.sent', $share), [
         'id' => $share->id,
-        'debt_id' => $debt->id,
         'sent' => !$share->sent,
     ]);
 
-    $response->assertStatus(302)
-        ->assertSessionHas('status', 'Share updated successfully.')
-        ->assertSessionHasNoErrors();
+    $response->assertStatus(302)->assertSessionHasNoErrors();
 
     // confirm status
     $this->assertDatabaseHas('shares', [
@@ -63,13 +60,13 @@ test("user can not select 'sent' on a share they do not own", function () {
         $share->user_id === $this->user->id)->first();
 
     // try to update it
-    $response = $this->patch(route('share.update'), [
+    $response = $this->patch(route('share.sent', $share), [
         'id' => $share->id,
-        'debt_id' => $debt->id,
         'sent' => !$share->sent,
     ]);
 
-    $response->assertSessionHasErrors('sent');
+    $response->assertStatus(302)
+        ->assertSessionHasErrors(['sent' => "You do not have permission to update the 'sent' status of this share"]);
 
     // confirm original status
     $this->assertDatabaseHas('shares', [
@@ -89,16 +86,13 @@ test("user can select 'seen' on a share they don't own for a debt they own", fun
         $share->user_id === $this->user->id)->first();
     
     // try to update it
-    $response = $this->patch(route('share.update'), [
+    $response = $this->patch(route('share.seen', $share), [
         'id' => $share->id,
-        'debt_id' => $debt->id,
         'seen' => !$share->seen,
     ]);
 
     // check correct response
-    $response->assertStatus(302)
-        ->assertSessionHas('status', 'Share updated successfully.')
-        ->assertSessionHasNoErrors();
+    $response->assertStatus(302)->assertSessionHasNoErrors();
 
     // confirm original status
     $this->assertDatabaseHas('shares', [
@@ -118,14 +112,13 @@ test("user can not select 'seen' on the share for a debt they do not own", funct
         $share->user_id === $this->user->id)->first();
 
    // try to update it
-    $response = $this->patch(route('share.update'), [
+    $response = $this->patch(route('share.seen', $share), [
         'id' => $share->id,
-        'debt_id' => $debt->id,
         'seen' => !$share->seen,
     ]);
 
-    $response->assertSessionHasErrors('seen', 'You do not have permission to update the status of this share.');
-
+    $response->assertStatus(302)
+        ->assertSessionHasErrors(['seen' => "You do not have permission to update the 'seen' status of this share"]);
     // confirm original status
     $this->assertDatabaseHas('shares', [
         'id' => $share->id,
@@ -141,15 +134,14 @@ test("user can not select 'seen' on a share they own", function() {
     
     $share = $debt->shares->where('user_id', $this->user->id)->first();
 
-    $response = $this->patch(route('share.update'), [
+    $response = $this->patch(route('share.seen', $share), [
         'id' => $share->id,
-        'debt_id' => $debt->id,
         'seen' => !$share->seen,
     ]);
 
     // check correct response
     $response->assertStatus(302)
-        ->assertSessionHasErrors('seen', "You can not set your own share as 'seen.'");
+        ->assertSessionHasErrors(['seen' => "You do not have permission to update the 'seen' status of this share"]);
 
     // confirm original status
     $this->assertDatabaseHas('shares', [
@@ -169,7 +161,7 @@ test("user can delete a share for a debt they own", function() {
         $share->user_id === $this->user->id)->first();
     
     // delete it
-    $response = $this->delete(route('share.destroy'), [
+    $response = $this->delete(route('share.destroy', $share), [
         'id' => $share->id,
         'debt_id' => $debt->id,
     ]);
@@ -199,15 +191,16 @@ test("user can update the name on a share for a debt they own", function() {
     $share = $debt->shares->where('user_id', $this->user->id)->first();
 
     // update it
-    $response = $this->patch(route('share.update'), [
+    $response = $this->patch(route('share.update', $share), [
         'id' => $share->id,
         'debt_id' => $debt->id,
-        'name' => 'new name for this share'
+        'name' => 'new name for this share',
+        'amount' => $share->amount->getMinorAmount()->toInt(),
     ]);
 
     $response->assertStatus(302)
         ->assertSessionHas('status', 'Share updated successfully.')
-        ->assertSessionHasNoErrors();;
+        ->assertSessionHasNoErrors();
 
     $this->assertDatabaseHas('shares', [
         'id' => $share->id,
@@ -225,13 +218,11 @@ test("user can update the amount on a share for a standard debt they own", funct
     
     $share = $debt->shares->where('user_id', $this->user->id)->first();
 
-    $new_amount = $share->amount->plus(10);
-    $difference = $new_amount->minus($share->amount);
-
-    $response = $this->patch(route('share.update'), [
+    $response = $this->patch(route('share.update', $share), [
         'id' => $share->id,
+        'name' => $share->name,
         'debt_id' => $debt->id,
-        'amount' => $new_amount->getAmount()->toInt(),
+        'amount' => $share->amount->plus(Money::of(10, 'GBP'))->getMinorAmount()->toInt(),
     ]);
 
     $response->assertStatus(302)
@@ -241,12 +232,12 @@ test("user can update the amount on a share for a standard debt they own", funct
     $this->assertDatabaseHas('shares', [
         'id' => $share->id,
         'user_id' => $share->user_id,
-        'amount' => $new_amount->getMinorAmount()->toInt(),
+        'amount' => $share->amount->plus(Money::of(10, 'GBP'))->getAmount()->toInt(),
     ]);
 
     $this->assertDatabaseHas('debts', [
         'id' => $debt->id,
-        'amount' => $debt->amount->plus($difference)->getMinorAmount()->toInt(),
+        'amount' => $debt->amount->getAmount()->toInt(),
     ]);
 });
 
@@ -294,7 +285,7 @@ test("user can not delete a share for a debt they do not own", function() {
 
     $share = $debt->shares->first();
 
-    $response = $this->delete(route('share.destroy'), [
+    $response = $this->delete(route('share.destroy', $share), [
         'id' => $share->id,
         'debt_id' => $debt->id,
     ]);
@@ -317,7 +308,7 @@ test("user can not update the a amount on a share for a debt they do not own", f
     $share = $debt->shares->first();
     $new_amount = $share->amount->plus(100);
 
-    $response = $this->patch(route('share.update'), [
+    $response = $this->patch(route('share.update', $share), [
         'id' => $share->id,
         'debt_id' => $debt->id,
         'amount' => $new_amount->getAmount()->toInt(),

--- a/tests/Feature/Http/Controllers/ShareControllerTest.php
+++ b/tests/Feature/Http/Controllers/ShareControllerTest.php
@@ -218,26 +218,36 @@ test("user can update the amount on a share for a standard debt they own", funct
     
     $share = $debt->shares->where('user_id', $this->user->id)->first();
 
+    // the 'new' amount is basically what the user sees,
+    // e..g if they add a fiver it's just 5
+    $new = $share->amount->plus(Money::of(10, 'GBP'));
+
     $response = $this->patch(route('share.update', $share), [
         'id' => $share->id,
         'name' => $share->name,
         'debt_id' => $debt->id,
-        'amount' => $share->amount->plus(Money::of(10, 'GBP'))->getMinorAmount()->toInt(),
+        // we have to do this weird thing as brick money deals in minor units
+        // and does not make ints into decimals, only decimals into ints
+        // so if new is 5.65, minorAmount gives us 565
+        // then /100 to simulate user input of 5.65
+        // as the casting is handled in Cash.php attribute cast
+        'amount' => $new->getMinorAmount()->toInt() / 100
     ]);
 
     $response->assertStatus(302)
         ->assertSessionHas('status', 'Share updated successfully.')
         ->assertSessionHasNoErrors();
 
+
     $this->assertDatabaseHas('shares', [
         'id' => $share->id,
         'user_id' => $share->user_id,
-        'amount' => $share->amount->plus(Money::of(10, 'GBP'))->getAmount()->toInt(),
+        'amount' => $new->getMinorAmount()->toInt(),
     ]);
 
     $this->assertDatabaseHas('debts', [
         'id' => $debt->id,
-        'amount' => $debt->amount->getAmount()->toInt(),
+        'amount' => $debt->amount->plus(Money::of(10, 'GBP'))->getMinorAmount()->toInt(),
     ]);
 });
 

--- a/tests/Feature/Http/Controllers/ShareControllerTest.php
+++ b/tests/Feature/Http/Controllers/ShareControllerTest.php
@@ -84,7 +84,11 @@ test("user can select 'seen' on a share they don't own for a debt they own", fun
     // get a share that's not mine
     $share = $debt->shares->reject(fn($share) => 
         $share->user_id === $this->user->id)->first();
-    
+
+    // set it to not sent
+    $share->sent = 1;
+    $share->save();
+
     // try to update it
     $response = $this->patch(route('share.seen', $share), [
         'id' => $share->id,
@@ -126,13 +130,44 @@ test("user can not select 'seen' on the share for a debt they do not own", funct
     ]);
 });
 
-test("user can not select 'seen' on a share they own", function() {
+test("user can not select 'seen' on a share that has not yet been sent", function() {
     $debt = Debt::factory()->withShares()->create([
         'user_id' => $this->user->id,
         'group_id' => $this->group->id,
     ]);
     
-    $share = $debt->shares->where('user_id', $this->user->id)->first();
+    // get a share that's not mine
+    $share = $debt->shares->reject(fn($share) => 
+        $share->user_id === $this->user->id)->first();
+
+    // set it to not sent
+    $share->sent = 0;
+    $share->save();
+
+    // try to update it
+    $response = $this->patch(route('share.seen', $share), [
+        'id' => $share->id,
+        'seen' => !$share->seen,
+    ]);
+
+    // check correct response
+    $response->assertStatus(302)
+        ->assertSessionHasErrors(['seen' => "You can not mark this share as seen becase it has not been sent yet"]);
+
+    // confirm original status
+    $this->assertDatabaseHas('shares', [
+        'id' => $share->id,
+        'seen' => $share->seen,
+    ]);
+});
+
+test("user can not select 'seen' on a share they own", function() {
+    $debt = Debt::factory()->withShares()->create([
+        'user_id' => $this->users->last()->id,
+        'group_id' => $this->group->id,
+    ]);
+
+    $share = $debt->shares->first();
 
     $response = $this->patch(route('share.seen', $share), [
         'id' => $share->id,

--- a/tests/Feature/TotalBalanceTest.php
+++ b/tests/Feature/TotalBalanceTest.php
@@ -44,7 +44,7 @@ test("adding a standard debt recalculates the user balances", function() {
 test("deleting a standard debt recalculates the user's balance", function() {
     $debt = Debt::where('split_even', 0)->first();
 
-    $response = $this->delete(route('debt.destroy'), [
+    $response = $this->delete(route('debt.destroy', $debt), [
         'id' => $debt->id
     ]);
 
@@ -85,7 +85,7 @@ test("adding a split even debt recalculates the user's balance", function() {
 test("deleting a split even debt recalculates the user's balance", function() {
     $debt = Debt::where('split_even', 1)->first();
 
-    $response = $this->delete(route('debt.destroy'), [
+    $response = $this->delete(route('debt.destroy', $debt), [
         'id' => $debt->id
     ]);
 
@@ -102,7 +102,7 @@ test("updating a split even debt recalculates the user's balance", function() {
             'amount' => Money::of(100, 'GBP'),
         ]);
 
-    $response = $this->patch(route('debt.update'), [
+    $response = $this->patch(route('debt.update', $debt), [
         'id' => $debt->id,
         'name' => $debt->name,
         'amount' => $debt->amount->getAmount()->toInt() + 10,
@@ -177,10 +177,11 @@ test("updating the amount of a standard share for yourself doesn't recalculate y
 
     $new_amount = $share->amount->plus(10);
 
-    $response = $this->patch(route('share.update'), [
+    $response = $this->patch(route('share.update', $share), [
         'id' => $share->id,
         'debt_id' => $debt->id,
         'amount' => (string) $new_amount->getAmount(),
+        'name' => $share->name,
 
     ]);
 
@@ -209,10 +210,11 @@ test("updating the amount of a standard share for another user recalculates both
     $other_user_original_balance = $other_user->user_balance;
     $self_original_balance = $this->self->user_balance;
 
-    $response = $this->patch(route('share.update'), [
+    $response = $this->patch(route('share.update', $other_share), [
         'id' => $other_share->id,
         'debt_id' => $debt->id,
         'amount' => (string) $new_amount->getAmount(),
+        'name' => $other_share->name,
     ]);
 
     $response->assertStatus(302);
@@ -234,7 +236,7 @@ test("deleting a standard share for yourself doesn't recalculate the user's bala
 
     $share = $debt->shares->where('user_id', $this->self->id)->first();
   
-    $response = $this->delete(route('share.destroy'), [
+    $response = $this->delete(route('share.destroy', $share), [
         'id' => $share->id,
         'debt_id' => $debt->id,
     ]);
@@ -262,7 +264,7 @@ test("deleting a standard share for another user recalculates both your balances
     $other_user_original_balance = $other_user->user_balance;
     $self_original_balance = $this->self->user_balance;
 
-    $response = $this->delete(route('share.destroy'), [
+    $response = $this->delete(route('share.destroy', $other_share), [
         'id' => $other_share->id,
         'debt_id' => $debt->id,
     ]);


### PR DESCRIPTION
So this is going to be quite a big one, and the scope will probably change as the planning and actual coding develops, but as it stands:

- Add policies for debts.
- Route model binding for delete debt.
- Add policies for shares.
- Route model binding for delete share.
- Rework the debts/shares/balance services to possibly just have a "balance service." I looked into using model events for all of this but there seems to be too many moving parts.
    - On the back of this, the whole sent/seen system will be reworked
- Take another look into how decimals are dealt with. Currently debt/share amount data is stored as a decimal, and this is achieved with the help from Brick Money for PHP and Dinero for JS, with a Cash cast. Looking back over it, this seems to be needlessly complex and I feel like I could do a better job this time around.

There'll be more to add, this is just all I can think of after taking a quick look.


So, relevant changes:

- Debt/Share operations are now a bit more split up. Create, update etc. actions for the relevant model are in the appropriate controller method. E.g. saving a Debt is in `create()`, but the act of creating the shares is in the `ShareService`. 
- Sent/Seen has been fixed/reworked around the use of Policies.
- Removed a lot of unnecessary Rule application, now that Policies are in place. Kept the classes for reference.
- Added a series of appends to the Share model so now displaying controls, options within the controls and some other bits on the frontend are a lot cleaner, no longer needing to repeat the same logic in different components. This is very similar to the updates to Debt/Comment in the previous PR.
- Share policy methods for `update` are now split up per relevant attribute, e.g. `updateSent`.
- `BalanceService` has been improved, docblocks etc.
- `DebtService` has now been farmed out.
- `SentSeenButton.vue` added, works equally with both operations.
- Tests all updated.

Extras:

- Users that were newly added to a group, when having an alias created would crash the page. There was no fallback for if an alias didn't exist, as `v-model` doesn't seem to like ?. operators or ternaries, temporarily added a separate variable. Probably a better way to do it but this is just to keep things going
- Bettered my understanding of my user of Dinero.js & Brick\Money. Left notes throughout project, Dinero is basically just for decimal issues following splitting debts on the frontend. Brick\Money is for casting to pennies etc. when saving in the db. E.g. £15 saves as 1500 in the db. £15.37 is 1537.
- Various (some overdue) seeder & factory updates. Notably comments and adding sent/seen randomness back.
- Discrepancy Error reworked
- Use of tailwind `hidden` changed to `invisible` as for some strange reason, `hidden` doesn't work in production


