### PR TITLE
Change User to Comments relationship

### DIFF
--- a/app/Http/Controllers/AliasController.php
+++ b/app/Http/Controllers/AliasController.php
@@ -15,7 +15,7 @@ class AliasController extends Controller
     {
         $validated = $request->validated();
 
-        $alias = Alias::create([
+        Alias::create([
             'user_id' => $validated['user_id'],
             'group_user_id' => $validated['group_user_id'],
             'alias' => $validated['alias'],

--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -38,14 +38,18 @@ class CommentController extends Controller
         $debt = Debt::findOrFail($validated['debt_id']);
 
         if ($request->user()->cannot('create', [Comment::class, $debt])) {
-          
-            return redirect()->route('debt.index')->withErrors(['debt_id' => 'You do not have permission to comment on this debt.']);
+            return redirect()->route('debt.index')
+                ->withErrors([
+                        'debt_id' => 'You do not have permission to comment on this debt.'
+                    ]);
         }
+
+        $group_user = $request->user()->group_users()->where('group_id', $debt->group_id)->first();
 
         Comment::create([
             'debt_id' => $validated['debt_id'],
             'content' => $validated['content'],
-            'user_id' => $validated['user_id'],
+            'group_user_id' => $group_user->id,
         ]);
 
         return redirect()->route('debt.index')->with('status', 'Comment added successfully.');

--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -41,9 +41,12 @@ class DebtController extends Controller
                         $query->where('user_id', $user->id);
                     })
                     ->latest()
+                    // todo: why am i doing this? look again into pagination
+                    // only load when scroll
+                    // also restructure again because loading .group_user.user repeatedly is silly
                     ->with([
                         'shares.group_user.user',
-                        'comments.user',
+                        'comments.group_user.user',
                         'group.group_users.user',
                     ])
                     ->paginate(5)

--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -4,26 +4,18 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\StoreDebtRequest;
 use App\Http\Requests\UpdateDebtRequest;
-use App\Http\Requests\StoreShareRequest;
 use Illuminate\Http\Request;
 use App\Models\Debt;
-use App\Models\GroupUser;
 use App\Models\Share;
 use App\Models\Group;
-use Illuminate\Support\Facades\Auth;
-use Carbon\Carbon;
 use Inertia\Inertia;
-use Illuminate\Support\Facades\Validator;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\RedirectResponse;
-use App\Services\DebtService;
 use App\Services\ShareService;
 use Brick\Money\Money;
 use App\Http\Resources\DebtResource;
 use App\Http\Resources\GroupResource;
 use App\Events\DebtCreated;
 use App\Events\DebtUpdated;
-use App\Notifications\DebtCreatedNotification;
 
 class DebtController extends Controller
 {

--- a/app/Http/Requests/StoreCommentRequest.php
+++ b/app/Http/Requests/StoreCommentRequest.php
@@ -24,7 +24,6 @@ class StoreCommentRequest extends FormRequest
         return [
             'debt_id' => ['required', 'exists:debts,id'],
             'content' => ['required', 'string'],
-            'user_id' => ['required', 'exists:users,id'],
         ];
     }
 }

--- a/app/Http/Resources/CommentResource.php
+++ b/app/Http/Resources/CommentResource.php
@@ -17,7 +17,7 @@ class CommentResource extends JsonResource
     {
         return [
             'id' => $this->id,
-            'user_id' => $this->user_id,
+            'group_user_id' => $this->group_user_id,
             'content' => $this->content,
             'edited' => $this->edited,
             'created_at' => $this->created_at,
@@ -30,8 +30,8 @@ class CommentResource extends JsonResource
             ],
 
             // relationships
-            'user' => new UserResource(
-                $this->whenLoaded('user')
+            'group_user' => new GroupUserResource(
+                $this->whenLoaded('group_user')
             ),
         ];
     }

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -19,7 +19,7 @@ class Comment extends Model
     protected $fillable = [
         'debt_id',
         'content', 
-        'user_id',
+        'group_user_id',
         'edited',
     ];
 

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use App\Models\Debt;
-use App\Models\User;
+use App\Models\GroupUser;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Facades\Auth;
 
@@ -38,8 +38,8 @@ class Comment extends Model
      * 
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function user(): BelongsTo
+    public function group_user(): BelongsTo
     {
-        return $this->belongsTo(User::class);
+        return $this->belongsTo(GroupUser::class);
     }
 }

--- a/app/Models/GroupUser.php
+++ b/app/Models/GroupUser.php
@@ -76,4 +76,15 @@ class GroupUser extends Model
     {
         return $this->hasMany(Alias::class);
     }
+
+    /**
+     * Comments made by the group user
+     * Meaning, these are comments mae by a user specific to that group
+     * 
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function comments(): HasMany
+    {
+        return $this->hasMany(Comment::class);
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -117,11 +117,11 @@ class User extends Authenticatable
     /**
      * Comments made on a debt by a user.
      * 
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     * @return \Illuminate\Database\Eloquent\Relations\HasManyThrough
      */
-    public function comments(): HasMany
+    public function comments(): HasManyThrough
     {
-        return $this->hasMany(Comment::class);
+        return $this->hasManyThrough(Comment::class, GroupUser::class, 'user_id', 'group_user_id');
     }
 
     /**

--- a/app/Observers/GroupUserObserver.php
+++ b/app/Observers/GroupUserObserver.php
@@ -32,6 +32,9 @@ class GroupUserObserver
             $alias->delete();
         }
 
+        foreach ($groupUser->comments as $comment) {
+            $comment->delete();
+        }
         // todo:
         // this has now opened a massive can of worms
         // that is prompting me to rethink the db structure

--- a/app/Policies/CommentPolicy.php
+++ b/app/Policies/CommentPolicy.php
@@ -40,7 +40,7 @@ class CommentPolicy
      */
     public function update(User $user, Comment $comment): bool
     {
-        return $user->id === $comment->user_id;
+        return $user->id === $comment->group_user->user_id;
     }
 
     /**
@@ -48,7 +48,7 @@ class CommentPolicy
      */
     public function delete(User $user, Comment $comment): bool
     {
-        return $user->id === $comment->user_id;
+        return $user->id === $comment->group_user->user_id;
     }
 
     /**

--- a/database/factories/DebtFactory.php
+++ b/database/factories/DebtFactory.php
@@ -54,12 +54,14 @@ class DebtFactory extends Factory
 
     public function withComments() {
         return $this->afterCreating(function(Debt $debt) {
-            Comment::factory()->create([
-                'debt_id' => $debt->id,
-                // just gonna make all comments by 1 person
-                // will revisit when seeder is majorly updated
-                'user_id' => $debt->user_id,
-            ]);
+
+            foreach ($debt->user->group_user as $group_user) {
+                Comment::factory()->create([
+                    'debt_id' => $debt->id,
+                    'group_user_id' => $group_user->id,
+                    'content' => "Comment by {$group_user->user->name}"
+                ]);
+            }
         });
     }
 

--- a/database/factories/DebtFactory.php
+++ b/database/factories/DebtFactory.php
@@ -54,12 +54,12 @@ class DebtFactory extends Factory
 
     public function withComments() {
         return $this->afterCreating(function(Debt $debt) {
-
-            foreach ($debt->user->group_user as $group_user) {
+            // todo: fix this when doing user->share relationship
+            foreach ($debt->users as $user) {
                 Comment::factory()->create([
                     'debt_id' => $debt->id,
-                    'group_user_id' => $group_user->id,
-                    'content' => "Comment by {$group_user->user->name}"
+                    'group_user_id' => $user->group_user->id,
+                    'content' => "Comment by {$user->group_user->user->name}"
                 ]);
             }
         });

--- a/database/migrations/2025_03_01_111306_create_comments_table.php
+++ b/database/migrations/2025_03_01_111306_create_comments_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('comments', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id')->constrained();
+            $table->foreignId('group_user_id')->constrained();
             $table->foreignId('debt_id')->constrained();
             $table->text('content')->nullable();
             $table->boolean('edited')->nullable();

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -111,7 +111,7 @@ class DatabaseSeeder extends Seeder
                 for ($i = 0; $i < $num_comments; $i++) {
                     Comment::factory()->create([
                         'debt_id' => $debt->id,
-                        'user_id' => Arr::random($debt->group->group_users->pluck('user_id')->toArray()),
+                        'group_user_id' => Arr::random($debt->group->group_users->pluck('id')->toArray()),
                     ]);
                 }
 

--- a/resources/js/Components/Comments/AddComment.vue
+++ b/resources/js/Components/Comments/AddComment.vue
@@ -27,7 +27,6 @@ const emit = defineEmits(['closeAddComment']);
         :transform="data => ({ 
             ...data, 
             debt_id: props.debt.id,
-            user_id: props.user.id,
         })"
         :options="{
             preserveScroll: true,

--- a/resources/js/Components/Comments/Comment.vue
+++ b/resources/js/Components/Comments/Comment.vue
@@ -44,7 +44,7 @@ onMounted(() => {
                 <UserProfileIcon class="mr-2"/>
                 <div class="flex flex-col">
                     <div>
-                        <strong>{{ comment.user.name }}</strong>
+                        <strong>{{ comment.group_user.user.name }}</strong>
                         <small> on {{ formatCommentDate(comment.created_at) }}</small>
                     </div>
                     <i v-if="comment.edited">

--- a/tests/Feature/Http/Controllers/AliasControllerTest.php
+++ b/tests/Feature/Http/Controllers/AliasControllerTest.php
@@ -14,21 +14,21 @@ beforeEach(function () {
         'user_id' => $this->user->id,
     ]);
 
-    $this->group = Group::where('user_id', $this->user->id)->get()[0];
+    $this->group = Group::where('user_id', $this->user->id)->first();
 
     $this->actingAs($this->user);
 });
 
 test('user can add an alias for another user', function() {
-    $other_group_user = $this->group->users->reject(fn($user) => 
-        $user->user_id === $this->user->id)->first();
+    $other_group_user = $this->group->group_users->reject(fn($group_user) => 
+        $group_user->user_id === $this->user->id)->first();
 
     $response = $this->post(route('alias.store'), [
         'alias' => 'some alias',
         'user_id' => $this->user->id,
         'group_user_id' => $other_group_user->id,
     ]);
-
+    
     $response->assertStatus(302)
         ->assertSessionHasNoErrors()
         ->assertSessionHas('status', 'Alias created successfully.')
@@ -42,8 +42,8 @@ test('user can add an alias for another user', function() {
 });
 
 test('user can update an alias for another user', function() {
-    $other_group_user = $this->group->users->reject(fn($user) => 
-        $user->user_id === $this->user->id)->first();
+    $other_group_user = $this->group->group_users->reject(fn($group_user) => 
+        $group_user->user_id === $this->user->id)->first();
     
     $alias = Alias::create([
         'alias' => 'change me',

--- a/tests/Feature/Http/Controllers/CommentControllerTest.php
+++ b/tests/Feature/Http/Controllers/CommentControllerTest.php
@@ -26,6 +26,9 @@ beforeEach(function () {
         'user_id' => $this->user->id,
     ]);
 
+    // the group user of the user that will be commenting etc
+    $this->group_user = $this->user->group_users()->where('group_id', $this->group->id)->first();
+
     $this->actingAs($this->user);
 });
 
@@ -33,7 +36,6 @@ test('user can comment on a debt', function () {
     $response = $this->post(route('comment.store'), [
         'debt_id' => $this->debt->id,
         'content' => 'This is a comment',
-        'user_id' => $this->user->id,
     ]);
 
     $response->assertStatus(302)
@@ -42,7 +44,7 @@ test('user can comment on a debt', function () {
     $this->assertDatabaseHas('comments', [
         'debt_id' => $this->debt->id,
         'content' => 'This is a comment',
-        'user_id' => $this->user->id,
+        'group_user_id' => $this->group_user->id,
     ]);
 });
 
@@ -50,19 +52,20 @@ test('user can not post an empty comment', function () {
     $response = $this->post(route('comment.store'), [
         'debt_id' => $this->debt->id,
         'content' => '',
-        'user_id' => $this->user->id,
+        'group_user_id' => $this->group_user->id,
     ]);
 
     $response->assertSessionHasErrors(['content' => 'The content field is required.']);
 
     $this->assertDatabaseMissing('comments', [
         'content' => '',
+        'group_user_id' => $this->group_user->id,
     ]);
 });
 
 test('user can edit their comment on a debt', function () {
     $comment = Comment::create([
-        'user_id' => $this->user->id,
+        'group_user_id' => $this->group_user->id,
         'debt_id' => $this->debt->id,
         'content' => 'I am a comment on a debt',
     ]);
@@ -77,12 +80,13 @@ test('user can edit their comment on a debt', function () {
     $this->assertDatabaseHas('comments', [
         'content' => 'I have now been updated',
         'edited' => 1,
+        'group_user_id' => $this->group_user->id,
     ]);
 });
 
 test('user can delete their comment on a debt', function () {
     $comment = Comment::create([
-        'user_id' => $this->user->id,
+        'group_user_id' => $this->group_user->id,
         'debt_id' => $this->debt->id,
         'content' => 'I am a comment on a debt',
     ]);
@@ -94,14 +98,15 @@ test('user can delete their comment on a debt', function () {
     $this->assertDatabaseHas('comments', [
         'id' => $comment->id,
         'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
+        'group_user_id' => $this->group_user->id,
     ]);
 });
 
 test('user can not edit another user comment on a debt', function () {
     // get a different user & create a comment by them
-    $other_user = User::where('id', '!=', $this->user->id)->first();
+    $other_group_user = GroupUser::where('id', '!=', $this->group_user->id)->first();
     $other_user_comment = Comment::create([
-        'user_id' => $other_user->id,
+        'group_user_id' => $other_group_user->id,
         'debt_id' => $this->debt->id,
         'content' => 'I am a comment on a debt',
     ]);
@@ -120,14 +125,15 @@ test('user can not edit another user comment on a debt', function () {
     $this->assertDatabaseHas('comments', [
         'content' => 'I am a comment on a debt',
         'edited' => null,
+        'group_user_id' => $other_group_user->id,
     ]);
 });
 
 // same principle as above test, just slightly different assertions 
 test('user can not delete another user comment on a debt', function () {
-    $other_user = User::where('id', '!=', $this->user->id)->first();
+    $other_group_user = GroupUser::where('id', '!=', $this->group_user->id)->first();
     $other_user_comment = Comment::create([
-        'user_id' => $other_user->id,
+        'group_user_id' => $other_group_user->id,
         'debt_id' => $this->debt->id,
         'content' => 'I am a comment on a debt',
     ]);
@@ -141,17 +147,18 @@ test('user can not delete another user comment on a debt', function () {
     $this->assertDatabaseHas('comments', [
         'id' => $other_user_comment->id,
         'deleted_at' => null,
+        'group_user_id' => $other_group_user->id,
     ]);
 });
 
 test('user can not comment on a debt they are not involved in', function () {
     $other_user = User::factory()->create();
+
     $this->actingAs($other_user);
 
     $response = $this->post(route('comment.store'), [
             'debt_id' => $this->debt->id,
             'content' => 'This is a comment',
-            'user_id' => $other_user->id,
         ]);
 
     $response->assertSessionHasErrors([

--- a/tests/Feature/Http/Controllers/GroupUserControllerTest.php
+++ b/tests/Feature/Http/Controllers/GroupUserControllerTest.php
@@ -2,6 +2,9 @@
 
 use App\Models\User;
 Use App\Models\Group;
+use App\Models\Debt;
+use App\Models\GroupUser;
+use App\Models\Comment;
 use Carbon\Carbon;
 
 beforeEach(function () {
@@ -14,15 +17,13 @@ beforeEach(function () {
         'user_id' => $this->user->id,
     ]);
 
-    $this->group = Group::where('user_id', $this->user->id)->get()[0];
+    $this->group = Group::first();
 });
 
 test('user can remove group users from a group they own', function() {
     $this->actingAs($this->user);
 
-    $response = $this->delete(route('group-users.destroy', $this->group->group_users[2]), [
-        'id' => $this->group->group_users[2]->id,
-    ]);
+    $response = $this->delete(route('group-users.destroy', $this->group->group_users[2]));
 
     $response->assertStatus(302)
         ->assertSessionHas('status', 'Group User deleted successfully.');
@@ -50,5 +51,32 @@ test('user can not remove group users from a group they do not own', function() 
     $this->assertDatabaseHas('group_users', [
         'id' => $group_user->id,
         'deleted_at' => null,
+    ]);
+});
+
+test('deleting a group user also delets their comments', function() {
+    $this->actingAs($this->user);
+
+    $debt = Debt::factory()->create([
+        'group_id' => $this->group->id,
+        'user_id' => $this->user->id,
+    ]);
+
+    // todo: change this after fixing debt factory later
+    $comment = Comment::factory()->create([
+        'group_user_id' => $this->group->group_users[0]->id,
+        'debt_id' => $debt->id,
+        'content' => 'comment'
+    ]);
+
+    $response = $this->delete(route('group-users.destroy', $this->group->group_users[0]));
+
+    $response->assertStatus(302)
+        ->assertSessionHas('status', 'Group User deleted successfully.');
+
+    $this->assertDatabaseHas('comments', [
+        'id' => $comment->id,
+        'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
+        'group_user_id' => $this->group->group_users[0]->id,
     ]);
 });


### PR DESCRIPTION
The aim of this PR is to change the user->comments  relationship to group_user->comments as this is better practice.

- Made relevant syntax changes to the following:
  - Controller
  - Frontend Components
  - Resource
  - Model
  - Policy
  - Migration
  - Seeder, though `DebtFactory` will be bugged until upcoming share changes
  - Tests

- Updated existing relationships & added a new group_user->comments relationship.
- Added comment deletion to `GroupUserObserver`.
- Added new test for the above

Extras:
- Cleaned up unused namespaces in `DebtController`
- Fixed some dodgy Alias tests