### PR TITLE
Monetary storage & minor unit representation

### DIFF
--- a/app/Http/Requests/StoreDebtRequest.php
+++ b/app/Http/Requests/StoreDebtRequest.php
@@ -25,7 +25,7 @@ class StoreDebtRequest extends FormRequest
             'group_id' => ['required', 'integer', 'exists:groups,id'],
             'user_id' => ['required', 'integer', 'exists:users,id'],
             'name' => ['required', 'string', 'min:1', 'max:255'],
-            'amount' => ['required', 'numeric', 'min:0.01', 'regex:/^\d+(\.\d{1,2})?$/'],
+            'amount' => ['required', 'numeric', 'min:1', 'max:1000000000'],
             'split_even' => ['required', 'boolean'],
             // todo: improve this by making appear for each relevant share
             'user_shares' => ['required', 'array', 'min:1', function ($attribute, $value, $fail) {
@@ -45,7 +45,6 @@ class StoreDebtRequest extends FormRequest
             'user_id.required' => 'Please select a user to own the debt.',
             'group_id.required' => 'Please select a group.',
             'amount.min' => 'The total :attribute must be at least 0.01.',
-            'amount.regex' => 'The :attribute must be a number with up to 2 decimal places.',
             'name.required' => 'The debt name is required.',
             'name.max' => 'The debt name may not be greater than 255 characters.',
             'user_shares.min' => 'Please select at least one user or enter a valid amount.',

--- a/database/migrations/2025_12_04_145604_change-float-column-types.php
+++ b/database/migrations/2025_12_04_145604_change-float-column-types.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('group_users', function (Blueprint $table) {
+            $table->bigInteger('balance')->default(0)->change();
+        });
+
+        Schema::table('debts', function (Blueprint $table) {
+            $table->bigInteger('amount')->default(0)->change();
+        });
+
+        Schema::table('shares', function (Blueprint $table) {
+            $table->bigInteger('amount')->default(0)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};

--- a/resources/js/Components/Debts/AddDebt/Form/AddDebtForm.vue
+++ b/resources/js/Components/Debts/AddDebt/Form/AddDebtForm.vue
@@ -44,7 +44,6 @@ const shareKey = ref(0);
 /**
  * Sets the group_user values for the form
  */
-
 function setSelectedGroup(groupId) {
     // set the group & it's users
     selectedGroup.value = groups.value.find((group) => group.id == groupId);

--- a/resources/js/Components/Debts/AddDebt/Form/AddDebtForm.vue
+++ b/resources/js/Components/Debts/AddDebt/Form/AddDebtForm.vue
@@ -5,8 +5,6 @@ import { store } from '@/debt.js';
 import CurrencyPicker from '@/Components/Forms/CurrencyPicker.vue';
 import UserPicker from '@/Components/Forms/UserPicker.vue';
 import GroupPicker from '@/Components/Groups/GroupPicker.vue';
-import InputError from '@/Components/Forms/InputError.vue';
-import Slider from '@/Components/Misc/Slider.vue';
 import AddDebtFormShare from './AddDebtFormShare.vue';
 import AddDebtFormName from './AddDebtFormName.vue';
 import AddDebtFormAmount from './AddDebtFormAmount.vue';
@@ -81,20 +79,6 @@ function setSelectedCurrency(currency) {
 }
 
 /**
- * Toggles between the debt being split even/custom shares. Basically looks at total_amount if split, 
- * and then indiviudal fields if not. 
- */
-function toggleSplitEven(toggle) {
-    store.addDebtForm.split_even = toggle;
-
-    if (store.addDebtForm.split_even) {
-        store.splitEven();
-    } else {
-        store.calcTotalAmount()
-    }
-}
-
-/**
  * Sets someone to 'own' the debt. This plays into how total balances are created.
  */
 function setDebtOwner(userId) {
@@ -128,7 +112,7 @@ function addDebt() {
     addDebtForm.post(route('debt.store'), {
         preserveScroll: true,
         onSuccess: (response) => {
-            // name has to be reset as the models are actuall the store
+            // name has to be reset as the models are actually the store
             store.addDebtForm.name = '';
             emit('closeModal');
         },
@@ -167,30 +151,19 @@ function addDebt() {
                     @userSelected="setDebtOwner"
                 >
                 </UserPicker>
+                <h3 class="font-bold my-2 text-center">Please enter all amounts in pounds and pence.</h3>
                 <AddDebtFormShare
                     v-for="group_user in selectedGroup.group_users"
                     :key="`${shareKey} + ${group_user.id}`"
                     :group_user="group_user"
+                    :addDebtFormErrors="addDebtForm.errors.user_shares"
                 >
                 </AddDebtFormShare>
-                <InputError class="mt-2" :message="addDebtForm.errors.user_shares" />
-            </div> 
-            <div class="flex flex-row mt-2 items-center justify-between">
-                <div class="flex flex-col">
-                    <p>Amount:</p>
-                    <AddDebtFormAmount
-                        :errors="addDebtForm.errors.amount"
-                    >
-                    </AddDebtFormAmount>
-                </div>
-                <Slider
-                    label="Split even"
-                    alignment="end"
-                    size="xs"
-                    @toggled="toggleSplitEven"
+                <AddDebtFormAmount
+                    :errors="addDebtForm.errors.amount"
                 >
-                </Slider>
-            </div>
+                </AddDebtFormAmount>
+            </div> 
             <div class="flex flex-row mt-4 justify-center sm:justify-end">
                 <SecondaryButton 
                     type="button"

--- a/resources/js/Components/Debts/AddDebt/Form/AddDebtFormAmount.vue
+++ b/resources/js/Components/Debts/AddDebt/Form/AddDebtFormAmount.vue
@@ -1,7 +1,8 @@
 <script setup>
-import { onMounted, ref } from 'vue';
+import { onMounted, ref, watch } from 'vue';
 import { store } from '@/debt.js';
 import InputError from '@/Components/Forms/InputError.vue';
+import Slider from '@/Components/Misc/Slider.vue';
 
 // props
 const props = defineProps({
@@ -10,31 +11,73 @@ const props = defineProps({
     },
 });
 
-onMounted(() => {
+// same principle as in AddDebtFormShare, make total a string for user's benefit
+const userFacingTotalValue = ref('');
 
+function setAmount() {
+    if (store.addDebtForm.split_even) {
+        store.splitEven(userFacingTotalValue.value);
+    } else if (!store.addDebtForm.split_even) {
+        store.calcTotalAmount();
+    }
+}
+
+/**
+ * Toggles between the debt being split even/custom shares. Basically looks at total_amount if split, 
+ * and then indiviudal fields if not. 
+ */
+function toggleSplitEven(toggle) {
+    store.addDebtForm.split_even = toggle;
+
+    if (store.addDebtForm.split_even) {
+        store.splitEven();
+    } else {
+        store.calcTotalAmount()
+    }
+}
+
+onMounted(() => {
+    console.log('f', store.addDebtForm);
 })
+
+// sort of inverse to how it works on shares
+// as shares take a string and make a number for the sake of the form
+// the total takes the number from the form and makes a string with decimal point
+watch(() => store.addDebtForm.amount, (newAmount) => {
+    const majorUnits = String(newAmount).slice(0, -2) || '0';
+    const minorUnits = String(newAmount).slice(-2) || '00';
+    userFacingTotalValue.value = majorUnits + '.' + minorUnits;
+});
 
 </script>
 <template>
-    <div>
-        <label 
-            for="debt-amount" 
-            class="block text-sm font-medium text-gray-700 hidden"
-            id="debtamount"
+    <div class="flex flex-row justify-between mt-2">
+        <div>
+            <label 
+                for="debt-amount" 
+                class="block text-sm font-medium text-gray-700"
+                id="debt-amount"
+            >
+                Amount:
+            </label>
+            <input
+                v-model="userFacingTotalValue" 
+                type="text"
+                id="debt-amount" 
+                amount="debt-amount" 
+                aria-labelledby="debt-amount"
+                @change="setAmount"
+                :disabled="!store.addDebtForm.split_even"
+                class="rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+            />
+        </div>
+        <Slider
+            label="Split even"
+            alignment="end"
+            size="xs"
+            @toggled="toggleSplitEven"
         >
-            Debt Amount
-        </label>
-        <input
-            v-model="store.addDebtForm.amount" 
-            type="number"
-            step="0.01" 
-            id="debt-amount" 
-            amount="debt-amount" 
-            aria-labelledby="debtAmount"
-            @change=store.splitEven()
-            :disabled="!store.addDebtForm.split_even"
-            class="rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-        />
+        </Slider>
         <InputError class="mt-2" :message="errors" />
     </div>
 </template>

--- a/resources/js/Components/Debts/AddDebt/Form/AddDebtFormAmount.vue
+++ b/resources/js/Components/Debts/AddDebt/Form/AddDebtFormAmount.vue
@@ -15,8 +15,9 @@ const props = defineProps({
 const userFacingTotalValue = ref('');
 
 function setAmount() {
+    store.addDebtForm.amount = Number(userFacingTotalValue.value.replace('.', ''));
     if (store.addDebtForm.split_even) {
-        store.splitEven(userFacingTotalValue.value);
+        store.splitEven();
     } else if (!store.addDebtForm.split_even) {
         store.calcTotalAmount();
     }
@@ -37,7 +38,7 @@ function toggleSplitEven(toggle) {
 }
 
 onMounted(() => {
-    console.log('f', store.addDebtForm);
+
 })
 
 // sort of inverse to how it works on shares

--- a/resources/js/Components/Debts/AddDebt/Form/AddDebtFormShare.vue
+++ b/resources/js/Components/Debts/AddDebt/Form/AddDebtFormShare.vue
@@ -65,7 +65,9 @@ function toggleShareChecked(toggle) {
 }
 
 watch(() => share.value.amount, (newValue) => {
-    userFacingShareValue.value = newValue;
+    const majorUnits = String(newValue).slice(0, -2) || '0';
+    const minorUnits = String(newValue).slice(-2) || '00';
+    userFacingShareValue.value = majorUnits + '.' + minorUnits;
 })
 
 onMounted(() => {

--- a/resources/js/Components/Debts/AddDebt/Form/AddDebtFormShare.vue
+++ b/resources/js/Components/Debts/AddDebt/Form/AddDebtFormShare.vue
@@ -4,56 +4,64 @@ import { store } from '@/debt.js';
 import Slider from '@/Components/Misc/Slider.vue';
 import TextInput from '@/Components/Forms/TextInput.vue';
 import Dinero from 'dinero.js'
+import InputError from '@/Components/Forms/InputError.vue';
 
 // props
 const props = defineProps({
     group_user: {
         type: Object,
     },
+    errors: {
+        type: Object,
+        required: false,
+    },
 });
 
+// because we have to mess around with string/int casting
+// show the user a string of the share with a decimal point
+const userFacingShareValue = ref('');
+// ref for changing css on share input element
+const isShareValid = ref(true);
+// the share for the user, taken from the store
 const share = ref(store.addDebtForm.user_shares.find((userShare) => 
     userShare.user_id == props.group_user.user_id
 ));
 
-// separate vars for major/minor units
-const majorUnits = ref(0);
-const minorUnits = ref(0);
-
+// check validity of share
+// if invalid, set it back to 0 and uncheck
+// otherwise, check & cast to number so it can be calced
 function setShareAmount() {
-    // if the user is interacting with either input
-    // set it as checked
-    share.value.checked = true;
+    isShareValid.value = validateShare();
+    
+    if (!isShareValid.value) {
 
-    // removing 0s leads to input being empty string, to manually set to 0
-    if (majorUnits.value == '') {
-        majorUnits.value = 0;
-    }
-
-    // same as above
-    if (minorUnits.value == '') {
-        minorUnits.value = 0;
-    }
-
-    // non strict comparison to allow major and minor units being 0
-    // uncheck if both are falsey
-    if (majorUnits.value == 0 && minorUnits.value == 0) {
         share.value.checked = false;
         share.value.amount = 0;
+    } else {
+
+        share.value.checked = true;
+        share.value.amount = Number(userFacingShareValue.value.replace('.', '')); 
     }
 
-    // recalc with entire amount in minor units, e.g. £12.34 = 1234
-    share.value.amount = majorUnits.value * 100 + minorUnits.value;
     store.calcTotalAmount();
 }
 
+// check the validity of user input when attempting to add a share
+// regex is for a 9 digit number with 2 decimal places
+// specifically including the decimal point
+function validateShare() {
+    const regex = new RegExp("^\\d{1,9}\\.\\d{2}$");
+    return regex.test(userFacingShareValue.value);
+}
+
+// just toggles if a split even share is checked
 function toggleShareChecked(toggle) {
     share.value.checked = toggle;
 
     store.addDebtForm.user_shares.find((userShare) => 
         userShare.user_id == share.value.user_id).checked = share.value.checked;
 
-    store.splitEven();
+    store.splitEven(store.addDebtForm.amount);
 }
 
 onMounted(() => {
@@ -87,54 +95,36 @@ onMounted(() => {
             <div class="flex flex-row justify-center items-center">
                 <label 
                     :for="`share-major-amount-${group_user.id}`"
-                    class="hidden"
+                   class="mr-1"
                 >
-                    Amount
+                    £
                 </label>
                 <input 
-                    type="number"
+                    type="text"
                     :id="`share-major-amount-${group_user.id}`"
                     :name="`share-major-amount-${group_user.id}`"
-                    v-model="majorUnits"
+                    v-model="userFacingShareValue"
                     @change="setShareAmount"
                     :disabled="store.addDebtForm.split_even"
-                    class="w-1/2 md:w-24 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 mr-2"
-                >
-                <label 
-                    :for="`share-minor-amount-${group_user.id}`"
-                    class="hidden"
-                >
-                    Amount
-                </label>
-                <input 
-                    type="number"
-                    :id="`share-minor-amount-${group_user.id}`"
-                    :name="`share-minor-amount-${group_user.id}`"
-                    v-model="minorUnits"
-                    @change="setShareAmount"
-                    :disabled="store.addDebtForm.split_even"
-                    class="w-1/2 md:w-24 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 mr-2"
-                    maxlength="2"
+                    class="w-1/2 md:w-24 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 mr-1"
+                    :class="isShareValid ? '' : 'bg-red-200'"
+                    maxlength="9"
+                    inputmode="decimal"
+                    placeholder="0.00"
                 >
                 <div :class="store.addDebtForm.split_even ? '' : 'invisible'">
-                <Slider
-                    @toggled="toggleShareChecked"
-                    :checked="share.checked"
-                    alignment="end"
-                >
-                </Slider>
+                    <Slider
+                        @toggled="toggleShareChecked"
+                        :checked="share.checked"
+                        alignment="end"
+                    >
+                    </Slider>
                 </div>
             </div>
         </div>
+        <InputError class="mt-2" :message="errors" />
     </div>
 </template>
 <style scoped>
 
-textarea {
-    resize: none;
-}
-
-textarea:invalid {
-  border: 2px solid red;
-}
 </style>

--- a/resources/js/Components/Debts/AddDebt/Form/AddDebtFormShare.vue
+++ b/resources/js/Components/Debts/AddDebt/Form/AddDebtFormShare.vue
@@ -1,8 +1,9 @@
 <script setup>
-import { onMounted, ref } from 'vue';
+import { onMounted, ref, watch } from 'vue';
 import { store } from '@/debt.js';
 import Slider from '@/Components/Misc/Slider.vue';
 import TextInput from '@/Components/Forms/TextInput.vue';
+import Dinero from 'dinero.js'
 
 // props
 const props = defineProps({
@@ -15,16 +16,34 @@ const share = ref(store.addDebtForm.user_shares.find((userShare) =>
     userShare.user_id == props.group_user.user_id
 ));
 
+// separate vars for major/minor units
+const majorUnits = ref(0);
+const minorUnits = ref(0);
+
 function setShareAmount() {
-    // checked is toggled so that if the user switches to split even mid-debt creation
-    // the added users are retained
+    // if the user is interacting with either input
+    // set it as checked
     share.value.checked = true;
-    // because adding a number then removing it from the input defaults to '', rather than 0
-    if (share.value.amount == '') {
+
+    // removing 0s leads to input being empty string, to manually set to 0
+    if (majorUnits.value == '') {
+        majorUnits.value = 0;
+    }
+
+    // same as above
+    if (minorUnits.value == '') {
+        minorUnits.value = 0;
+    }
+
+    // non strict comparison to allow major and minor units being 0
+    // uncheck if both are falsey
+    if (majorUnits.value == 0 && minorUnits.value == 0) {
         share.value.checked = false;
         share.value.amount = 0;
     }
 
+    // recalc with entire amount in minor units, e.g. £12.34 = 1234
+    share.value.amount = majorUnits.value * 100 + minorUnits.value;
     store.calcTotalAmount();
 }
 
@@ -37,7 +56,9 @@ function toggleShareChecked(toggle) {
     store.splitEven();
 }
 
-onMounted(() => {});
+onMounted(() => {
+
+});
 
 </script>
 <template>
@@ -46,7 +67,7 @@ onMounted(() => {});
             {{ group_user.user.name }}
         </p>
         <div class="flex flex-row justify-around">
-            <div class="flex flex-row items-center w-full">
+            <div class="flex flex-row items-center w-full mr-2">
                 <label 
                     :for="`share-name-${group_user.id}`"
                     class="hidden"
@@ -59,36 +80,49 @@ onMounted(() => {});
                     :name="`share-name-${group_user.id}`"
                     v-model="share.name"
                     placeholder="Share name..."
-      
                     class="w-full"
                 >
                 </TextInput>
             </div>
             <div class="flex flex-row justify-center items-center">
                 <label 
-                    :for="`share-amount-${group_user.id}`"
+                    :for="`share-major-amount-${group_user.id}`"
                     class="hidden"
                 >
                     Amount
                 </label>
                 <input 
                     type="number"
-                    step="0.01"
-                    :id="`share-amount-${group_user.id}`"
-                    :name="`share-amount-${group_user.id}`"
-                    v-model="share.amount"
+                    :id="`share-major-amount-${group_user.id}`"
+                    :name="`share-major-amount-${group_user.id}`"
+                    v-model="majorUnits"
                     @change="setShareAmount"
                     :disabled="store.addDebtForm.split_even"
-           
-                    class="w-1/2 md:w-24 ml-4 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 mr-2"
+                    class="w-1/2 md:w-24 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 mr-2"
+                >
+                <label 
+                    :for="`share-minor-amount-${group_user.id}`"
+                    class="hidden"
+                >
+                    Amount
+                </label>
+                <input 
+                    type="number"
+                    :id="`share-minor-amount-${group_user.id}`"
+                    :name="`share-minor-amount-${group_user.id}`"
+                    v-model="minorUnits"
+                    @change="setShareAmount"
+                    :disabled="store.addDebtForm.split_even"
+                    class="w-1/2 md:w-24 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 mr-2"
+                    maxlength="2"
                 >
                 <div :class="store.addDebtForm.split_even ? '' : 'invisible'">
-                    <Slider
-                        @toggled="toggleShareChecked"
-                        :checked="share.checked"
-                        alignment="end"
-                    >
-                    </Slider>
+                <Slider
+                    @toggled="toggleShareChecked"
+                    :checked="share.checked"
+                    alignment="end"
+                >
+                </Slider>
                 </div>
             </div>
         </div>

--- a/resources/js/Components/Debts/AddDebt/Form/AddDebtFormShare.vue
+++ b/resources/js/Components/Debts/AddDebt/Form/AddDebtFormShare.vue
@@ -61,8 +61,12 @@ function toggleShareChecked(toggle) {
     store.addDebtForm.user_shares.find((userShare) => 
         userShare.user_id == share.value.user_id).checked = share.value.checked;
 
-    store.splitEven(store.addDebtForm.amount);
+    store.splitEven();
 }
+
+watch(() => share.value.amount, (newValue) => {
+    userFacingShareValue.value = newValue;
+})
 
 onMounted(() => {
 

--- a/resources/js/Components/Debts/AddDebt/Form/AddDebtFormShare.vue
+++ b/resources/js/Components/Debts/AddDebt/Form/AddDebtFormShare.vue
@@ -21,7 +21,7 @@ const props = defineProps({
 // show the user a string of the share with a decimal point
 const userFacingShareValue = ref('');
 // ref for changing css on share input element
-const isShareValid = ref(true);
+// const isShareValid = ref(true);
 // the share for the user, taken from the store
 const share = ref(store.addDebtForm.user_shares.find((userShare) => 
     userShare.user_id == props.group_user.user_id
@@ -31,7 +31,7 @@ const share = ref(store.addDebtForm.user_shares.find((userShare) =>
 // if invalid, set it back to 0 and uncheck
 // otherwise, check & cast to number so it can be calced
 function setShareAmount() {
-    isShareValid.value = validateShare();
+  
     
     if (!isShareValid.value) {
 
@@ -46,13 +46,13 @@ function setShareAmount() {
     store.calcTotalAmount();
 }
 
-// check the validity of user input when attempting to add a share
-// regex is for a 9 digit number with 2 decimal places
-// specifically including the decimal point
-function validateShare() {
-    const regex = new RegExp("^\\d{1,9}\\.\\d{2}$");
-    return regex.test(userFacingShareValue.value);
-}
+// // check the validity of user input when attempting to add a share
+// // regex is for a 9 digit number with 2 decimal places
+// // specifically including the decimal point
+// function validateShare() {
+//     const regex = new RegExp("^\\d{1,9}\\.\\d{2}$");
+//     return regex.test(userFacingShareValue.value);
+// }
 
 // just toggles if a split even share is checked
 function toggleShareChecked(toggle) {
@@ -65,6 +65,7 @@ function toggleShareChecked(toggle) {
 }
 
 watch(() => share.value.amount, (newValue) => {
+    console.log('nv', newValue);
     const majorUnits = String(newValue).slice(0, -2) || '0';
     const minorUnits = String(newValue).slice(-2) || '00';
     userFacingShareValue.value = majorUnits + '.' + minorUnits;

--- a/resources/js/Components/Misc/CurrencyInput.vue
+++ b/resources/js/Components/Misc/CurrencyInput.vue
@@ -1,0 +1,35 @@
+<script setup>
+
+ import { onMounted, ref, watch } from 'vue';
+
+ const props = defineProps({
+    type: {
+        type: String,
+        required: true,
+    },
+ })
+
+ const isShareValid = ref(true);
+
+ // check the validity of user input when attempting to add a share
+// regex is for a 9 digit number with 2 decimal places
+// specifically including the decimal point
+function validateShare() {
+    const regex = new RegExp("^\\d{1,9}\\.\\d{2}$");
+    isShareValid.value = regex.test(userFacingShareValue.value);
+}
+
+</script>
+<template>
+    <div>
+        <input 
+            type="text"
+            @change="validateShare"
+            class="w-1/2 md:w-24 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 mr-1"
+            :class="isShareValid ? '' : 'bg-red-200'"
+            maxlength="9"
+            inputmode="decimal"
+            placeholder="0.00"
+        />
+    </div>
+</template>

--- a/resources/js/debt.js
+++ b/resources/js/debt.js
@@ -17,12 +17,13 @@ export const store = reactive({
      */
     calcTotalAmount() {
         const amount = Dinero({
-            amount: this.addDebtForm.user_shares.map(share => share.amount)
+            amount: this.addDebtForm.user_shares.map((share) => share.amount)
                 .reduce((acc, value) => acc + value, 0),
             currency: this.addDebtForm.currency,
         })
 
-        this.addDebtForm.amount = amount.getAmount();
+        // recast as minor units number
+        this.addDebtForm.amount = Number(amount.getAmount());
     },
 
     /**
@@ -32,12 +33,12 @@ export const store = reactive({
     splitEven() {
         // total users being added 
         const selectedUsersLength = this.addDebtForm.user_shares.filter((share) => share.checked == true).length;
-        
+        console.log(selectedUsersLength);
         const amount = Dinero({
-            amount: this.addDebtForm.amount * 100,
+            amount: this.addDebtForm.amount,
             currency: this.addDebtForm.currency,
         });
-
+        console.log(amount);
         const splits = [];
 
         // this is how Dinero.js wants the splits to be defined
@@ -47,16 +48,18 @@ export const store = reactive({
         }
 
         // handling the allocation of splits
-        const shares = amount.allocate(splits).map(s => s.getAmount());
-
+        const shares = amount.allocate(splits).map((share) => share.getAmount());
+        console.log('s', shares);
         // set as share amount for the user if they are selected
         // by default, give the first user the slightly larger share
         this.addDebtForm.user_shares.forEach((share) => {
             share.amount = 0;
 
             if (share.checked) {
-                share.amount = shares.shift() / 100;
+                share.amount = shares.shift();
             }
         });
+
+        console.log(this.addDebtForm.user_shares);
     },
 })


### PR DESCRIPTION
**CLOSED AS THIS IS NOW LONG DEFUNCT, CHANGES HAVE BEEN MADE ACROSS SEVERAL OTHER PRS** 

The aim of this PR is to resolve a bug that was preventing (absurdly) large numbers from being entered as a share/debt total. Additionally as it's somewhat related, this PR will be used to look at any issues with, or improving, the way in which data is represented as a decimal (where applicable) to the user. 

Looking back at it, bit unsure on the use of Dinero.js on the frontend. Backend seems okay with casting to/from minor units but the necessity of that does initially depend on the fronted. Seeder is showing the occasional £0.00 discrepancy showing up as insane numbers like £-1.1368683772161603e-13, as is creating a debt full of decimal numbers. 

Borderline going in circles, writing notes here for a series of options on dealing with major/minor units.

- Two `number` inputs, each for major/minor. Clean code but potentially poor UX? Can potentially cause problems with splitEven().
- Single `string` input. More finnicky js required, may well require more backend validation too. 


Changelog:

- Migration to change 'decimal' db columns to 'bigInteger'



After working on this for a couple of weeks, the PR has become a bit of a mess. The changes from decimal column types to bigInt are sound, and I may end up just taking them out and having a tiny PR for them, as well as a few small changes to the share/amount inputs that'll prevent minor issues. I'll basically sum up what I feel I need from this PR, and what I've tried. This has been slow work few commits as I don't think I've written/deleted so much code repeatedly in my life before.


- Inputs are to be strings, this is so the input element can have a character limit at a html level. Because of this, some things are forced to come into play:
    - User input is to be trimmed into a minor units number. E.g. £12.34 is 1234. This is so we can use Dinero to create money objects, but it's especially helpful for splits as it doesn't leave us with annoying floats.
    - Because we use Dinero, split values are output as a number. So splitting £10.00 three ways will produce 3333, 3333 and 3334. So these have to be formatted to strings. Only problem is we run into issues like that, as 1/3 of £10.00 isn't £33.33.
    - Similar things also happen with minor unit amounts, like £00.12 three ways becomes a share of 40p.
    
Having to have lots of use-case js isn't ideal and quickly becomes messy and bloated. I've tried creating a component where the soul purpose is to deal with string->number conversion for example, that's what required for a share. However when a debt needs to be split evenly, that input needs number->string conversion. I've also experimented with having the input be entered as a "first character last" so the string sort of fills out from the back. Hard to explain, but the idea is that entering a 1 will give you £00.01 rather than £10.00, but I couldn't really get it to work properly. 

Also had the idea of having a sort of frontend validation on the input (turns red if input is not in format of 1234567.89) but that's sort of an aside, and depends on how the form ends up being built really. 

The Cash cast will likely end up being deleted, as the aim is to deal with everything in minor units as soon as a string is converted. Long term, it ends up being so much cleaner. However, inertia have just released something called precognition which can hit your backend validation without making a request (I think)... though that might not actually be very useful. Worth thinking about though.