### PR TITLE
Fix comment create policy

### DIFF
--- a/app/Policies/CommentPolicy.php
+++ b/app/Policies/CommentPolicy.php
@@ -30,7 +30,9 @@ class CommentPolicy
      */
     public function create(User $user, Debt $debt): bool
     {
-        return $user->id === $debt->user_id;
+        return $debt->group->users()
+            ->where('users.id', $user->id)
+            ->exists();
     }
 
     /**

--- a/app/Policies/CommentPolicy.php
+++ b/app/Policies/CommentPolicy.php
@@ -30,7 +30,7 @@ class CommentPolicy
      */
     public function create(User $user, Debt $debt): bool
     {
-        return $debt->group->users()
+        return $debt->users()
             ->where('users.id', $user->id)
             ->exists();
     }

--- a/resources/js/Components/Misc/Toast.vue
+++ b/resources/js/Components/Misc/Toast.vue
@@ -25,7 +25,7 @@ watch(
     () => usePage().props.flash.status,
     (newMessage) => {
         showToast.value = true;
-        console.log('new', newMessage);
+
         setTimeout(() => {
             showToast.value = false;
             usePage().props.flash.status = null;

--- a/resources/js/Components/Shares/Share.vue
+++ b/resources/js/Components/Shares/Share.vue
@@ -41,7 +41,7 @@ function setSentSeenMessage(message) {
 }
 
 onMounted(() => {
-    console.log('s', props.share);
+
 })
 
 </script>


### PR DESCRIPTION
This PR is to address an oversight of the policy for creating comments being incorrect. The previous policy mistakenly only allowed the debt owner to comment on a debt, now it allows group members in the debt to comment. 