### PR TITLE
Sent and seen improvements

### DIFF
--- a/app/Http/Controllers/ShareController.php
+++ b/app/Http/Controllers/ShareController.php
@@ -87,18 +87,28 @@ class ShareController extends Controller
      */
     public function update(UpdateShareRequest $request, Share $share, ShareService $shareService): RedirectResponse
     {
-        // validated data
-        $validated = $request->validated();
-        
         // switch case to handle share policy checks
         switch ($request->user()) {
             case $request->user()->cannot('updateName', $share) && $request->user()->cannot('updateAmount', $share):
-                 return redirect()->route('debt.index')->withErrors(['share' => "You do not have permission to update this share."]);
+                 return redirect()
+                    ->route('debt.index')
+                    ->withErrors([
+                        'share' => "You do not have permission to update this share."
+                    ]);
             case $request->user()->cannot('updateName', $share):
-                 return redirect()->route('debt.index')->withErrors(['name' => "You do not have permission to update the name of this share."]);
+                 return redirect()
+                    ->route('debt.index')
+                    ->withErrors([
+                        'name' => "You do not have permission to update the name of this share."
+                    ]);
             case $share->wasChanged('amount') && $request->user()->cannot('updateAmount', $share):
-                 return redirect()->route('debt.index')->withErrors(['amount' => "You do not have permission to update the amount of this share."]);
+                 return redirect()
+                    ->route('debt.index')
+                    ->withErrors([
+                        'amount' => "You do not have permission to update the amount of this share."
+                    ]);
             default:
+                $validated = $request->validated();
                 $original_amount = $share->amount;
         
                 $share->update([
@@ -112,7 +122,9 @@ class ShareController extends Controller
                     $shareService->updateShareDebt($share, $discrepancy);
                 }
 
-                return redirect()->route('debt.index')->with('status', 'Share updated successfully.');
+                return redirect()
+                    ->route('debt.index')
+                    ->with('status', 'Share updated successfully.');
         }
     }
 
@@ -122,7 +134,11 @@ class ShareController extends Controller
     public function sent(UpdateShareRequest $request, Share $share, BalanceService $balanceService)
     {
         if ($request->user()->cannot('updateSent', $share)) {
-            return redirect()->route('debt.index')->withErrors(['sent' => "You do not have permission to update the 'sent' status of this share"]);
+            return redirect()
+                ->route('debt.index')
+                ->withErrors([
+                    'sent' => "You do not have permission to update the 'sent' status of this share"
+                ]);
         }
 
         $validated = $request->validated();
@@ -132,7 +148,6 @@ class ShareController extends Controller
         ]);
 
         // only change user balances on sent status update
-        // 'seen' is merely cosmetic, jsut for user clarity
         // maybe one day can expand balance into having a pending/unconfirmed status
         if ($validated['sent'] == 1) {
             $balanceService->subtractFromGroupUserBalance($share, $share->amount);
@@ -149,20 +164,30 @@ class ShareController extends Controller
     public function seen(UpdateShareRequest $request, Share $share)
     {
         if ($request->user()->cannot('updateSeen', $share)) {
-            return redirect()->route('debt.index')->withErrors(['seen' => "You do not have permission to update the 'seen' status of this share"]);
+            return redirect()
+                ->route('debt.index')
+                ->withErrors([
+                    'seen' => "You do not have permission to update the 'seen' status of this share"
+                ]);
         }
 
+        // if the user can update 'seen' and the share has not been sent
+        // they cannot 'see' an 'unsent' share
         if ($share->sent == 0) {
-            return redirect()->route('debt.index')->withErrors(['seen' => "You can not mark this share as seen becase it has not been sent yet"]);
-        } else {
-            $validated = $request->validated();
-
-            $share->update([
-                'seen' => $validated['seen'],
-            ]);
-
-            return redirect()->route('debt.index');
+            return redirect()
+                ->route('debt.index')
+                ->withErrors([
+                    'seen' => "You can not mark this share as seen becase it has not been sent yet"
+                ]);
         }
+        
+        $validated = $request->validated();
+
+        $share->update([
+            'seen' => $validated['seen'],
+        ]);
+
+        return redirect()->route('debt.index');
     }
 
     /**

--- a/app/Http/Requests/UpdateShareRequest.php
+++ b/app/Http/Requests/UpdateShareRequest.php
@@ -25,7 +25,11 @@ class UpdateShareRequest extends FormRequest
     public function rules(): array
     { 
         return [
-            'sent' => ['sometimes', 'boolean'],
+            'sent' => ['sometimes', 'boolean', function($attribute, $value, $fail) {
+                if ($this->user()->cannot('updateSent', $this->route('share'))) {
+                    return $fail('gtgggg');
+                }
+            }],
             'seen' => ['sometimes', 'boolean'],
             'amount' => ['sometimes', 'numeric'],
             'name' => ['sometimes', 'nullable', 'string', 'max:255'],

--- a/app/Http/Requests/UpdateShareRequest.php
+++ b/app/Http/Requests/UpdateShareRequest.php
@@ -25,11 +25,7 @@ class UpdateShareRequest extends FormRequest
     public function rules(): array
     { 
         return [
-            'sent' => ['sometimes', 'boolean', function($attribute, $value, $fail) {
-                if ($this->user()->cannot('updateSent', $this->route('share'))) {
-                    return $fail('gtgggg');
-                }
-            }],
+            'sent' => ['sometimes', 'boolean'],
             'seen' => ['sometimes', 'boolean'],
             'amount' => ['sometimes', 'numeric'],
             'name' => ['sometimes', 'nullable', 'string', 'max:255'],

--- a/resources/js/Components/Shares/SentSeenButton.vue
+++ b/resources/js/Components/Shares/SentSeenButton.vue
@@ -1,13 +1,9 @@
 <script setup>
 import { Form } from '@inertiajs/vue3';
-import { onMounted, computed } from 'vue';
+import { onMounted, ref } from 'vue';
 
 const props = defineProps({
     operation: {
-        type: String,
-        required: true,
-    },
-    type: {
         type: String,
         required: true,
     },
@@ -17,11 +13,15 @@ const props = defineProps({
     },
 })
 
+// emitting errors up to parent is just so the error can appear in the right place
 const emit = defineEmits(['seenError', 'sentError']);
 
-onMounted(() => {
+// for changing the status on the frontend
+// as using partial reloads we don't get the updated share back from the db
+// so traffic is only going one way until we perform a refresh
+const status = ref(props.share[props.operation]);
 
-})
+onMounted(() => {})
 
 </script>
 <template>
@@ -29,16 +29,17 @@ onMounted(() => {
         class=" flex flex-col mx-2"
         :action="route('share.' + operation, share)"
         method="patch"
-        #default="{ errors, invalid, validate, validating }"
+        #default="{ errors }"
         :options="{
             preserveScroll: true,
+            only: ['share'],
         }"
         :transform="data => ({ 
             ...data, 
-            id: props.share.id,
-            [operation]: !props.share[operation],
+            [operation]: !status,
         })"
         @error="(errors) => emit(operation + 'Error', errors)"
+        @success="status = !status;"
     >
         <label :for="operation + share.id" class="text-xs font-semibold">
             {{ operation.toUpperCase() }}
@@ -49,9 +50,9 @@ onMounted(() => {
             class="hidden"
             :name="operation"
             :value="share[operation]"
-            @change="validate()"
         >
         <button
+            type="submit"
             :disabled="props.share.sent && props.share.seen"
             :id="props.operation + '-button-' + share.id"
             class="border-2 bg-gray-100 rounded border-black"
@@ -60,10 +61,9 @@ onMounted(() => {
             <i
                 :id="props.operation + '-tick-' + share.id" 
                 class="fa-solid fa-check"
-                :class="share[operation] ? '' : 'invisible'"
+                :class="status ? '' : 'invisible'"
             >
             </i>
         </button>
-        <p v-if="invalid(operation)">{{ errors.sent }}</p>
     </Form>
 </template>

--- a/resources/js/Components/Shares/SentSeenButton.vue
+++ b/resources/js/Components/Shares/SentSeenButton.vue
@@ -32,7 +32,7 @@ onMounted(() => {})
         #default="{ errors }"
         :options="{
             preserveScroll: true,
-            only: ['share'],
+            only: ['this is a hack to prevent full reload'],
         }"
         :transform="data => ({ 
             ...data, 

--- a/resources/js/Components/Shares/SentSeenButton.vue
+++ b/resources/js/Components/Shares/SentSeenButton.vue
@@ -19,10 +19,6 @@ const props = defineProps({
 
 const emit = defineEmits(['seenError', 'sentError']);
 
-const sentAndSeenClasses = computed(() => {
-
-})
-
 onMounted(() => {
 
 })
@@ -33,7 +29,7 @@ onMounted(() => {
         class=" flex flex-col mx-2"
         :action="route('share.' + operation, share)"
         method="patch"
-        #default="{ errors }"
+        #default="{ errors, invalid, validate, validating }"
         :options="{
             preserveScroll: true,
         }"
@@ -53,6 +49,7 @@ onMounted(() => {
             class="hidden"
             :name="operation"
             :value="share[operation]"
+            @change="validate()"
         >
         <button
             :disabled="props.share.sent && props.share.seen"
@@ -67,5 +64,6 @@ onMounted(() => {
             >
             </i>
         </button>
+        <p v-if="invalid(operation)">{{ errors.sent }}</p>
     </Form>
 </template>

--- a/resources/js/Components/Shares/Share.vue
+++ b/resources/js/Components/Shares/Share.vue
@@ -61,13 +61,11 @@ onMounted(() => {
                 <div v-if="props.share.user_id !== props.debt.user_id" class="flex flex-row items-center">
                     <SentSeenButton
                         operation="sent"
-                        type="submit"
                         :share="share"
                         @sentError="setSentSeenMessage($event)"
                     />
                     <SentSeenButton
                         operation="seen"
-                        type="submit"
                         :share="share"
                         @seenError="setSentSeenMessage($event)"
                     />

--- a/resources/js/Components/Shares/Share.vue
+++ b/resources/js/Components/Shares/Share.vue
@@ -145,7 +145,7 @@ onMounted(() => {
                         <SecondaryButton
                             type="button"
                             class="mr-2"
-                            @click="isEditing = false"
+                            @click="isEditing = false;refresh & refresh()"
                         >
                             Cancel
                         </SecondaryButton>

--- a/resources/js/Components/Shares/Share.vue
+++ b/resources/js/Components/Shares/Share.vue
@@ -89,75 +89,75 @@ onMounted(() => {
             </div>
         </div>
         <!-- editing form -->
-        <div v-else class="w-full">
-            <Form
-                :action="route('share.update', props.share)" 
-                method="patch" 
-                #default="{ errors }"
-                @success="isEditing = false"
-                :options="{
-                    preserveScroll: true,
-                }"
-            >
-                <div class="flex flex-col">
-                    <div v-if="props.share.can.update_name" class="flex flex-row">
-                        <label 
-                            for="newShareName" 
-                            style="display:none;"
-                            id="newShareNameLabel"
-                        >
-                        New Name
-                        </label>
-                        <TextInput
-                            name="name"
-                            v-model="props.share.name"
-                            type="text"
-                            id="newShareName"
-                            aria-labelledby="newShareNameLabel"
-                            placeholder="Enter a new share name..."
-                            class="w-full"
-                            style="height:48px"
-                        />
-                    </div>
-                    <InputError class="mt-2" :message="errors.name" />
-                    <div v-if="props.share.can.update_amount" class="flex flex-row">
-                        <label 
-                            for="ShareAmount"
-                            style="display:none;"
-                            id="newShareAmountLabel
-                        ">
-                        New Amount
-                        </label>
-                        <TextInput 
-                            name="amount"
-                            v-model="props.share.amount.amount"
-                            type="number"
-                            step="0.01"
-                            id="newShareAmount"
-                            placeholder="Enter a new amount..."
-                            aria-labelledby="newShareAmountLabel"
-                            class="w-full mt-2"
-                            style="height:48px"
-                        />
-                    </div>
-                    <InputError class="mt-2" :message="errors.amount" />
-                    <div class="flex flex-row mt-2 sm:justify-end">
-                        <SecondaryButton
-                            type="button"
-                            class="mr-2"
-                            @click="isEditing = false;refresh & refresh()"
-                        >
-                            Cancel
-                        </SecondaryButton>
-                        <PrimaryButton
-                            type="submit"
-                        >
-                            Save
-                        </PrimaryButton>
-                    </div>
+        <Form
+            v-else
+            class="w-full"
+            :action="route('share.update', props.share)" 
+            method="patch" 
+            #default="{ errors }"
+            @success="isEditing = false"
+            :options="{
+                preserveScroll: true,
+            }"
+        >
+            <div class="flex flex-col">
+                <div v-if="props.share.can.update_name" class="flex flex-row">
+                    <label 
+                        for="newShareName" 
+                        style="display:none;"
+                        id="newShareNameLabel"
+                    >
+                    New Name
+                    </label>
+                    <TextInput
+                        name="name"
+                        v-model="props.share.name"
+                        type="text"
+                        id="newShareName"
+                        aria-labelledby="newShareNameLabel"
+                        placeholder="Enter a new share name..."
+                        class="w-full"
+                        style="height:48px"
+                    />
                 </div>
-            </Form>
-        </div>
+                <InputError class="mt-2" :message="errors.name" />
+                <div v-if="props.share.can.update_amount" class="flex flex-row">
+                    <label 
+                        for="ShareAmount"
+                        style="display:none;"
+                        id="newShareAmountLabel
+                    ">
+                    New Amount
+                    </label>
+                    <TextInput 
+                        name="amount"
+                        v-model="props.share.amount.amount"
+                        type="number"
+                        step="0.01"
+                        id="newShareAmount"
+                        placeholder="Enter a new amount..."
+                        aria-labelledby="newShareAmountLabel"
+                        class="w-full mt-2"
+                        style="height:48px"
+                    />
+                </div>
+                <InputError class="mt-2" :message="errors.amount" />
+                <div class="flex flex-row mt-2 sm:justify-end">
+                    <SecondaryButton
+                        type="button"
+                        class="mr-2"
+                        @click="isEditing = false;refresh & refresh()"
+                    >
+                        Cancel
+                    </SecondaryButton>
+                    <PrimaryButton
+                        type="submit"
+                    >
+                        Save
+                    </PrimaryButton>
+                </div>
+            </div>
+        </Form>
         <InputError v-if="sentSeenMessage" class="mt-2" :message="sentSeenMessage" />
         <Modal :show="confirmingShareDeletion">
             <div class="p-6">


### PR DESCRIPTION
This aim of this PR is to make it so the sent/seen checkboxes show no sort of delay when updated by a user. Currently, with the `redirect()->route('debts.index')` at the end of the `sent()` and `seen()` controller methods, the ~0.3s page refresh is being enacted every time. This is not ideal, as any user that is quick enough to interact with the boxes more frequent that ~0.3s won't be able to properly do so. After some research, there are some changes to consider to get around this:

- ~~Laravel Precognition.~~ This was the first idea, as it's supposed to validate form fields without firing the request, though it looks like it still at least performs a `back()`. Not what I need.
- Inertia Partial reloads. Tried this with debt names and somehow got it to work, but not with the share checkboxes. May well be doing something wrong but either way it keeps the page route as the one that just fired. E.g. in testing checking a share box will change the url to /sent/share/1537, and then a refresh of the page bugs because it's trying to hit that route again. Going to look into this again though. 
- Store object. This would be a quite drastic change and doesn't really sit well with me. Currently all CRUD updates are done in a very standard way of submitting a form relative to the field(s). Creating a store object (much like the add debt form), but *just* for the sent/seen aspects of each share. It seems a bit over the top, as when mounting a `Debt` component, I'd have to map all share id, sent & seen statuses to an object, then have the checkboxes mapped to the relative share for that checkbox. The "good" part of this idea is just building up a big object that the user can make reactive changes to, then after 1000ms it fires to the backend, user gets a notification of "x statuses updated"


Edit:

So the best option was using partial reloads, turned out I was just makin a syntax error when trying to implement it. Though I am still using a sort of hacky way. As it turns out, partial reloads don't work with nested props, hence why they worked fine when I was updating the debt names, but not shares statuses. To get around this, I'm sending one-way traffic to the backend and just changing the appearance of the box. Since it's just a true/false toggle, there's no way it can ever be incorrect. The "only" prop is a dummy, and just makes the page re-render the `Debts` page but with no new data. So, example:

- The user clicks the unchecked "sent" box,
- Payload with `"sent" => true` is sent to backend, with param for fake prop to partial reload
- Controller logic executes, redirect to debt controller index method
- No prop to partial reload
- Logic in checkbox changes it to !status, so appears to the user that it has the db value
- So if the user does perform a full page refresh, checkbox shows correct status

Only problem is that this now messes with the user total balance in the nav bar, but having that on an append for the user model is terrible as it's access an insane amount of time in the resource. Plan is to implement that with websockets any way.