### PR TITLE
check status on toast mount

### DIFF
--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -33,7 +33,7 @@ class GroupController extends Controller
                     ->paginate(5)
                 )
             );
-
+    dump('t', $request->session()->get('status'));
         return Inertia::render('Groups', [
             'groups' => $groups,
             'status' => $request->session()->get('status') ?? null,

--- a/resources/js/Components/Misc/Toast.vue
+++ b/resources/js/Components/Misc/Toast.vue
@@ -2,12 +2,6 @@
 import { ref, onMounted, watch} from 'vue';
 import { usePage } from '@inertiajs/vue3';
 
-const props = defineProps({
-    message: {
-        type: String,
-    },
-});
-
 const showToast = ref(false);
 
 /**
@@ -18,14 +12,20 @@ const showToast = ref(false);
  * So should be quite future-proof
  */
 onMounted(() => {
-
+    if (usePage().props.flash.status) {
+        showToast.value = true;
+        setTimeout(() => {
+            showToast.value = false;
+            usePage().props.flash.status = null;
+        }, 3000);
+    }
 });
 
 watch(
     () => usePage().props.flash.status,
     (newMessage) => {
         showToast.value = true;
-
+        console.log('new', newMessage);
         setTimeout(() => {
             showToast.value = false;
             usePage().props.flash.status = null;

--- a/tests/Feature/Http/Controllers/InviteControllerTest.php
+++ b/tests/Feature/Http/Controllers/InviteControllerTest.php
@@ -240,12 +240,12 @@ test('user clicking on the invite link after accepting it logs them in and redir
     $user = $this->group->users->first();
 
     $group = Group::factory()->withGroupUsers()->create([
-                'user_id' => $user,
+                'user_id' => $this->user,
             ]);
-
+    
     $invite = Invite::factory()->create([
         'group_id' => $group->id,
-        'user_id' => $user->id,
+        'user_id' => $this->user->id,
         'recipient' => $user->email,
         'accepted_at' => Carbon::now(),
     ]);
@@ -253,9 +253,15 @@ test('user clicking on the invite link after accepting it logs them in and redir
     $this->actingAs($user);
 
     $response = $this->get('/invite/accept/' . $invite->token);
+    dump($response->getSession()->all());
 
+    $this->assertDatabaseHas('invites', [
+        'id' => $invite->id,
+        'accepted_at' => Carbon::now(),
+    ]);
+    
     $response->assertRedirect(route('group.index'))
-        ->assertSessionHas('status', "You have successfully joined {$this->group->name}");
+        ->assertSessionHas('status', "You have successfully joined {$group->name}");
 });
 
 test('invites are expired after 24 hours', function() {


### PR DESCRIPTION
This PR is just to fix a bug that prevents the toast popup from working when an unregistered user accepts an invite. This was because the status message in the toast wasn't changing in a way that a `watch()` can understand, it was being mounted with the status. 