### PR TITLE
Invites rework

### DIFF
--- a/app/Events/InviteCreated.php
+++ b/app/Events/InviteCreated.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use App\Models\Invite;
+
+class InviteCreated
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(public Invite $invite)
+    {
+        //
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, \Illuminate\Broadcasting\Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('channel-name'),
+        ];
+    }
+}

--- a/app/Http/Controllers/InviteController.php
+++ b/app/Http/Controllers/InviteController.php
@@ -35,9 +35,9 @@ class InviteController extends Controller
             ->get();
 
         // if there are any, return recipient error
-        if ($existing_invites) {
-
-            // partition into accepted & pending
+        // partition into accepted & pending
+        // redriect with errors
+        if ($existing_invites->isNotEmpty()) {
             [$accepted, $pending] = $existing_invites->partition(
                 fn ($invite) => !is_null($invite->accepted_at)
             );

--- a/app/Http/Controllers/InviteController.php
+++ b/app/Http/Controllers/InviteController.php
@@ -5,9 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Route;
-use App\Mail\InviteToGroup;
 use App\Models\Group;
 use App\Models\GroupUser;
 use App\Models\Invite;
@@ -18,7 +16,7 @@ use App\Http\Requests\InviteToGroupRequest;
 use App\Http\Requests\AcceptInviteRequest;
 use Illuminate\Support\Str;
 use Inertia\Inertia;
-use App\Jobs\ExpireInvite;
+use App\Events\InviteCreated;
 
 class InviteController extends Controller
 {
@@ -48,11 +46,8 @@ class InviteController extends Controller
                 ]);
         }
 
-        $count = 0;
-
         // so if all recipients don't have pending invites, send them
         foreach ($validated['recipients'] as $recipient) {
-
             $invite = Invite::create([
                 'group_id' => $validated['group_id'],
                 'user_id' => $validated['user_id'],
@@ -60,17 +55,13 @@ class InviteController extends Controller
                 'recipient' => $recipient,
                 'token' => Str::random(16),
             ]);
+
+            InviteCreated::dispatch($invite);
         
-            Mail::to($recipient)->queue(new InviteToGroup($invite));
-            
-            ExpireInvite::dispatch($invite)->delay(Carbon::now()->addDays(1));
-            
-            $count++;
+            $plural = count($validated['recipients']) > 1 ? 's' : '';
+
+            return redirect()->route('group.index')->with('status', "{$count} invite{$plural} sent successfully.");
         }
-
-        $plural = $count > 1 ? 's' : '';
-
-        return redirect()->route('group.index')->with('status', "{$count} invite{$plural} sent successfully.");
     }
 
     public function accept($token)

--- a/app/Http/Controllers/InviteController.php
+++ b/app/Http/Controllers/InviteController.php
@@ -31,9 +31,26 @@ class InviteController extends Controller
     {
         $validated = $request->validated();
 
+        // check for existing pending invites
+        $pending_invites = Invite::whereIn('recipient', $validated['recipients'])
+            ->where('group_id', $validated['group_id'])
+            ->whereNull('accepted_at')
+            ->whereNull('expired_at')
+            ->pluck('recipient')
+            ->toArray();
+
+        // if there are any, return recipient error
+        if ($pending_invites) {
+            return redirect()
+                ->back()
+                ->withErrors([
+                    'recipients' => 'Pending invites exist for:' . implode(', ', $pending_invites)
+                ]);
+        }
+
         $count = 0;
 
-        // loop over recipients so mail doesn't stack up in to()
+        // so if all recipients don't have pending invites, send them
         foreach ($validated['recipients'] as $recipient) {
 
             $invite = Invite::create([

--- a/app/Http/Controllers/InviteController.php
+++ b/app/Http/Controllers/InviteController.php
@@ -29,37 +29,38 @@ class InviteController extends Controller
     {
         $validated = $request->validated();
 
-        // check for existing pending invites
-        $existing_invites = Invite::whereIn('recipient', $validated['recipients'])
-            ->where('group_id', $validated['group_id'])
+        $errors = [];
+
+        // check if email belongs to someone already in group
+        $users_in_group = Group::findOrFail($validated['group_id'])
+            ->users()
+            ->whereIn('email', $validated['recipients'])
             ->get();
 
-        // if there are any, return recipient error
-        // partition into accepted & pending
-        // redriect with errors
-        if ($existing_invites->isNotEmpty()) {
-            [$accepted, $pending] = $existing_invites->partition(
-                fn ($invite) => !is_null($invite->accepted_at)
-            );
+        if ($users_in_group->isNotEmpty()) {
+            $errors['existing'] = 'The following recipients are already in the group: ' . 
+                implode(', ', $users_in_group->pluck('email')->toArray());
+        }
+        
+        // check if email belongs to someone with a pending invite to the group
+        $existing_user_invites = Invite::whereIn('recipient', $validated['recipients'])
+            ->where('group_id', $validated['group_id'])
+            ->whereNull('accepted_at')
+            ->get();
 
-            $errors = [];
+        if ($existing_user_invites->isNotEmpty()) {
+            $errors['pending'] = 'The following recipients have pending invites: ' . 
+                implode(', ', $existing_user_invites->pluck('recipient')->toArray());    
+        }
 
-            if ($accepted->isNotEmpty()) {
-                $errors['recipients.accepted'] = 'The following recipients have already accepted invites: ' . 
-                    implode(', ', $accepted->pluck('recipient')->toArray());
-            }
-
-            if ($pending->isNotEmpty()) {
-                $errors['recipients.pending'] = 'The following recipients have pending invites: ' . 
-                    implode(', ', $pending->pluck('recipient')->toArray());
-            }
-
+        // if errors built, return
+        if ($errors) {
             return redirect()
                 ->back()
                 ->withErrors($errors);
         }
 
-        // so if all recipients don't have pending invites, send them
+        // not already in group or invited, send invites
         foreach ($validated['recipients'] as $recipient) {
             $invite = Invite::create([
                 'group_id' => $validated['group_id'],
@@ -72,7 +73,6 @@ class InviteController extends Controller
             InviteCreated::dispatch($invite);
         }
 
-        // return with success message
         $count = count($validated['recipients']);
 
         return redirect()

--- a/app/Http/Controllers/InviteController.php
+++ b/app/Http/Controllers/InviteController.php
@@ -57,11 +57,16 @@ class InviteController extends Controller
             ]);
 
             InviteCreated::dispatch($invite);
-        
-            $plural = count($validated['recipients']) > 1 ? 's' : '';
-
-            return redirect()->route('group.index')->with('status', "{$count} invite{$plural} sent successfully.");
         }
+
+        // return with success message
+        $count = count($validated['recipients']);
+
+        return redirect()
+            ->route('group.index')
+            ->with([
+                'status' => "{$count} " . Str::plural('invite', $count) . " sent successfully."
+            ]);
     }
 
     public function accept($token)

--- a/app/Http/Controllers/InviteController.php
+++ b/app/Http/Controllers/InviteController.php
@@ -30,19 +30,26 @@ class InviteController extends Controller
         $validated = $request->validated();
 
         // check for existing pending invites
-        $pending_invites = Invite::whereIn('recipient', $validated['recipients'])
+        $existing_invites = Invite::whereIn('recipient', $validated['recipients'])
             ->where('group_id', $validated['group_id'])
-            ->whereNull('accepted_at')
-            ->whereNull('expired_at')
-            ->pluck('recipient')
-            ->toArray();
+            ->get();
 
         // if there are any, return recipient error
-        if ($pending_invites) {
+        if ($existing_invites) {
+
+            // partition into accepted & pending
+            [$accepted, $pending] = $existing_invites->partition(
+                fn ($invite) => !is_null($invite->accepted_at)
+            );
+
+            $accepted = $accepted->pluck('recipient')->toArray();
+            $pending = $pending->pluck('recipient')->toArray();
+
             return redirect()
                 ->back()
                 ->withErrors([
-                    'recipients' => 'Pending invites exist for:' . implode(', ', $pending_invites)
+                    'recipients.pending' => 'Pending invites exist for: ' . implode(', ', $pending),
+                    'recipients.accepted' => 'Users already in the group: ' . implode(', ', $accepted),
                 ]);
         }
 

--- a/app/Http/Controllers/InviteController.php
+++ b/app/Http/Controllers/InviteController.php
@@ -42,15 +42,21 @@ class InviteController extends Controller
                 fn ($invite) => !is_null($invite->accepted_at)
             );
 
-            $accepted = $accepted->pluck('recipient')->toArray();
-            $pending = $pending->pluck('recipient')->toArray();
+            $errors = [];
+
+            if ($accepted->isNotEmpty()) {
+                $errors['recipients.accepted'] = 'The following recipients have already accepted invites: ' . 
+                    implode(', ', $accepted->pluck('recipient')->toArray());
+            }
+
+            if ($pending->isNotEmpty()) {
+                $errors['recipients.pending'] = 'The following recipients have pending invites: ' . 
+                    implode(', ', $pending->pluck('recipient')->toArray());
+            }
 
             return redirect()
                 ->back()
-                ->withErrors([
-                    'recipients.pending' => 'Pending invites exist for: ' . implode(', ', $pending),
-                    'recipients.accepted' => 'Users already in the group: ' . implode(', ', $accepted),
-                ]);
+                ->withErrors($errors);
         }
 
         // so if all recipients don't have pending invites, send them

--- a/app/Http/Middleware/CheckInviteExpiry.php
+++ b/app/Http/Middleware/CheckInviteExpiry.php
@@ -31,7 +31,7 @@ class CheckInviteExpiry
                 // they can log in as you
                 Auth::login($user);
 
-                return redirect()->route('group.index');
+                return redirect()->route('group.index')->with('status', "You have successfully joined {$invite->group->name}");
             // invite is expired, redirect to registration w/message
             case $invite->expired_at !== null:
                 return Inertia::render('Auth/Register', [

--- a/app/Http/Requests/InviteToGroupRequest.php
+++ b/app/Http/Requests/InviteToGroupRequest.php
@@ -27,18 +27,6 @@ class InviteToGroupRequest extends FormRequest
             'group_id' => ['exists:groups,id'],
             'user_id' => ['exists:users,id'],
             'recipients' => ['required', 'array', 'min:1'],
-            'recipients.*' => [new IsUserInGroup($this->all()), function ($attribute, $value, $fail) {
-                $invite = Invite::where('recipient', $value)
-                    ->where('group_id', $this->group_id)
-                    ->whereNull('accepted_at')
-                    ->whereNull('expired_at')
-                    ->first();
-       
-                if ($invite) {
-                    return $fail("There is already a pending invite to {$value} for this group.");
-                }
-
-            }],
             'body' => ['string'],
         ];
     }

--- a/app/Listeners/SendGroupInvite.php
+++ b/app/Listeners/SendGroupInvite.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\InviteCreated;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\Mail;
+use App\Mail\InviteToGroup;
+use App\Jobs\ExpireInvite;
+use Carbon\Carbon;
+
+class SendGroupInvite
+{
+    /**
+     * Create the event listener.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     */
+    public function handle(InviteCreated $event): void
+    {
+        Mail::to($event->invite->recipient)
+            ->queue(new InviteToGroup($event->invite));
+
+        ExpireInvite::dispatch($event->invite)
+            ->delay(Carbon::now()->addDays(1));
+    }
+}

--- a/resources/js/Components/Invites/InviteToGroup.vue
+++ b/resources/js/Components/Invites/InviteToGroup.vue
@@ -57,100 +57,101 @@ function removeRecipient(emailAddress) {
             :closeable="true" 
             @close="openModal = !openModal"
         >     
-        <div class="p-6">
-            <!-- input for building email array -->
-            <div class="mb-4 w-full">
-                <label
-                    for="recipient"
-                    class="text-lg font-medium text-gray-900"
-                >
-                    Enter the addresses of who you wish to invite:
-                </label>
-                <input
-                    id="recipient"
-                    class="rounded-l-md border-gray-300 shadow-sm"
-                    type="email"
-                    name="recipient"
-                    v-model="recipient"
-                    @keydown.enter.prevent="addRecipient($event.target.value)"
-                    placeholder="Enter email & press enter"
-                    style="border-right:none;width:calc(100% - 37px)"
-                >
-                <button
-                    type="button"
-                    class="px-2 rounded-r-md border border-gray-300 shadow-sm"
-                    style="height:42px;border-left:none"
-                    @click="recipient = ''"
-                    >
-                    <i
-                        class="fa-solid fa-x mx-1 fa-xs"
-                    ></i>
-                </button>
-            </div>
-            <InputError class="mt-2" :message="recipientError" />
-            <!-- actual form for submission -->
-            <Form
-                :action="route('invite.send')" 
-                method="post" 
-                #default="{ errors }"
-                @success="openModal = false"
-                resetOnSuccess
-                :transform="data => ({ 
-                    ...data, 
-                    recipients: recipients,
-                    group_id: props.group.id,
-                    user_id: usePage().props.auth.user.id,
-                })"
-            >
-                <!-- recipient badges -->
-                <div class="mb-4">
-                    <span 
-                        v-for="recipient in recipients"
-                        class="items-center rounded-md border border-black p-1 bg-gray-900 text-white font-semibold my-1 mr-1"
-                        style="display:inline-block;word-break:break-word"
-                        >
-                        {{ recipient }}
-                        <i
-                            class="fa-solid fa-x mx-1 fa-xs"
-                            @click="removeRecipient(recipient)"
-                        ></i>
-                    </span>
-                </div>
-                <!-- just so this appears to be an error for the mail input field -->
-                <div v-for="(error, key) in errors" class="my-2">
-                    <InputError v-if="key != 'body'" :message="error" />
-                </div>
-                <!-- message -->
-                <div class="mb-4">
+            <div class="p-6">
+                <!-- input for building email array -->
+                <div class="mb-4 w-full">
                     <label
+                        for="recipient"
                         class="text-lg font-medium text-gray-900"
                     >
-                        And a message for them:
+                        Enter the addresses of who you wish to invite:
                     </label>
-                    <textarea
-                        class="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-                        type="text"
-                        name="body"
-                        placeholder="Add a message to your invite"
+                    <input
+                        id="recipient"
+                        class="rounded-l-md border-gray-300 shadow-sm"
+                        type="email"
+                        name="recipient"
+                        v-model="recipient"
+                        @keydown.enter.prevent="addRecipient($event.target.value)"
+                        placeholder="Enter email & press enter"
+                        style="border-right:none;width:calc(100% - 37px)"
                     >
-                    </textarea>
-                    <InputError class="mt-2" v-if="errors.body" :message="errors.body" />
-                </div>
-                <div class="flex flex-row mt-4 justify-center sm:justify-end w-full">
-                    <SecondaryButton 
+                    <button
                         type="button"
-                        @click="openModal = false"
-                    >
-                        Cancel
-                    </SecondaryButton>
-                    <PrimaryButton
-                        type="submit"
-                    >
-                        Send
-                    </PrimaryButton>
+                        class="px-2 rounded-r-md border border-gray-300 shadow-sm"
+                        style="height:42px;border-left:none"
+                        @click="recipient = ''"
+                        >
+                        <i
+                            class="fa-solid fa-x mx-1 fa-xs"
+                        ></i>
+                    </button>
                 </div>
-            </Form>
-        </div>
+                <InputError class="mt-2" :message="recipientError" />
+                <!-- actual form for submission -->
+                <Form
+                    :action="route('invite.send')" 
+                    method="post" 
+                    #default="{ errors }"
+                    @success="openModal = false"
+                    resetOnSuccess
+                    :transform="data => ({ 
+                        ...data, 
+                        recipients: recipients,
+                        group_id: props.group.id,
+                        user_id: usePage().props.auth.user.id,
+                    })"
+                >
+                    <!-- recipient badges -->
+                    <div class="mb-4">
+                        <span 
+                            v-for="recipient in recipients"
+                            class="items-center rounded-md border border-black p-1 bg-gray-900 text-white font-semibold my-1 mr-1"
+                            style="display:inline-block;word-break:break-word"
+                            >
+                            {{ recipient }}
+                            <i
+                                class="fa-solid fa-x mx-1 fa-xs"
+                                @click="removeRecipient(recipient)"
+                            ></i>
+                        </span>
+                    </div>
+                    <!-- recipient errors -->
+                    <div class="my-2">
+                        <InputError v-if="errors.pending" :message="errors.pending" />
+                        <InputError v-if="errors.existing" :message="errors.existing" />
+                    </div>
+                    <!-- message -->
+                    <div class="mb-4">
+                        <label
+                            class="text-lg font-medium text-gray-900"
+                        >
+                            And a message for them:
+                        </label>
+                        <textarea
+                            class="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                            type="text"
+                            name="body"
+                            placeholder="Add a message to your invite"
+                        >
+                        </textarea>
+                        <InputError class="mt-2" v-if="errors.body" :message="errors.body" />
+                    </div>
+                    <div class="flex flex-row mt-4 justify-center sm:justify-end w-full">
+                        <SecondaryButton 
+                            type="button"
+                            @click="openModal = false"
+                        >
+                            Cancel
+                        </SecondaryButton>
+                        <PrimaryButton
+                            type="submit"
+                        >
+                            Send
+                        </PrimaryButton>
+                    </div>
+                </Form>
+            </div>
         </Modal>
     </div>
 </template>

--- a/resources/js/Components/Invites/InviteToGroup.vue
+++ b/resources/js/Components/Invites/InviteToGroup.vue
@@ -117,8 +117,8 @@ function removeRecipient(emailAddress) {
                     </span>
                 </div>
                 <!-- just so this appears to be an error for the mail input field -->
-                <div v-for="(error, key) in errors" class="mb-4">
-                    <InputError v-if="key != 'body'" class="mt-2" :message="error" />
+                <div v-for="(error, key) in errors" class="my-2">
+                    <InputError v-if="key != 'body'" :message="error" />
                 </div>
                 <!-- message -->
                 <div class="mb-4">

--- a/tests/Feature/Http/Controllers/InviteControllerTest.php
+++ b/tests/Feature/Http/Controllers/InviteControllerTest.php
@@ -37,6 +37,9 @@ test('user can invite someone to the group if they are the owner', function() {
         'body' => 'hey join this group',
     ]);
 
+    Mail::assertQueued(InviteToGroup::class, 'randomguy@example.com');
+    Mail::assertQueuedCount(1);
+
     $response->assertStatus(302)
         ->assertSessionHas('status', '1 invite sent successfully.')
         ->assertSessionHasNoErrors();
@@ -47,9 +50,6 @@ test('user can invite someone to the group if they are the owner', function() {
         'recipient'=> 'randomguy@example.com',
         'body' => 'hey join this group',
     ]);
-    
-    Mail::assertQueued(InviteToGroup::class, 'randomguy@example.com');
-    Mail::assertQueuedCount(1);
 });
 
 test('user can invite someone to the group if they are not the owner', function() {
@@ -222,7 +222,7 @@ test('a user can not send an invite link to a user who is already in the group',
     $recipient = $this->group->users->last();
     
     $this->actingAs($sender);
-    
+
     $response = $this->post(route('invite.send'), [
         'group_id' => $this->group->id,
         'user_id' => $sender->id,
@@ -232,7 +232,7 @@ test('a user can not send an invite link to a user who is already in the group',
     
     $response->assertStatus(302)
         ->assertSessionHasErrors([
-            'recipients.0' => "The user with email {$recipient->email} is already a member of the group."
+            'existing' => "The following recipients are already in the group: {$recipient->email}"
         ]);
 });
 
@@ -253,7 +253,6 @@ test('user clicking on the invite link after accepting it logs them in and redir
     $this->actingAs($user);
 
     $response = $this->get('/invite/accept/' . $invite->token);
-    dump($response->getSession()->all());
 
     $this->assertDatabaseHas('invites', [
         'id' => $invite->id,
@@ -300,7 +299,7 @@ test('user can not invite an address who has a pending invite for that group', f
     
     $response->assertStatus(302)
         ->assertSessionHasErrors([
-            'recipients.0' => "There is already a pending invite to dupeguy@example.com for this group."
+            'pending' => "The following recipients have pending invites: dupeguy@example.com"
     ]);
 });
 


### PR DESCRIPTION
The main objective of this PR is to rework invites, using improved knowledge in how events, listeners and queues work. Additionally, I'll look at improving areas of the invite logic that can be improved. Checklist of what's been done so far:

- Sending and invite now uses an event/listener pattern.
- Checks for existing invites have been improved.. though now thinking about it this may be better served in the middleware.
- Fixed the dodgy test, though this is contingent on the previously mentioned points on middleware. Basically, the `Auth::user()` session was happening first in the middleware, then being regenerated when hitting the controller. Essentially, the user is being redirected twice.
- Improved error returns.

The more I've looked into this, the more I've realised a lot of the process needs to be redone from a wider scope. The middleware should be the only place where checks for invite expiry exist. Alternatively, links could be generated with `URL::temporarySignedRoute` and invites then don't need to expire if the link stops existing in the first place. 

Update: Gonna close this PR off for now and keep it as just reworking the logic for sending invites using queues. Next PR will be for reworking accepting invites using `exceptions, signed routes etc. 