### PR TITLE
Events & Listeners

### DIFF
--- a/app/Events/DebtCreated.php
+++ b/app/Events/DebtCreated.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use App\Models\Debt;
+
+class DebtCreated
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(public Debt $debt)
+    {
+        
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, \Illuminate\Broadcasting\Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('channel-name'),
+        ];
+    }
+}

--- a/app/Events/GroupCreated.php
+++ b/app/Events/GroupCreated.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class GroupCreated
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, \Illuminate\Broadcasting\Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('channel-name'),
+        ];
+    }
+}

--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -21,6 +21,7 @@ use App\Services\ShareService;
 use Brick\Money\Money;
 use App\Http\Resources\DebtResource;
 use App\Http\Resources\GroupResource;
+use App\Events\DebtCreated;
 
 class DebtController extends Controller
 {
@@ -92,6 +93,8 @@ class DebtController extends Controller
         ]);
 
         $shareService->createDebtShares($validated['user_shares'], $debt);
+
+        event(new DebtCreated($debt));
 
         return redirect()->route('debt.index')->with('status', 'Debt created successfully.');
     }

--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -92,9 +92,9 @@ class DebtController extends Controller
             'currency' => $validated['currency'],
         ]);
 
-        $shareService->createDebtShares($validated['user_shares'], $debt);
+        DebtCreated::dispatch($debt);
 
-        event(new DebtCreated($debt));
+        $shareService->createDebtShares($validated['user_shares'], $debt);
 
         return redirect()->route('debt.index')->with('status', 'Debt created successfully.');
     }

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -33,7 +33,7 @@ class GroupController extends Controller
                     ->paginate(5)
                 )
             );
-    dump('t', $request->session()->get('status'));
+
         return Inertia::render('Groups', [
             'groups' => $groups,
             'status' => $request->session()->get('status') ?? null,

--- a/app/Listeners/DebtCreatedNotification.php
+++ b/app/Listeners/DebtCreatedNotification.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\DebtCreated;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+
+class DebtCreatedNotification
+{
+    /**
+     * Create the event listener.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     */
+    public function handle(DebtCreated $event): void
+    {
+        dd($event);
+    }
+}

--- a/app/Listeners/DebtCreatedNotification.php
+++ b/app/Listeners/DebtCreatedNotification.php
@@ -6,7 +6,7 @@ use App\Events\DebtCreated;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
 
-class DebtCreatedNotification
+class DebtCreatedNotification implements ShouldQueue
 {
     /**
      * Create the event listener.
@@ -21,6 +21,6 @@ class DebtCreatedNotification
      */
     public function handle(DebtCreated $event): void
     {
-        dd($event);
+        dump($event);
     }
 }

--- a/tests/Feature/Http/Controllers/DebtControllerTest.php
+++ b/tests/Feature/Http/Controllers/DebtControllerTest.php
@@ -7,6 +7,10 @@ use App\Models\Share;
 use App\Models\GroupUser;
 use Inertia\Testing\AssertableInertia as Assert;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Event;
+use App\Events\DebtCreated;
+use App\Listeners\DebtCreatedNotification;
 
 beforeEach(function () {
     // create a handful of users so those involved can be randomised
@@ -56,6 +60,8 @@ test('debts, shares and comments all appear with permissions paginated', functio
 test('user can add a debt with different value shares', function() {
     $user_shares = selectRandomGroupUsers($this->users, 100, false);
 
+    Event::fake();
+
     // save the debt 
     $response = $this->post(route('debt.store'), [
         'group_id' => $this->group->id,
@@ -66,6 +72,8 @@ test('user can add a debt with different value shares', function() {
         'user_shares' => $user_shares,
         'currency' => 'GBP',
     ]);
+
+    Event::assertDispatched(DebtCreated::class);
    
     // 302 is because of inertia redirect
     $response->assertStatus(302)


### PR DESCRIPTION
This is a PR just to play around with the basics of events & listeners, checking how they work etc. The eventual plan is progress into moving the queue to redis, then using notifications & websockets to rework toasts. This will also allow websockets to be used for user total balance, though that may be better served in the event/listener pattern. It's also possible that the share/debt services will be updated to this pattern, though that depends on how websockets works out with sent/seen.