### PR TITLE
Once props

### DIFF
--- a/app/Http/Controllers/ShareController.php
+++ b/app/Http/Controllers/ShareController.php
@@ -99,15 +99,24 @@ class ShareController extends Controller
             case $share->wasChanged('amount') && $request->user()->cannot('updateAmount', $share):
                  return redirect()->route('debt.index')->withErrors(['amount' => "You do not have permission to update the amount of this share."]);
             default:
-                $original_amount = $share->amount;
-        
-                $share->update([
-                    'name' => $validated['name'],
-                    'amount' => Money::of($validated['amount'], $share->debt->currency),
-                ]);
+                
+                $updateData = [];
+                
+                if (array_key_exists('name', $validated)) {
+                    $updateData['name'] = $validated['name'];
+                }
+
+                if (array_key_exists('amount', $validated)) {
+                    $updateData['amount'] = Money::of($validated['amount'], $share->debt->currency);
+                }
+
+                if (!empty($updateData)) {
+                    $share->update($updateData);
+                }
 
                 // similar to updating a debt, extra stuff to do if a share amount is updated
                 if ($share->wasChanged('amount')) {
+                    $original_amount = $share->amount;
                     $discrepancy = $share->amount->minus($original_amount);
                     $shareService->updateShareDebt($share, $discrepancy);
                 }

--- a/app/Http/Controllers/ShareController.php
+++ b/app/Http/Controllers/ShareController.php
@@ -15,6 +15,7 @@ use App\Services\BalanceService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
 use Brick\Money\Money;
+use Inertia\Inertia;
 
 /**
  * Shares have observers, which fire events that perform operations for debt & user->total_balance
@@ -85,7 +86,7 @@ class ShareController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(UpdateShareRequest $request, Share $share, ShareService $shareService): RedirectResponse
+    public function update(UpdateShareRequest $request, Share $share, ShareService $shareService)
     {
         // validated data
         $validated = $request->validated();
@@ -121,7 +122,9 @@ class ShareController extends Controller
                     $shareService->updateShareDebt($share, $discrepancy);
                 }
 
-                return redirect()->route('debt.index')->with('status', 'Share updated successfully.');
+                return Inertia::render('Debts', [
+                    'status' => 'Share updated successfully.'
+                ]);
         }
     }
 

--- a/resources/js/Components/Shares/Share.vue
+++ b/resources/js/Components/Shares/Share.vue
@@ -98,6 +98,7 @@ onMounted(() => {
                 #default="{ errors }"
                 @success="isEditing = false"
                 :options="{
+                    // only: ['share'],
                     preserveScroll: true,
                 }"
             >


### PR DESCRIPTION
The purpose of this PR is to have a bit of a play around with inertia.js [once props](https://inertiajs.com/docs/v2/data-props/once-props). Currently, the architecture of the app reloads the debts or groups index page on every form submission. This is not ideal. A brief test with changing the name of the share shows a notable improvement from a user POV that isn't aware of the flow. However, some kind of bug occurs with the `InfiniteScroll` component. Everything still appears to work.. but the console is firing messages; I haven't investigated it yet.

I'll likely test `InfiniteScroll` replacements on the groups page, as the data is a lot simpler. 

Lost of expansion on research following this. Seems I *may* have been using flash messages incorrectly, or at least inconsistently. I'd like to at least add partial reloads for for share sent/seen as the user would be expecting immediate changes for the checking/unchecking of the box. This can also be achieved with precognition, I'm just not sure which one is best. Additionally, flash messages can also be sent as errors and then used in a toast, but that could end up leading to a possible toast rework (currently, it's a bit janky and needs to be event based)

A more concise list of what can/will be looked into:

- Event based notifications
- Correct/consistent implementation of flash message with inertia
- Possibly replacing some validation errors with flash messages, notably sent/seen as they don't really use validation errors. The data will always be valid as it's just a boolean value, but the permissions are what causes the error