### PR TITLE
Notifications frontend

### DIFF
--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -96,11 +96,9 @@ class DebtController extends Controller
 
         $shareService->createDebtShares($validated['user_shares'], $debt);
 
+        // fire event to start chain that notifies users of debt creation
+        // event->listener->notif
         DebtCreated::dispatch($debt);
-
-        foreach ($debt->users as $user) {
-            $user->notify(new DebtCreatedNotification($debt));
-        };
 
         return redirect()->route('debt.index')->with('status', 'Debt created successfully.');
     }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -42,7 +42,7 @@ class HandleInertiaRequests extends Middleware
             'flash' => [
                 'status' => fn () => $request->session()->get('status'),
             ],
-            'notifications' => $user->unreadNotifications,
+            'notifications' => $user ? $user->unreadNotifications : [],
         ]);
     }
 }

--- a/app/Listeners/DebtCreatedListener.php
+++ b/app/Listeners/DebtCreatedListener.php
@@ -5,8 +5,9 @@ namespace App\Listeners;
 use App\Events\DebtCreated;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
+use App\Notifications\DebtCreatedNotification;
 
-class DebtCreatedNotification implements ShouldQueue
+class DebtCreatedListener implements ShouldQueue
 {
     /**
      * Create the event listener.
@@ -21,6 +22,10 @@ class DebtCreatedNotification implements ShouldQueue
      */
     public function handle(DebtCreated $event): void
     {
-
+        foreach ($event->debt->users as $user) {
+            // automatically broadcasts on the user channel in channels.php
+            // otherwise, you broadcast it in the event
+            $user->notify(new DebtCreatedNotification($event->debt));
+        };
     }
 }

--- a/app/Notifications/DebtCreatedNotification.php
+++ b/app/Notifications/DebtCreatedNotification.php
@@ -52,6 +52,9 @@ class DebtCreatedNotification extends Notification
     {
         return [
             'name' => $this->debt->name,
+            'amount' => $this->debt->amount,
+            'group_name' => $this->debt->group->name,
+            'owner' => $this->debt->user,
         ];
     }
 }

--- a/app/Notifications/DebtCreatedNotification.php
+++ b/app/Notifications/DebtCreatedNotification.php
@@ -8,7 +8,7 @@ use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use App\Models\Debt;
 
-class DebtCreatedNotification extends Notification
+class DebtCreatedNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
             - '${APP_PORT:-80}:80'
             - '${VITE_PORT:-5173}:${VITE_PORT:-5173}'
             - '8000:8000'
-            - '9000:9000'
+            - '8080:8080'
         environment:
             WWWUSER: '${WWWUSER}'
             LARAVEL_SAIL: 1
@@ -106,7 +106,7 @@ services:
         image: ghcr.io/buggregator/server:latest
         ports:
         # internal:app ports
-        - '8080:8000'
+        - '9000:8000'
         - '1025:1025'
         networks:
         - sail

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
-    "name": "html",
+    "name": "chopr",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "dependencies": {
-                "dinero.js": "^1.9.1"
+                "dinero.js": "^1.9.1",
+                "pinia": "^3.0.4"
             },
             "devDependencies": {
                 "@inertiajs/vue3": "^2.3.2",
@@ -41,7 +42,6 @@
             "version": "7.25.9",
             "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
             "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -51,7 +51,6 @@
             "version": "7.25.9",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
             "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -61,7 +60,6 @@
             "version": "7.26.3",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.3.tgz",
             "integrity": "sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/types": "^7.26.3"
@@ -77,7 +75,6 @@
             "version": "7.26.3",
             "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
             "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.25.9",
@@ -599,7 +596,6 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
             "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
@@ -1006,7 +1002,6 @@
             "version": "3.5.13",
             "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.13.tgz",
             "integrity": "sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.25.3",
@@ -1020,7 +1015,6 @@
             "version": "3.5.13",
             "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.13.tgz",
             "integrity": "sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@vue/compiler-core": "3.5.13",
@@ -1031,7 +1025,6 @@
             "version": "3.5.13",
             "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.13.tgz",
             "integrity": "sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.25.3",
@@ -1049,18 +1042,49 @@
             "version": "3.5.13",
             "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.13.tgz",
             "integrity": "sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@vue/compiler-dom": "3.5.13",
                 "@vue/shared": "3.5.13"
             }
         },
+        "node_modules/@vue/devtools-api": {
+            "version": "7.7.9",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
+            "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/devtools-kit": "^7.7.9"
+            }
+        },
+        "node_modules/@vue/devtools-kit": {
+            "version": "7.7.9",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
+            "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/devtools-shared": "^7.7.9",
+                "birpc": "^2.3.0",
+                "hookable": "^5.5.3",
+                "mitt": "^3.0.1",
+                "perfect-debounce": "^1.0.0",
+                "speakingurl": "^14.0.1",
+                "superjson": "^2.2.2"
+            }
+        },
+        "node_modules/@vue/devtools-shared": {
+            "version": "7.7.9",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
+            "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+            "license": "MIT",
+            "dependencies": {
+                "rfdc": "^1.4.1"
+            }
+        },
         "node_modules/@vue/reactivity": {
             "version": "3.5.13",
             "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.13.tgz",
             "integrity": "sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@vue/shared": "3.5.13"
@@ -1070,7 +1094,6 @@
             "version": "3.5.13",
             "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.13.tgz",
             "integrity": "sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "3.5.13",
@@ -1081,7 +1104,6 @@
             "version": "3.5.13",
             "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.13.tgz",
             "integrity": "sha512-dLaj94s93NYLqjLiyFzVs9X6dWhTdAlEAciC3Moq7gzAc13VJUdCnjjRurNM6uTLFATRHexHCTu/Xp3eW6yoog==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "3.5.13",
@@ -1094,7 +1116,6 @@
             "version": "3.5.13",
             "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.13.tgz",
             "integrity": "sha512-wAi4IRJV/2SAW3htkTlB+dHeRmpTiVIK1OGLWV1yeStVSebSQQOwGwIq0D3ZIoBj2C2qpgz5+vX9iEBkTdk5YA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@vue/compiler-ssr": "3.5.13",
@@ -1108,7 +1129,6 @@
             "version": "3.5.13",
             "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
             "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/ansi-regex": {
@@ -1243,6 +1263,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/birpc": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+            "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/brace-expansion": {
@@ -1578,6 +1607,21 @@
                 "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
             }
         },
+        "node_modules/copy-anything": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+            "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+            "license": "MIT",
+            "dependencies": {
+                "is-what": "^5.2.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/mesqueeb"
+            }
+        },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1610,7 +1654,6 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/debug": {
@@ -1731,7 +1774,6 @@
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
             "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.12"
@@ -1844,7 +1886,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
             "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-glob": {
@@ -2142,6 +2183,12 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/hookable": {
+            "version": "5.5.3",
+            "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+            "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+            "license": "MIT"
+        },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -2212,6 +2259,18 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.12.0"
+            }
+        },
+        "node_modules/is-what": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+            "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/mesqueeb"
             }
         },
         "node_modules/isexe": {
@@ -2337,7 +2396,6 @@
             "version": "0.30.17",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
             "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0"
@@ -2436,6 +2494,12 @@
                 "node": ">=16 || 14 >=14.17"
             }
         },
+        "node_modules/mitt": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+            "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+            "license": "MIT"
+        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2460,7 +2524,6 @@
             "version": "3.3.8",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
             "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -2576,11 +2639,16 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/perfect-debounce": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+            "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+            "license": "MIT"
+        },
         "node_modules/picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/picomatch": {
@@ -2606,6 +2674,27 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/pinia": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
+            "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/devtools-api": "^7.7.7"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/posva"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.5.0",
+                "vue": "^3.5.11"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/pirates": {
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
@@ -2620,7 +2709,6 @@
             "version": "8.4.49",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
             "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -2885,6 +2973,12 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/rfdc": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+            "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+            "license": "MIT"
+        },
         "node_modules/rollup": {
             "version": "4.30.1",
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.30.1.tgz",
@@ -3119,7 +3213,15 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
             "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/speakingurl": {
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+            "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -3250,6 +3352,18 @@
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/superjson": {
+            "version": "2.2.6",
+            "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+            "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+            "license": "MIT",
+            "dependencies": {
+                "copy-anything": "^4"
+            },
+            "engines": {
+                "node": ">=16"
             }
         },
         "node_modules/supports-color": {
@@ -3511,7 +3625,6 @@
             "version": "3.5.13",
             "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.13.tgz",
             "integrity": "sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@vue/compiler-dom": "3.5.13",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "vue": "^3.4.0"
     },
     "dependencies": {
-        "dinero.js": "^1.9.1"
+        "dinero.js": "^1.9.1",
+        "pinia": "^3.0.4"
     }
 }

--- a/resources/js/Components/Forms/Dropdown.vue
+++ b/resources/js/Components/Forms/Dropdown.vue
@@ -28,6 +28,7 @@ onUnmounted(() => document.removeEventListener('keydown', closeOnEscape));
 const widthClass = computed(() => {
     return {
         48: 'w-48',
+        80: 'w-80',
     }[props.width.toString()];
 });
 

--- a/resources/js/Components/Forms/Dropdown.vue
+++ b/resources/js/Components/Forms/Dropdown.vue
@@ -28,7 +28,7 @@ onUnmounted(() => document.removeEventListener('keydown', closeOnEscape));
 const widthClass = computed(() => {
     return {
         48: 'w-48',
-        80: 'w-80',
+        96: 'w-96',
     }[props.width.toString()];
 });
 

--- a/resources/js/Components/Notifications/MobileNotifications.vue
+++ b/resources/js/Components/Notifications/MobileNotifications.vue
@@ -1,5 +1,8 @@
 <script setup>
 import { computed, ref } from 'vue';
+import Notification from '@/Components/Notifications/Notification.vue';
+import Notifications from './Notifications.vue';
+
 const active = ref(false);
 
 // stolen from ResponsiveNavLink
@@ -14,7 +17,22 @@ const classes = computed(() =>
     <div>
         <p @click="active = !active" :class="classes">Notifications</p>
         <div v-if="active" class="ps-3 pe-4 py-2">
-            aaaa
+            <div v-if="Notifications.length === 0">
+
+            </div>
+            <div v-else>
+                <Notification v-for="notification in notifications"
+                    :notification="notification"
+                    @notificationRead="readNotification"
+                >
+                </Notification>
+                <button 
+                    class="block w-full px-4 py-2 text-center text-sm leading-5 text-blue-700 transition duration-150 ease-in-out hover:underline hover:cursor-pointer hover:bg-gray-100 focus:bg-gray-100 focus:outline-none"
+                    @click="readAllNotifications"
+                >
+                    Mark all as read
+                </button>
+            </div>
         </div>
     </div>
 </template>

--- a/resources/js/Components/Notifications/MobileNotifications.vue
+++ b/resources/js/Components/Notifications/MobileNotifications.vue
@@ -19,7 +19,17 @@ const classes = computed(() =>
 </script>
 <template>
     <div>
-        <p @click="active = !active" :class="classes">Notifications</p>
+        <div class="flex flex-row items-center justify-between" :class="classes" @click="active = !active">
+            <p>Notifications</p>
+            <div
+                class="bg-red-500 rounded-full flex items-center justify-center" 
+                :class="notifications.length > 0 ? 'visible' : 'invisible'" 
+                style="height:25px;width:25px"
+            >
+                <p v-if="notifications.length < 100" class="text-white text-center">{{ notifications.length }}</p>
+                <p v-else class="text-white text-center">100+</p>
+            </div>
+        </div>
         <div v-if="active" class="ps-3 pe-4 py-2">
             <div v-if="Notifications.length === 0">
                 <p>No notifications to show!</p>

--- a/resources/js/Components/Notifications/MobileNotifications.vue
+++ b/resources/js/Components/Notifications/MobileNotifications.vue
@@ -1,9 +1,11 @@
 <script setup>
-import { computed, ref } from 'vue';
+import { computed, ref, onMounted } from 'vue';
 import Notification from '@/Components/Notifications/Notification.vue';
 import Notifications from './Notifications.vue';
+import { useNotificationStore } from '@/Stores/NotificationStore.js';
 
 const active = ref(false);
+const notificationStore = useNotificationStore();
 
 // stolen from ResponsiveNavLink
 const classes = computed(() =>
@@ -11,6 +13,10 @@ const classes = computed(() =>
         ? 'block w-full ps-3 pe-4 py-2 border-l-4 border-indigo-400 text-start text-base font-medium text-indigo-700 bg-indigo-50 focus:outline-none focus:text-indigo-800 focus:bg-indigo-100 focus:border-indigo-700 transition duration-150 ease-in-out'
         : 'block w-full ps-3 pe-4 py-2 border-l-4 border-transparent text-start text-base font-medium text-gray-600 hover:text-gray-800 hover:bg-gray-50 hover:border-gray-300 focus:outline-none focus:text-gray-800 focus:bg-gray-50 focus:border-gray-300 transition duration-150 ease-in-out',
 );
+
+onMounted(() => {
+    console.log(notificationStore.notifications);
+});
 
 </script>
 <template>

--- a/resources/js/Components/Notifications/MobileNotifications.vue
+++ b/resources/js/Components/Notifications/MobileNotifications.vue
@@ -1,0 +1,20 @@
+<script setup>
+import { computed, ref } from 'vue';
+const active = ref(false);
+
+// stolen from ResponsiveNavLink
+const classes = computed(() =>
+    active.value
+        ? 'block w-full ps-3 pe-4 py-2 border-l-4 border-indigo-400 text-start text-base font-medium text-indigo-700 bg-indigo-50 focus:outline-none focus:text-indigo-800 focus:bg-indigo-100 focus:border-indigo-700 transition duration-150 ease-in-out'
+        : 'block w-full ps-3 pe-4 py-2 border-l-4 border-transparent text-start text-base font-medium text-gray-600 hover:text-gray-800 hover:bg-gray-50 hover:border-gray-300 focus:outline-none focus:text-gray-800 focus:bg-gray-50 focus:border-gray-300 transition duration-150 ease-in-out',
+);
+
+</script>
+<template>
+    <div>
+        <p @click="active = !active" :class="classes">Notifications</p>
+        <div v-if="active" class="ps-3 pe-4 py-2">
+            aaaa
+        </div>
+    </div>
+</template>

--- a/resources/js/Components/Notifications/MobileNotifications.vue
+++ b/resources/js/Components/Notifications/MobileNotifications.vue
@@ -1,11 +1,13 @@
 <script setup>
-import { computed, ref, onMounted } from 'vue';
+import { computed, ref } from 'vue';
 import Notification from '@/Components/Notifications/Notification.vue';
 import Notifications from './Notifications.vue';
 import { useNotificationStore } from '@/Stores/NotificationStore.js';
 
+const notifications = ref(useNotificationStore().notifications);
+
 const active = ref(false);
-const notificationStore = useNotificationStore();
+
 
 // stolen from ResponsiveNavLink
 const classes = computed(() =>
@@ -14,18 +16,15 @@ const classes = computed(() =>
         : 'block w-full ps-3 pe-4 py-2 border-l-4 border-transparent text-start text-base font-medium text-gray-600 hover:text-gray-800 hover:bg-gray-50 hover:border-gray-300 focus:outline-none focus:text-gray-800 focus:bg-gray-50 focus:border-gray-300 transition duration-150 ease-in-out',
 );
 
-onMounted(() => {
-    console.log(notificationStore.notifications);
-});
-
 </script>
 <template>
     <div>
         <p @click="active = !active" :class="classes">Notifications</p>
         <div v-if="active" class="ps-3 pe-4 py-2">
             <div v-if="Notifications.length === 0">
-
+                <p>No notifications to show!</p>
             </div>
+            <!-- todo: calc height of this or something -->
             <div v-else>
                 <Notification v-for="notification in notifications"
                     :notification="notification"

--- a/resources/js/Components/Notifications/MobileNotifications.vue
+++ b/resources/js/Components/Notifications/MobileNotifications.vue
@@ -30,7 +30,7 @@ const classes = computed(() =>
                 <p v-else class="text-white text-center">100+</p>
             </div>
         </div>
-        <div v-if="active" class="ps-3 pe-4 py-2">
+        <div v-if="active" class="ps-3 pe-4 py-2" style="height:50vh;overflow-y:scroll;">
             <div v-if="Notifications.length === 0">
                 <p>No notifications to show!</p>
             </div>

--- a/resources/js/Components/Notifications/Notification.vue
+++ b/resources/js/Components/Notifications/Notification.vue
@@ -16,7 +16,7 @@ onMounted(() => {
 
 <template>
     <div class="block w-full px-4 py-2 text-start text-sm leading-5 text-gray-700 transition duration-150 ease-in-out hover:bg-gray-100 focus:bg-gray-100 focus:outline-none">
-        <p>{{ notification.data.name }}</p>
+        <p>You have been added to a debt of £{{ notification.data.amount.amount }} for {{ notification.data.name }} in <b>{{ notification.data.group_name }}</b> by {{ notification.data.owner.name }}</p>
     </div>
 </template>
 <style>

--- a/resources/js/Components/Notifications/Notification.vue
+++ b/resources/js/Components/Notifications/Notification.vue
@@ -25,18 +25,19 @@ function readNotification() {
 }
 
 onMounted(() => {
-
+    console.log(props.notification.type);
 })
 
 </script>
 
 <template>
-    <div class="block w-full px-4 py-2 text-start text-sm leading-5 text-gray-700 transition duration-150 ease-in-out hover:bg-gray-100 focus:bg-gray-100 focus:outline-none">
-        <p
-            @click="readNotification"
-        >
+    <div class="flex flex-row items-center w-full py-2 text-start text-sm leading-5 text-gray-700 transition duration-150 ease-in-out hover:bg-gray-100 focus:bg-gray-100 focus:outline-none">
+        
+        <i class="fa-solid fa-x px-4"></i>
+        <p>
             You have been added to a debt of <b>£{{ notification.data.amount.amount }}</b> for <b>{{ notification.data.name }}</b> in {{ notification.data.group_name }} by <b>{{ notification.data.owner.name }}</b>
         </p>
+        <i class="fa-solid fa-x px-2 hover:cursor-pointer hover:bg-gray-200 rounded-full text-center" style="height:20px;width:20px" @click="readNotification"></i>
     </div>
 </template>
 <style>

--- a/resources/js/Components/Notifications/Notification.vue
+++ b/resources/js/Components/Notifications/Notification.vue
@@ -16,7 +16,7 @@ onMounted(() => {
 
 <template>
     <div class="block w-full px-4 py-2 text-start text-sm leading-5 text-gray-700 transition duration-150 ease-in-out hover:bg-gray-100 focus:bg-gray-100 focus:outline-none">
-        <p>You have been added to a debt of £{{ notification.data.amount.amount }} for {{ notification.data.name }} in <b>{{ notification.data.group_name }}</b> by {{ notification.data.owner.name }}</p>
+        <p>You have been added to a debt of <b>£{{ notification.data.amount.amount }}</b> for <b>{{ notification.data.name }}</b> in {{ notification.data.group_name }} by <b>{{ notification.data.owner.name }}</b></p>
     </div>
 </template>
 <style>

--- a/resources/js/Components/Notifications/Notification.vue
+++ b/resources/js/Components/Notifications/Notification.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, onMounted, watch } from 'vue';
+import { ref, onMounted, watch, computed } from 'vue';
 import { usePage, router } from '@inertiajs/vue3';
 
 const emit = defineEmits(['notificationRead']);
@@ -24,8 +24,20 @@ function readNotification() {
     )
 }
 
+const iconClass = computed(() => {
+    const type = props.notification.type;
+    
+    if (type.includes('Debt')) {
+        return 'fa-list text-green-300';
+    } else if (type.includes('Group')) {
+        return 'fa-users text-blue-300';
+    } else if (type.includes('Share')) {
+        return 'fa-chart-pie text-orange-300';
+    }
+});
+
 onMounted(() => {
-    console.log(props.notification.type);
+    console.log(iconClass.value);
 })
 
 </script>
@@ -33,7 +45,7 @@ onMounted(() => {
 <template>
     <div class="flex flex-row items-center w-full py-2 text-start text-sm leading-5 text-gray-700 transition duration-150 ease-in-out hover:bg-gray-100 focus:bg-gray-100 focus:outline-none">
         
-        <i class="fa-solid fa-x px-4"></i>
+        <i class="fa-solid px-4" :class="iconClass"></i>
         <p>
             You have been added to a debt of <b>£{{ notification.data.amount.amount }}</b> for <b>{{ notification.data.name }}</b> in {{ notification.data.group_name }} by <b>{{ notification.data.owner.name }}</b>
         </p>

--- a/resources/js/Components/Notifications/Notification.vue
+++ b/resources/js/Components/Notifications/Notification.vue
@@ -20,7 +20,5 @@ onMounted(() => {
     </div>
 </template>
 <style>
-.notification:hover {
-    background-color: rgb(55 65 81 / var(--tw-text-opacity, 1));
-}
+
 </style>

--- a/resources/js/Components/Notifications/Notification.vue
+++ b/resources/js/Components/Notifications/Notification.vue
@@ -1,5 +1,8 @@
 <script setup>
 import { ref, onMounted, watch } from 'vue';
+import { usePage, router } from '@inertiajs/vue3';
+
+const emit = defineEmits(['notificationRead']);
 
 const props = defineProps({
     notification: {
@@ -7,6 +10,20 @@ const props = defineProps({
         required: true,
     }
 })
+
+function readNotification() {
+    console.log('aa2');
+    router.post(
+        `/notifications/read/${props.notification.id}`, 
+        {},
+        {
+            preserveScroll: true,
+            onSuccess: () => {
+                emit('notificationRead', props.notification.id)
+            },
+        },
+    )
+}
 
 onMounted(() => {
     console.log(props.notification);
@@ -16,7 +33,11 @@ onMounted(() => {
 
 <template>
     <div class="block w-full px-4 py-2 text-start text-sm leading-5 text-gray-700 transition duration-150 ease-in-out hover:bg-gray-100 focus:bg-gray-100 focus:outline-none">
-        <p>You have been added to a debt of <b>£{{ notification.data.amount.amount }}</b> for <b>{{ notification.data.name }}</b> in {{ notification.data.group_name }} by <b>{{ notification.data.owner.name }}</b></p>
+        <p
+            @click="readNotification"
+        >
+            You have been added to a debt of <b>£{{ notification.data.amount.amount }}</b> for <b>{{ notification.data.name }}</b> in {{ notification.data.group_name }} by <b>{{ notification.data.owner.name }}</b>
+        </p>
     </div>
 </template>
 <style>

--- a/resources/js/Components/Notifications/Notification.vue
+++ b/resources/js/Components/Notifications/Notification.vue
@@ -43,13 +43,19 @@ onMounted(() => {
 </script>
 
 <template>
-    <div class="flex flex-row items-center w-full py-2 text-start text-sm leading-5 text-gray-700 transition duration-150 ease-in-out hover:bg-gray-100 focus:bg-gray-100 focus:outline-none">
+    <div class="flex flex-row items-center w-full py-2 text-start text-sm leading-5 text-gray-700 border-b border-gray-100 transition duration-150 ease-in-out hover:bg-gray-100 focus:bg-gray-100 focus:outline-none">
         
         <i class="fa-solid px-4" :class="iconClass"></i>
         <p>
             You have been added to a debt of <b>£{{ notification.data.amount.amount }}</b> for <b>{{ notification.data.name }}</b> in {{ notification.data.group_name }} by <b>{{ notification.data.owner.name }}</b>
         </p>
-        <i class="fa-solid fa-x px-2 hover:cursor-pointer hover:bg-gray-200 rounded-full text-center" style="height:20px;width:20px" @click="readNotification"></i>
+        <svg class=" p-1 ml-2 mr-6 block shrink-0 aspect-square hover:cursor-pointer hover:bg-gray-200 rounded-full"
+            width="25" height="25" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"
+            @click="readNotification"
+        >
+            <line x1="10" y1="10" x2="90" y2="90" stroke="gray" stroke-width="15" stroke-linecap="round"/>
+            <line x1="90" y1="10" x2="10" y2="90" stroke="gray" stroke-width="15" stroke-linecap="round"/>
+        </svg>
     </div>
 </template>
 <style>

--- a/resources/js/Components/Notifications/Notification.vue
+++ b/resources/js/Components/Notifications/Notification.vue
@@ -12,21 +12,17 @@ const props = defineProps({
 })
 
 function readNotification() {
-    console.log('aa2');
     router.post(
         `/notifications/read/${props.notification.id}`, 
         {},
         {
             preserveScroll: true,
-            onSuccess: () => {
-                emit('notificationRead', props.notification.id)
-            },
         },
     )
 }
 
 onMounted(() => {
-    console.log(props.notification);
+
 })
 
 </script>

--- a/resources/js/Components/Notifications/Notification.vue
+++ b/resources/js/Components/Notifications/Notification.vue
@@ -1,0 +1,26 @@
+<script setup>
+import { ref, onMounted, watch } from 'vue';
+
+const props = defineProps({
+    notification: {
+        type: Object,
+        required: true,
+    }
+})
+
+onMounted(() => {
+    console.log(props.notification);
+})
+
+</script>
+
+<template>
+    <div class="block w-full px-4 py-2 text-start text-sm leading-5 text-gray-700 transition duration-150 ease-in-out hover:bg-gray-100 focus:bg-gray-100 focus:outline-none">
+        <p>{{ notification.data.name }}</p>
+    </div>
+</template>
+<style>
+.notification:hover {
+    background-color: rgb(55 65 81 / var(--tw-text-opacity, 1));
+}
+</style>

--- a/resources/js/Components/Notifications/Notification.vue
+++ b/resources/js/Components/Notifications/Notification.vue
@@ -37,7 +37,7 @@ const iconClass = computed(() => {
 });
 
 onMounted(() => {
-    console.log(iconClass.value);
+
 })
 
 </script>

--- a/resources/js/Components/Notifications/Notification.vue
+++ b/resources/js/Components/Notifications/Notification.vue
@@ -12,7 +12,6 @@ const props = defineProps({
 })
 
 function readNotification() {
-    console.log('aa2');
     router.post(
         `/notifications/read/${props.notification.id}`, 
         {},
@@ -26,7 +25,7 @@ function readNotification() {
 }
 
 onMounted(() => {
-    console.log(props.notification);
+
 })
 
 </script>

--- a/resources/js/Components/Notifications/Notification.vue
+++ b/resources/js/Components/Notifications/Notification.vue
@@ -12,17 +12,21 @@ const props = defineProps({
 })
 
 function readNotification() {
+    console.log('aa2');
     router.post(
         `/notifications/read/${props.notification.id}`, 
         {},
         {
             preserveScroll: true,
+            onSuccess: () => {
+                emit('notificationRead', props.notification.id)
+            },
         },
     )
 }
 
 onMounted(() => {
-
+    console.log(props.notification);
 })
 
 </script>

--- a/resources/js/Components/Notifications/Notifications.vue
+++ b/resources/js/Components/Notifications/Notifications.vue
@@ -48,7 +48,14 @@ function readNotification(notificationId) {
                 class="text-center inline-flex items-center rounded-md border border-transparent bg-white px-3 py-2 text-sm font-medium leading-4 text-gray-500 transition duration-150 ease-in-out hover:text-gray-700 focus:outline-none"
             >
                 <i class="fa-solid fa-circle-exclamation text-2xl text-gray-400"></i>
-                <p class="text-white bg-red-500 p-1 rounded-full text-center" style="height:25px;width:25px;position:relative;right:10px;bottom:10px" :class="notifications.length > 0 ? 'visible' : 'invisible'">{{ notifications.length }}</p>
+                <div
+                    class="bg-red-500 rounded-full flex items-center justify-center" 
+                    :class="notifications.length > 0 ? 'visible' : 'invisible'" 
+                    style="position:relative;right:10px;bottom:10px;height:25px;width:25px"
+                >
+                    <p v-if="notifications.length < 100" class="text-white text-center">{{ notifications.length }}</p>
+                    <p v-else class="text-white text-center">100+</p>
+                </div>
             </button>
         </template>
         <template #content v-if="notifications.length === 0">

--- a/resources/js/Components/Notifications/Notifications.vue
+++ b/resources/js/Components/Notifications/Notifications.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref } from 'vue';
+import { ref, watch } from 'vue';
 import { usePage, router } from '@inertiajs/vue3';
 import { useEchoNotification } from "@laravel/echo-vue";
 import Notification from '@/Components/Notifications/Notification.vue';
@@ -10,12 +10,7 @@ const notifications = ref(usePage().props.notifications);
 useEchoNotification(
     `App.Models.User.${usePage().props.auth.user.id}`,
     (notification) => {
-        // structure the notification the same way they are taken from db
-        const dataNotification = {
-            'data' : notification
-        };
 
-        notifications.value.push(dataNotification);
     },
 );
 
@@ -25,17 +20,16 @@ function readAllNotifications() {
         {},
         {
             preserveScroll: true,
-            onSuccess: () => {
-                notifications.value = [];
-            },
         },
     )
 }
 
-function readNotification(notificationId) {
-    notifications.value = notifications.value.filter((notif) => notif.id !== notificationId);
-    console.log('a2', notifications.value);
-}
+watch(
+    () => usePage().props.notifications,
+    (notifs) => {
+        notifications.value = notifs;
+    }
+)
 
 </script>
 <template>
@@ -60,13 +54,12 @@ function readNotification(notificationId) {
         <template #content v-else>
             <Notification v-for="notification in notifications"
                 :notification="notification"
-                @notificationRead="readNotification"
             >
             </Notification>
             <button 
                 class="block w-full px-4 py-2 text-center text-sm leading-5 text-blue-700 transition duration-150 ease-in-out hover:underline hover:cursor-pointer hover:bg-gray-100 focus:bg-gray-100 focus:outline-none"
                 @click="readAllNotifications"
-            >
+                >
                 Mark all as read
             </button>
         </template>

--- a/resources/js/Components/Notifications/Notifications.vue
+++ b/resources/js/Components/Notifications/Notifications.vue
@@ -29,7 +29,8 @@ useEchoNotification(
                 type="button"
                 class="text-center inline-flex items-center rounded-md border border-transparent bg-white px-3 py-2 text-sm font-medium leading-4 text-gray-500 transition duration-150 ease-in-out hover:text-gray-700 focus:outline-none"
             >
-                <i class="fa-solid fa-circle-exclamation text-2xl text-gray-400"></i>
+                <i v-if="notifications.length > 0" class="fa-solid fa-circle-exclamation text-2xl text-gray-400"></i>
+                <p class="flex justify-center text-white bg-red-500 p-1 rounded-full text-center" style="height:25px;width:25px;position:relative;right:10px;bottom:10px">{{ notifications.length }}</p>
             </button>
         </template>
         <template #content v-if="notifications.length === 0">

--- a/resources/js/Components/Notifications/Notifications.vue
+++ b/resources/js/Components/Notifications/Notifications.vue
@@ -29,8 +29,8 @@ useEchoNotification(
                 type="button"
                 class="text-center inline-flex items-center rounded-md border border-transparent bg-white px-3 py-2 text-sm font-medium leading-4 text-gray-500 transition duration-150 ease-in-out hover:text-gray-700 focus:outline-none"
             >
-                <i v-if="notifications.length > 0" class="fa-solid fa-circle-exclamation text-2xl text-gray-400"></i>
-                <p class="flex justify-center text-white bg-red-500 p-1 rounded-full text-center" style="height:25px;width:25px;position:relative;right:10px;bottom:10px">{{ notifications.length }}</p>
+                <i class="fa-solid fa-circle-exclamation text-2xl text-gray-400"></i>
+                <p class="flex justify-center text-white bg-red-500 p-1 rounded-full text-center" style="height:25px;width:25px;position:relative;right:10px;bottom:10px" :class="notifications.length > 0 ? 'visible' : 'invisible'">{{ notifications.length }}</p>
             </button>
         </template>
         <template #content v-if="notifications.length === 0">

--- a/resources/js/Components/Notifications/Notifications.vue
+++ b/resources/js/Components/Notifications/Notifications.vue
@@ -32,6 +32,11 @@ function readAllNotifications() {
     )
 }
 
+function readNotification(notificationId) {
+    notifications.value = notifications.value.filter((notif) => notif.id !== notificationId);
+    console.log('a2', notifications.value);
+}
+
 </script>
 <template>
     <Dropdown 
@@ -55,6 +60,7 @@ function readAllNotifications() {
         <template #content v-else>
             <Notification v-for="notification in notifications"
                 :notification="notification"
+                @notificationRead="readNotification"
             >
             </Notification>
             <button 

--- a/resources/js/Components/Notifications/Notifications.vue
+++ b/resources/js/Components/Notifications/Notifications.vue
@@ -40,7 +40,7 @@ function readNotification(notificationId) {
 <template>
     <Dropdown 
         align="right"
-        width="80"
+        width="96"
     >
         <template #trigger>
             <button

--- a/resources/js/Components/Notifications/Notifications.vue
+++ b/resources/js/Components/Notifications/Notifications.vue
@@ -1,23 +1,12 @@
 <script setup>
 import { ref } from 'vue';
-import { usePage, router } from '@inertiajs/vue3';
-import { useEchoNotification } from "@laravel/echo-vue";
+import { router } from '@inertiajs/vue3';
 import Notification from '@/Components/Notifications/Notification.vue';
 import Dropdown from '@/Components/Forms/Dropdown.vue';
+import { useNotificationStore } from '@/Stores/NotificationStore.js';
 
-const notifications = ref(usePage().props.notifications);
-
-useEchoNotification(
-    `App.Models.User.${usePage().props.auth.user.id}`,
-    (notification) => {
-        notifications.value.unshift({
-            id: notification.id,
-            type: notification.type,
-            data: notification,
-            read_at: null,
-        });
-    },
-);
+// set a ref from the store
+const notifications = ref(useNotificationStore().notifications);
 
 function readAllNotifications() {
     router.post(

--- a/resources/js/Components/Notifications/Notifications.vue
+++ b/resources/js/Components/Notifications/Notifications.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, watch } from 'vue';
+import { ref } from 'vue';
 import { usePage, router } from '@inertiajs/vue3';
 import { useEchoNotification } from "@laravel/echo-vue";
 import Notification from '@/Components/Notifications/Notification.vue';
@@ -10,7 +10,12 @@ const notifications = ref(usePage().props.notifications);
 useEchoNotification(
     `App.Models.User.${usePage().props.auth.user.id}`,
     (notification) => {
+        // structure the notification the same way they are taken from db
+        const dataNotification = {
+            'data' : notification
+        };
 
+        notifications.value.push(dataNotification);
     },
 );
 
@@ -20,16 +25,17 @@ function readAllNotifications() {
         {},
         {
             preserveScroll: true,
+            onSuccess: () => {
+                notifications.value = [];
+            },
         },
     )
 }
 
-watch(
-    () => usePage().props.notifications,
-    (notifs) => {
-        notifications.value = notifs;
-    }
-)
+function readNotification(notificationId) {
+    notifications.value = notifications.value.filter((notif) => notif.id !== notificationId);
+    console.log('a2', notifications.value);
+}
 
 </script>
 <template>
@@ -54,12 +60,13 @@ watch(
         <template #content v-else>
             <Notification v-for="notification in notifications"
                 :notification="notification"
+                @notificationRead="readNotification"
             >
             </Notification>
             <button 
                 class="block w-full px-4 py-2 text-center text-sm leading-5 text-blue-700 transition duration-150 ease-in-out hover:underline hover:cursor-pointer hover:bg-gray-100 focus:bg-gray-100 focus:outline-none"
                 @click="readAllNotifications"
-                >
+            >
                 Mark all as read
             </button>
         </template>

--- a/resources/js/Components/Notifications/Notifications.vue
+++ b/resources/js/Components/Notifications/Notifications.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref } from 'vue';
-import { usePage } from '@inertiajs/vue3';
+import { usePage, router } from '@inertiajs/vue3';
 import { useEchoNotification } from "@laravel/echo-vue";
 import Notification from '@/Components/Notifications/Notification.vue';
 import Dropdown from '@/Components/Forms/Dropdown.vue';
@@ -18,6 +18,20 @@ useEchoNotification(
         notifications.value.push(dataNotification);
     },
 );
+
+function readAllNotifications() {
+    router.post(
+        '/notifications/read-all', 
+        {},
+        {
+            preserveScroll: true,
+            onSuccess: () => {
+                notifications.value = [];
+            },
+        },
+    )
+}
+
 </script>
 <template>
     <Dropdown 
@@ -43,6 +57,12 @@ useEchoNotification(
                 :notification="notification"
             >
             </Notification>
+            <button 
+                class="block w-full px-4 py-2 text-center text-sm leading-5 text-blue-700 transition duration-150 ease-in-out hover:underline hover:cursor-pointer hover:bg-gray-100 focus:bg-gray-100 focus:outline-none"
+                @click="readAllNotifications"
+            >
+                Mark all as read
+            </button>
         </template>
     </Dropdown>
 </template>

--- a/resources/js/Components/Notifications/Notifications.vue
+++ b/resources/js/Components/Notifications/Notifications.vue
@@ -43,6 +43,7 @@ function readNotification(notificationId) {
         width="96"
     >
         <template #trigger>
+            <p>test 2</p>
             <button
                 type="button"
                 class="text-center inline-flex items-center rounded-md border border-transparent bg-white px-3 py-2 text-sm font-medium leading-4 text-gray-500 transition duration-150 ease-in-out hover:text-gray-700 focus:outline-none"
@@ -64,6 +65,7 @@ function readNotification(notificationId) {
             </p>
         </template>
         <template #content v-else>
+            <p>test3 </p>
             <div style="max-height:50vh;overflow-y:scroll;">
                 <Notification v-for="notification in notifications"
                     :notification="notification"

--- a/resources/js/Components/Notifications/Notifications.vue
+++ b/resources/js/Components/Notifications/Notifications.vue
@@ -43,7 +43,6 @@ function readNotification(notificationId) {
         width="96"
     >
         <template #trigger>
-            <p>test 2</p>
             <button
                 type="button"
                 class="text-center inline-flex items-center rounded-md border border-transparent bg-white px-3 py-2 text-sm font-medium leading-4 text-gray-500 transition duration-150 ease-in-out hover:text-gray-700 focus:outline-none"
@@ -65,7 +64,6 @@ function readNotification(notificationId) {
             </p>
         </template>
         <template #content v-else>
-            <p>test3 </p>
             <div style="max-height:50vh;overflow-y:scroll;">
                 <Notification v-for="notification in notifications"
                     :notification="notification"

--- a/resources/js/Components/Notifications/Notifications.vue
+++ b/resources/js/Components/Notifications/Notifications.vue
@@ -48,7 +48,7 @@ function readNotification(notificationId) {
                 class="text-center inline-flex items-center rounded-md border border-transparent bg-white px-3 py-2 text-sm font-medium leading-4 text-gray-500 transition duration-150 ease-in-out hover:text-gray-700 focus:outline-none"
             >
                 <i class="fa-solid fa-circle-exclamation text-2xl text-gray-400"></i>
-                <p class="flex justify-center text-white bg-red-500 p-1 rounded-full text-center" style="height:25px;width:25px;position:relative;right:10px;bottom:10px" :class="notifications.length > 0 ? 'visible' : 'invisible'">{{ notifications.length }}</p>
+                <p class="text-white bg-red-500 p-1 rounded-full text-center" style="height:25px;width:25px;position:relative;right:10px;bottom:10px" :class="notifications.length > 0 ? 'visible' : 'invisible'">{{ notifications.length }}</p>
             </button>
         </template>
         <template #content v-if="notifications.length === 0">
@@ -57,11 +57,13 @@ function readNotification(notificationId) {
             </p>
         </template>
         <template #content v-else>
-            <Notification v-for="notification in notifications"
-                :notification="notification"
-                @notificationRead="readNotification"
-            >
-            </Notification>
+            <div style="max-height:50vh;overflow-y:scroll;">
+                <Notification v-for="notification in notifications"
+                    :notification="notification"
+                    @notificationRead="readNotification"
+                >
+                </Notification>
+            </div>
             <button 
                 class="block w-full px-4 py-2 text-center text-sm leading-5 text-blue-700 transition duration-150 ease-in-out hover:underline hover:cursor-pointer hover:bg-gray-100 focus:bg-gray-100 focus:outline-none"
                 @click="readAllNotifications"

--- a/resources/js/Components/Notifications/Notifications.vue
+++ b/resources/js/Components/Notifications/Notifications.vue
@@ -1,0 +1,47 @@
+<script setup>
+import { ref } from 'vue';
+import { usePage } from '@inertiajs/vue3';
+import { useEchoNotification } from "@laravel/echo-vue";
+import Notification from '@/Components/Notifications/Notification.vue';
+import Dropdown from '@/Components/Forms/Dropdown.vue';
+
+const notifications = ref(usePage().props.notifications);
+
+useEchoNotification(
+    `App.Models.User.${usePage().props.auth.user.id}`,
+    (notification) => {
+        // structure the notification the same way they are taken from db
+        const dataNotification = {
+            'data' : notification
+        };
+
+        notifications.value.push(dataNotification);
+    },
+);
+</script>
+<template>
+    <Dropdown 
+        align="right"
+        width="80"
+    >
+        <template #trigger>
+            <button
+                type="button"
+                class="text-center inline-flex items-center rounded-md border border-transparent bg-white px-3 py-2 text-sm font-medium leading-4 text-gray-500 transition duration-150 ease-in-out hover:text-gray-700 focus:outline-none"
+            >
+                <i class="fa-solid fa-circle-exclamation text-2xl text-gray-400"></i>
+            </button>
+        </template>
+        <template #content v-if="notifications.length === 0">
+            <p class="block w-full px-4 py-2 text-start text-sm leading-5 text-gray-700 transition duration-150 ease-in-out hover:bg-gray-100 focus:bg-gray-100 focus:outline-none">
+                You have no new notifications
+            </p>
+        </template>
+        <template #content v-else>
+            <Notification v-for="notification in notifications"
+                :notification="notification"
+            >
+            </Notification>
+        </template>
+    </Dropdown>
+</template>

--- a/resources/js/Components/Notifications/Notifications.vue
+++ b/resources/js/Components/Notifications/Notifications.vue
@@ -10,12 +10,12 @@ const notifications = ref(usePage().props.notifications);
 useEchoNotification(
     `App.Models.User.${usePage().props.auth.user.id}`,
     (notification) => {
-        // structure the notification the same way they are taken from db
-        const dataNotification = {
-            'data' : notification
-        };
-
-        notifications.value.push(dataNotification);
+        notifications.value.unshift({
+            id: notification.id,
+            type: notification.type,
+            data: notification,
+            read_at: null,
+        });
     },
 );
 
@@ -34,7 +34,6 @@ function readAllNotifications() {
 
 function readNotification(notificationId) {
     notifications.value = notifications.value.filter((notif) => notif.id !== notificationId);
-    console.log('a2', notifications.value);
 }
 
 </script>

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -9,6 +9,7 @@ import Toast from '@/Components/Misc/Toast.vue';
 import { Link, usePage } from '@inertiajs/vue3';
 import { currencies } from '@/currencies.js';
 import Notifications from '@/Components/Notifications/Notifications.vue';
+import MobileNotifications from '@/Components/Notifications/MobileNotifications.vue';
 
 const props = defineProps({
     status: {
@@ -169,7 +170,7 @@ const showingNavigationDropdown = ref(false);
                             </div>
 
                             <!-- Notifications -->
-                            <Notifications />
+                            <Notifications class="hidden sm:flex" />
                         </div>
                     </div>
                 </div>
@@ -223,6 +224,7 @@ const showingNavigationDropdown = ref(false);
                             >
                                 Log Out
                             </ResponsiveNavLink>
+                            <MobileNotifications />
                         </div>
                     </div>
                 </div>

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -22,7 +22,7 @@ const props = defineProps({
 const user_balance = ref(usePage().props.auth.user.user_balance.amount);
 
 onMounted(() => {
-    console.log(usePage().props);
+
 });
 
 watch( () => usePage().props.auth.user.user_balance, (newBalance) => {

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -23,8 +23,12 @@ const notifications = ref(usePage().props.notifications);
 useEchoNotification(
     `App.Models.User.${usePage().props.auth.user.id}`,
     (notification) => {
-        console.log(notification);
-        notifications.value.push(notification);
+        // structure the notification the same way they are taken from db
+        const dataNotification = {
+            'data' : notification
+        };
+
+        notifications.value.push(dataNotification);
     },
 );
  

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -24,7 +24,7 @@ useEchoNotification(
     `App.Models.User.${usePage().props.auth.user.id}`,
     (notification) => {
         console.log(notification);
-        notifications.value.push(notification.name);
+        notifications.value.push(notification);
     },
 );
  
@@ -180,7 +180,9 @@ const showingNavigationDropdown = ref(false);
                             </div>
 
                             <!-- Notifications -->
-                            <Dropdown align="right">
+                            <Dropdown align="right"
+                                width="80"
+                            >
                                 <template #trigger>
                                     <button
                                         type="button"

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -170,7 +170,6 @@ const showingNavigationDropdown = ref(false);
 
                             <!-- Notifications -->
                             <Notifications />
-                            <p>test 1</p>
                         </div>
                     </div>
                 </div>

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -8,8 +8,7 @@ import ResponsiveNavLink from '@/Components/ResponsiveNavLink.vue';
 import Toast from '@/Components/Misc/Toast.vue';
 import { Link, usePage } from '@inertiajs/vue3';
 import { currencies } from '@/currencies.js';
-import { useEchoNotification } from "@laravel/echo-vue";
-import Notification from '@/Components/Notifications/Notification.vue';
+import Notifications from '@/Components/Notifications/Notifications.vue';
 
 const props = defineProps({
     status: {
@@ -18,20 +17,6 @@ const props = defineProps({
     },
 });
 
-const notifications = ref(usePage().props.notifications);
-
-useEchoNotification(
-    `App.Models.User.${usePage().props.auth.user.id}`,
-    (notification) => {
-        // structure the notification the same way they are taken from db
-        const dataNotification = {
-            'data' : notification
-        };
-
-        notifications.value.push(dataNotification);
-    },
-);
- 
 // this will be part of the eventual exchange rework, choosing to show your balance in whichever currency
 // const currency = currencies.find((currency) => currency.code == usePage().props.auth.user.user_balance.currency);
 const user_balance = ref(usePage().props.auth.user.user_balance.amount);
@@ -184,29 +169,7 @@ const showingNavigationDropdown = ref(false);
                             </div>
 
                             <!-- Notifications -->
-                            <Dropdown align="right"
-                                width="80"
-                            >
-                                <template #trigger>
-                                    <button
-                                        type="button"
-                                        class="text-center inline-flex items-center rounded-md border border-transparent bg-white px-3 py-2 text-sm font-medium leading-4 text-gray-500 transition duration-150 ease-in-out hover:text-gray-700 focus:outline-none"
-                                    >
-                                        <i class="fa-solid fa-circle-exclamation text-2xl text-gray-400"></i>
-                                    </button>
-                                </template>
-                                <template #content v-if="notifications.length === 0">
-                                    <p class="block w-full px-4 py-2 text-start text-sm leading-5 text-gray-700 transition duration-150 ease-in-out hover:bg-gray-100 focus:bg-gray-100 focus:outline-none">
-                                        You have no new notifications
-                                    </p>
-                                </template>
-                                <template #content v-else>
-                                    <Notification v-for="notification in notifications"
-                                        :notification="notification"
-                                    >
-                                    </Notification>
-                                </template>
-                            </Dropdown>
+                            <Notifications />
                         </div>
                     </div>
                 </div>

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -10,6 +10,26 @@ import { Link, usePage } from '@inertiajs/vue3';
 import { currencies } from '@/currencies.js';
 import Notifications from '@/Components/Notifications/Notifications.vue';
 import MobileNotifications from '@/Components/Notifications/MobileNotifications.vue';
+import { useEchoNotification } from "@laravel/echo-vue";
+import { useNotificationStore } from '@/Stores/NotificationStore.js';
+
+/*
+* As user is auth'd at this point, we need usePage().props.auth.user to subscribe to echo
+* So when a new notif comes through, add it to the store
+* By default, the store loads with notifs from shared inertia middleware in HandleInertiaRequests
+* Any more websockets stuff in the future, will almost certainly live here too
+*/
+useEchoNotification(
+    `App.Models.User.${usePage().props.auth.user.id}`,
+    (notification) => {
+        useNotificationStore().notifications.unshift({
+            id: notification.id,
+            type: notification.type,
+            data: notification,
+            read_at: null,
+        });
+    },
+);
 
 const props = defineProps({
     status: {

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -189,7 +189,12 @@ const showingNavigationDropdown = ref(false);
                                         Notifications
                                     </button>
                                 </template>
-                                <template #content>
+                                <template #content v-if="notifications.length === 0">
+                                    <p class="block w-full px-4 py-2 text-start text-sm leading-5 text-gray-700 transition duration-150 ease-in-out hover:bg-gray-100 focus:bg-gray-100 focus:outline-none">
+                                        You have no new notifications
+                                    </p>
+                                </template>
+                                <template #content v-else>
                                     <Notification v-for="notification in notifications"
                                         :notification="notification"
                                     >

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -25,6 +25,8 @@ useEchoNotification(
         useNotificationStore().notifications.unshift({
             id: notification.id,
             type: notification.type,
+            // this has to be like this because the component uses data from the model
+            // as well as using data from the data property
             data: notification,
             read_at: null,
         });

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -52,6 +52,7 @@ const showingNavigationDropdown = ref(false);
                 <!-- Primary Navigation Menu -->
                 <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
                     <div class="flex h-16 justify-between">
+                        <!-- First half: logo & nav links -->
                         <div class="flex">
                             <!-- Logo -->
                             <div class="flex shrink-0 items-center">
@@ -80,97 +81,117 @@ const showingNavigationDropdown = ref(false);
                                 </NavLink>
                             </div>
                         </div> 
+                        <!-- Second half: User Balance, Settings/Burger & Notifications -->
                         <div class="flex items-center">
-                            <div class="flex me-4 text-gray-500" title="Your current balance in your default currency">
-                                <!-- bit hacky because obviously vue files can't access brick/money methods -->
-                                <small class="mr-2 font-semibold" :class="user_balance >= 0 ? 'text-green-500' : 'text-red-500'">£{{ user_balance }}</small>
+                            <!-- User Balance -->
+                            <div class="flex items-center">
+                                <div class="flex text-gray-500" title="Your current balance in your default currency">
+                                    <!-- bit hacky because obviously vue files can't access brick/money methods -->
+                                    <small class="font-semibold" :class="user_balance >= 0 ? 'text-green-500' : 'text-red-500'">£{{ user_balance }}</small>
+                                </div>
                             </div>
-                        </div>
-                        <div class="hidden sm:ms-6 sm:flex sm:items-center">
+
                             <!-- Settings Dropdown -->
-                            <div class="relative ms-3">
-                                <Dropdown align="right" width="48">
-                                    <template #trigger>
-                                        <span class="inline-flex rounded-md">
-                                            <button
-                                                type="button"
-                                                class="text-center inline-flex items-center rounded-md border border-transparent bg-white px-3 py-2 text-sm font-medium leading-4 text-gray-500 transition duration-150 ease-in-out hover:text-gray-700 focus:outline-none"
-                                            >
-                                                
-                                                {{ $page.props.auth.user.name }}
-                                                <svg
-                                                    class="-me-0.5 ms-2 h-4 w-4"
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                    viewBox="0 0 20 20"
-                                                    fill="currentColor"
+                            <div class="hidden sm:flex sm:items-center">
+                                <div class="relative">
+                                    <Dropdown align="right" width="48">
+                                        <template #trigger>
+                                            <span class="inline-flex rounded-md">
+                                                <button
+                                                    type="button"
+                                                    class="text-center inline-flex items-center rounded-md border border-transparent bg-white px-3 py-2 text-sm font-medium leading-4 text-gray-500 transition duration-150 ease-in-out hover:text-gray-700 focus:outline-none"
                                                 >
-                                                    <path
-                                                        fill-rule="evenodd"
-                                                        d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
-                                                        clip-rule="evenodd"
-                                                    />
-                                                </svg>
-                                            </button>
-                                        </span>
-                                    </template>
+                                                    
+                                                    {{ $page.props.auth.user.name }}
+                                                    <svg
+                                                        class="-me-0.5 ms-2 h-4 w-4"
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                        viewBox="0 0 20 20"
+                                                        fill="currentColor"
+                                                    >
+                                                        <path
+                                                            fill-rule="evenodd"
+                                                            d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+                                                            clip-rule="evenodd"
+                                                        />
+                                                    </svg>
+                                                </button>
+                                            </span>
+                                        </template>
 
-                                    <template #content>
-                                        <DropdownLink
-                                            :href="route('profile.edit')"
-                                        >
-                                            Profile
-                                        </DropdownLink>
-                                        <DropdownLink
-                                            :href="route('logout')"
-                                            method="post"
-                                            as="button"
-                                        >
-                                            Log Out
-                                        </DropdownLink>
-                                    </template>
-                                </Dropdown>
+                                        <template #content>
+                                            <DropdownLink
+                                                :href="route('profile.edit')"
+                                            >
+                                                Profile
+                                            </DropdownLink>
+                                            <DropdownLink
+                                                :href="route('logout')"
+                                                method="post"
+                                                as="button"
+                                            >
+                                                Log Out
+                                            </DropdownLink>
+                                        </template>
+                                    </Dropdown>
+                                </div>
                             </div>
-                        </div>
 
-                        <!-- Hamburger -->
-                        <div class="-me-2 flex items-center sm:hidden">
-                            <button
-                                @click="
-                                    showingNavigationDropdown =
-                                        !showingNavigationDropdown
-                                "
-                                class="inline-flex items-center justify-center rounded-md p-2 text-gray-400 transition duration-150 ease-in-out hover:bg-gray-100 hover:text-gray-500 focus:bg-gray-100 focus:text-gray-500 focus:outline-none"
-                            >
-                                <svg
-                                    class="h-6 w-6"
-                                    stroke="currentColor"
-                                    fill="none"
-                                    viewBox="0 0 24 24"
+                            <!-- Hamburger -->
+                            <div class="flex items-center sm:hidden">
+                                <button
+                                    @click="
+                                        showingNavigationDropdown =
+                                            !showingNavigationDropdown
+                                    "
+                                    class="inline-flex items-center justify-center rounded-md p-2 text-gray-400 transition duration-150 ease-in-out hover:bg-gray-100 hover:text-gray-500 focus:bg-gray-100 focus:text-gray-500 focus:outline-none"
                                 >
-                                    <path
-                                        :class="{
-                                            hidden: showingNavigationDropdown,
-                                            'inline-flex':
-                                                !showingNavigationDropdown,
-                                        }"
-                                        stroke-linecap="round"
-                                        stroke-linejoin="round"
-                                        stroke-width="2"
-                                        d="M4 6h16M4 12h16M4 18h16"
-                                    />
-                                    <path
-                                        :class="{
-                                            hidden: !showingNavigationDropdown,
-                                            'inline-flex':
-                                                showingNavigationDropdown,
-                                        }"
-                                        stroke-linecap="round"
-                                        stroke-linejoin="round"
-                                        stroke-width="2"
-                                        d="M6 18L18 6M6 6l12 12"
-                                    />
-                                </svg>
-                            </button>
+                                    <svg
+                                        class="h-6 w-6"
+                                        stroke="currentColor"
+                                        fill="none"
+                                        viewBox="0 0 24 24"
+                                    >
+                                        <path
+                                            :class="{
+                                                hidden: showingNavigationDropdown,
+                                                'inline-flex':
+                                                    !showingNavigationDropdown,
+                                            }"
+                                            stroke-linecap="round"
+                                            stroke-linejoin="round"
+                                            stroke-width="2"
+                                            d="M4 6h16M4 12h16M4 18h16"
+                                        />
+                                        <path
+                                            :class="{
+                                                hidden: !showingNavigationDropdown,
+                                                'inline-flex':
+                                                    showingNavigationDropdown,
+                                            }"
+                                            stroke-linecap="round"
+                                            stroke-linejoin="round"
+                                            stroke-width="2"
+                                            d="M6 18L18 6M6 6l12 12"
+                                        />
+                                    </svg>
+                                </button>
+                            </div>
+
+                            <!-- Notifications -->
+                            <Dropdown align="right">
+                                <template #trigger>
+                                    <button
+                                        type="button"
+                                        class="text-center inline-flex items-center rounded-md border border-transparent bg-white px-3 py-2 text-sm font-medium leading-4 text-gray-500 transition duration-150 ease-in-out hover:text-gray-700 focus:outline-none"
+                                    >
+                                        Notifications
+                                    </button>
+                                </template>
+                                <template #content>
+                                    <p>notifications popup</p>
+                                </template>
+                            </Dropdown>
                         </div>
                     </div>
                 </div>

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -79,12 +79,13 @@ const showingNavigationDropdown = ref(false);
                                     Groups
                                 </NavLink>
                             </div>
-                        </div>    
+                        </div> 
                         <div class="flex items-center">
                             <div class="flex me-4 text-gray-500" title="Your current balance in your default currency">
                                 <!-- bit hacky because obviously vue files can't access brick/money methods -->
                                 <small class="mr-2 font-semibold" :class="user_balance >= 0 ? 'text-green-500' : 'text-red-500'">£{{ user_balance }}</small>
                             </div>
+                        </div>
                         <div class="hidden sm:ms-6 sm:flex sm:items-center">
                             <!-- Settings Dropdown -->
                             <div class="relative ms-3">
@@ -171,7 +172,6 @@ const showingNavigationDropdown = ref(false);
                                 </svg>
                             </button>
                         </div>
-                    </div>
                     </div>
                 </div>
 

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -192,7 +192,7 @@ const showingNavigationDropdown = ref(false);
                                         type="button"
                                         class="text-center inline-flex items-center rounded-md border border-transparent bg-white px-3 py-2 text-sm font-medium leading-4 text-gray-500 transition duration-150 ease-in-out hover:text-gray-700 focus:outline-none"
                                     >
-                                        Notifications
+                                        <i class="fa-solid fa-circle-exclamation text-2xl text-gray-400"></i>
                                     </button>
                                 </template>
                                 <template #content v-if="notifications.length === 0">

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -9,6 +9,7 @@ import Toast from '@/Components/Misc/Toast.vue';
 import { Link, usePage } from '@inertiajs/vue3';
 import { currencies } from '@/currencies.js';
 import { useEchoNotification } from "@laravel/echo-vue";
+import Notification from '@/Components/Notifications/Notification.vue';
 
 const props = defineProps({
     status: {
@@ -189,7 +190,10 @@ const showingNavigationDropdown = ref(false);
                                     </button>
                                 </template>
                                 <template #content>
-                                    <p>notifications popup</p>
+                                    <Notification v-for="notification in notifications"
+                                        :notification="notification"
+                                    >
+                                    </Notification>
                                 </template>
                             </Dropdown>
                         </div>

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -170,6 +170,7 @@ const showingNavigationDropdown = ref(false);
 
                             <!-- Notifications -->
                             <Notifications />
+                            <p>test 1</p>
                         </div>
                     </div>
                 </div>

--- a/resources/js/Stores/NotificationStore.js
+++ b/resources/js/Stores/NotificationStore.js
@@ -1,7 +1,9 @@
 import { defineStore } from 'pinia';
+import { usePage } from '@inertiajs/vue3';
 
 export const useNotificationStore = defineStore('notificationStore', {
     state: () => ({
-        notifications: ['test notif'],
+        // taken from HandleInertiaRequests
+        notifications: usePage().props.notifications,
     })
 })

--- a/resources/js/Stores/NotificationStore.js
+++ b/resources/js/Stores/NotificationStore.js
@@ -1,0 +1,7 @@
+import { defineStore } from 'pinia';
+
+export const useNotificationStore = defineStore('notificationStore', {
+    state: () => ({
+        notifications: ['test notif'],
+    })
+})

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -6,6 +6,7 @@ import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 import { createApp, h } from 'vue';
 import { ZiggyVue } from '../../vendor/tightenco/ziggy';
 import { configureEcho } from "@laravel/echo-vue";
+import { createPinia } from 'pinia';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 
@@ -20,6 +21,7 @@ createInertiaApp({
         return createApp({ render: () => h(App, props) })
             .use(plugin)
             .use(ZiggyVue)
+            .use(createPinia())
             .mount(el);
     },
     progress: {

--- a/routes/web.php
+++ b/routes/web.php
@@ -98,6 +98,13 @@ Route::get('/invite/accept/{invite}', [InviteController::class, 'accept'])
     ->middleware(['signed', CheckInviteExpiry::class])
     ->name('invite.accept');    
 
+// notifications
+Route::middleware('auth')->group(function () {
+    Route::post('/notifications/read-all', function () {
+        auth()->user()->unreadNotifications->markAsRead();
+    });
+});
+
 
 // testing/playground
 Route::get('/playground', function() {

--- a/routes/web.php
+++ b/routes/web.php
@@ -103,6 +103,15 @@ Route::middleware('auth')->group(function () {
     Route::post('/notifications/read-all', function () {
         auth()->user()->unreadNotifications->markAsRead();
     });
+    Route::post('/notifications/read/{notification}', function ($notification_id) {
+        auth()->user()
+            ->notifications()
+            ->where('id', $notification_id)
+            ->firstOrFail()
+            ->markAsRead();
+        });
+
+        return back();
 });
 
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -102,6 +102,8 @@ Route::get('/invite/accept/{invite}', [InviteController::class, 'accept'])
 Route::middleware('auth')->group(function () {
     Route::post('/notifications/read-all', function () {
         auth()->user()->unreadNotifications->markAsRead();
+
+        return back();
     });
     Route::post('/notifications/read/{notification}', function ($notification_id) {
         auth()->user()

--- a/tests/Feature/Http/Controllers/AliasControllerTest.php
+++ b/tests/Feature/Http/Controllers/AliasControllerTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use App\Models\User;
+use App\Models\Group;
+use App\Models\Alias;
+
+beforeEach(function () {
+    // create a handful of users so those involved can be randomised
+    $this->users = User::factory(5)->create();
+    $this->user = $this->users[0];
+
+    // a group for them to go in
+    Group::factory(1)->withGroupUsers()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->group = Group::where('user_id', $this->user->id)->get()[0];
+
+    $this->actingAs($this->user);
+});
+
+test('user can add an alias for another user', function() {
+    $other_group_user = $this->group->users->reject(fn($user) => 
+        $user->user_id === $this->user->id)->first();
+
+    $response = $this->post(route('alias.store'), [
+        'alias' => 'some alias',
+        'user_id' => $this->user->id,
+        'group_user_id' => $other_group_user->id,
+    ]);
+
+    $response->assertStatus(302)
+        ->assertSessionHasNoErrors()
+        ->assertSessionHas('status', 'Alias created successfully.')
+        ->assertRedirect('/groups');
+
+    $this->assertDatabaseHas('aliases', [
+        'alias' => 'some alias',
+        'user_id' => $this->user->id,
+        'group_user_id' => $other_group_user->id,
+    ]);
+});
+
+test('user can update an alias for another user', function() {
+    $other_group_user = $this->group->users->reject(fn($user) => 
+        $user->user_id === $this->user->id)->first();
+    
+    $alias = Alias::create([
+        'alias' => 'change me',
+        'user_id' => $this->user->id,
+        'group_user_id' => $other_group_user->id,
+    ]);
+    
+    $response = $this->patch(route('alias.update', $alias->id), [
+        'id' => $alias->id,
+        'alias' => 'some new alias',
+        'user_id' => $this->user->id,
+        'group_user_id' => $other_group_user->id,
+    ]);
+
+    $response->assertStatus(302)
+        ->assertSessionHasNoErrors()
+        ->assertSessionHas('status', 'Alias updated successfully.')
+        ->assertRedirect('/groups');
+    
+    $this->assertDatabaseHas('aliases', [
+        'id' => $alias->id,
+        'alias' => 'some new alias',
+        'user_id' => $this->user->id,
+        'group_user_id' => $other_group_user->id,
+    ]);
+});
+


### PR DESCRIPTION
The aim of this PR is to build out the frontend for notifications, following the backend work in the previous PR. 

Main additions:
- More info added to `DebtCreatedNotification` so the written alert can be built
- `Notifications` component in the standard  view navbar to handle viewing notifications, clicking bring up scrollable notifs
-  `MobileNotifications`  component that appears in the navbar burger menu in mobile views, same functionality as standard notifs component
- `Notification` component that covers both standard & mobile views
- Installed Pinia.js for state management, rather than just writing my own version. In future, existing states will be adapted this way as well as being the standard going forward
- Routes for reading & reading all notifs

Extras:
- Extra width class on `Dropdown` to cover mobile views
- Moved reverb to serve on port 8080 rather than 9000
- Moved an older test into the correct directory
- Moved debt creation notif to appropriate listener rather than have it in controller

Fixes:
- Ternary based around `$user` in `HandleInertiaRequests` middleware for when there are no notifications

So not _entirely_ just the frontend, but we now have a basic notification system that currently handles notifications for when a debt is added, going to each user involved in the debt. 