### PR TITLE
Bug: Unable to create aliases

### DIFF
--- a/resources/js/Components/GroupUsers/GroupUser.vue
+++ b/resources/js/Components/GroupUsers/GroupUser.vue
@@ -26,23 +26,22 @@ const refresh = inject('collapsibleRefresh');
 const confirmingGroupUserDeletion = ref(false);
 const isEditing = ref(false);
 
-// if there are group user aliases, find the one for the logged in user
-// otherwise, return object with alias property & empty string
-
-// set the alias object to the input value
 const alias = computed({
+    // if there are group user aliases, find the one for the logged in user
+    // otherwise, return object with alias property & empty string
     get() {
         return props.group_user.aliases.find(
             alias => alias.user_id === Number(usePage().props.auth.user.id)
         ) || { alias: '' };
     },
+    // set the alias object to the input value
     set(value) {
         this.alias = value;
     }
 });
 
 onMounted(() => {
-    console.log(alias.value);
+
 })
 </script>
 

--- a/resources/js/Components/GroupUsers/GroupUser.vue
+++ b/resources/js/Components/GroupUsers/GroupUser.vue
@@ -26,6 +26,7 @@ const refresh = inject('collapsibleRefresh');
 const confirmingGroupUserDeletion = ref(false);
 const isEditing = ref(false);
 
+
 // show the user alias that is logged in currently
 const visibleAlias = computed(() =>
     props.group_user.aliases.find(
@@ -69,8 +70,11 @@ onMounted(() => {
                     }"
                 :transform="data => ({
                     ...(visibleAlias 
-                        ? visibleAlias 
-                        : {}
+                        ? {}
+                        : { 
+                            user_id: usePage().props.auth.user.id, 
+                            group_user_id: props.group_user.id 
+                        }
                     ),
                     ...data,
                 })"

--- a/resources/js/Components/GroupUsers/GroupUser.vue
+++ b/resources/js/Components/GroupUsers/GroupUser.vue
@@ -25,30 +25,24 @@ const props = defineProps({
 const refresh = inject('collapsibleRefresh');
 const confirmingGroupUserDeletion = ref(false);
 const isEditing = ref(false);
-const newAlias = ref('');
 
-// show the user alias that is logged in currently
-const visibleAlias = computed(() => 
-    props.group_user.aliases.find(
-        alias => alias.user_id === Number(usePage().props.auth.user.id)
-    )
-);
+// if there are group user aliases, find the one for the logged in user
+// otherwise, return object with alias property & empty string
 
-const aliasInput = computed({
+// set the alias object to the input value
+const alias = computed({
     get() {
-        return visibleAlias.value ? visibleAlias.value.alias : newAlias.value;
+        return props.group_user.aliases.find(
+            alias => alias.user_id === Number(usePage().props.auth.user.id)
+        ) || { alias: '' };
     },
     set(value) {
-        if (visibleAlias.value) {
-            visibleAlias.value.alias = value;
-        } else {
-            newAlias.value = value;
-        }
+        this.alias = value;
     }
 });
 
 onMounted(() => {
-
+    console.log(alias.value);
 })
 </script>
 
@@ -62,28 +56,23 @@ onMounted(() => {
             <h3 class="text-xl text-center font-semibold">
                 {{ group_user.user.name }}
             </h3>
-            <small>{{ visibleAlias ? visibleAlias.alias : '' }}</small>
+            <small>{{ alias ? alias.alias : '' }}</small>
         </div>
         <div v-else class="flex flex-col w-full">
             <Form
-                :action="visibleAlias 
-                    ? route('alias.update', visibleAlias.id) 
+                :action="alias.id
+                    ? route('alias.update', alias.id) 
                     : route('alias.store')
                 " 
-                :method="visibleAlias ? 'patch' : 'post'"
+                :method="alias.id? 'patch' : 'post'"
                 #default="{ errors }"
                 @success="isEditing = false;refresh & refresh()"
                 :options="{
                         preserveScroll: true,
                     }"
                 :transform="data => ({
-                    ...(visibleAlias 
-                        ? {}
-                        : { 
-                            user_id: usePage().props.auth.user.id, 
-                            group_user_id: props.group_user.id 
-                        }
-                    ),
+                    user_id: usePage().props.auth.user.id, 
+                    group_user_id: props.group_user.id,
                     ...data,
                 })"
             >
@@ -96,7 +85,7 @@ onMounted(() => {
                     New Alias
                     </label>
                     <TextInput
-                        v-model="aliasInput"
+                        v-model="alias.alias"
                         name="alias"
                         type="text"
                         id="newGroupUserAlias"

--- a/resources/js/Components/GroupUsers/GroupUser.vue
+++ b/resources/js/Components/GroupUsers/GroupUser.vue
@@ -25,19 +25,27 @@ const props = defineProps({
 const refresh = inject('collapsibleRefresh');
 const confirmingGroupUserDeletion = ref(false);
 const isEditing = ref(false);
-
+const newAlias = ref('');
 
 // show the user alias that is logged in currently
-const visibleAlias = computed(() =>
+const visibleAlias = computed(() => 
     props.group_user.aliases.find(
         alias => alias.user_id === Number(usePage().props.auth.user.id)
     )
 );
 
-// for some weird reason, v-model doesn't like visibleAlias?.alias
-// or any sort of ternary involving it
-// so this is a temporary fix until i figure out the 'correct' fix
-const loggedInUserAlias = visibleAlias ? visibleAlias.alias : '';
+const aliasInput = computed({
+    get() {
+        return visibleAlias.value ? visibleAlias.value.alias : newAlias.value;
+    },
+    set(value) {
+        if (visibleAlias.value) {
+            visibleAlias.value.alias = value;
+        } else {
+            newAlias.value = value;
+        }
+    }
+});
 
 onMounted(() => {
 
@@ -88,7 +96,7 @@ onMounted(() => {
                     New Alias
                     </label>
                     <TextInput
-                        v-model="loggedInUserAlias"
+                        v-model="aliasInput"
                         name="alias"
                         type="text"
                         id="newGroupUserAlias"


### PR DESCRIPTION
There stands a bug where you're currently unable to create Aliases for a group user, however editing an existing Alias is working fine.  The bug was cause by using a ternary in conjunction with `transform` on the form helper to determine the data passed in. 

Due to the nature of the form being multi-use, I've changed the data to just be the `user_id` and `group_user_id` as they are necessary for both create & update requests (despite the update route being able to take just the object), it reads cleaner to just pass the `alias.id` in to the update route rather than having an extra ternary in both that param, and the form params in general.

Additionally, rather than the confusing `visibleAlias` and `loggedInUserAlias`, I've adopted a getter/setter model that handles what's loaded into the form, and what's posted/patched. 