### PR TITLE
Change user to shares relationship

### DIFF
--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -28,17 +28,15 @@ class DebtController extends Controller
 
         $debts = Inertia::scroll(fn() => 
             DebtResource::collection(
-                $user->debts()->where('user_id', $user->id)
+                Debt::where('user_id', $user->id)
                     ->orWhereHas('shares.group_user', function ($query) use ($user) {
                         $query->where('user_id', $user->id);
                     })
+                    ->distinct()
                     ->latest()
-                    // todo: why am i doing this? look again into pagination
-                    // only load when scroll
-                    // also restructure again because loading .group_user.user repeatedly is silly
                     ->with([
-                        'shares.group_user.user',
-                        'comments.group_user.user',
+                        'shares.group_user.user:id,name',
+                        'comments.group_user.user:id,name',
                         'group.group_users.user',
                     ])
                     ->paginate(5)

--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -28,6 +28,8 @@ class DebtController extends Controller
 
         $debts = Inertia::scroll(fn() => 
             DebtResource::collection(
+                // query builder to get the debts where the user is the owner
+                // or has a share in the debt via group_user
                 Debt::where('user_id', $user->id)
                     ->orWhereHas('shares.group_user', function ($query) use ($user) {
                         $query->where('user_id', $user->id);
@@ -45,9 +47,9 @@ class DebtController extends Controller
 
         $groups = GroupResource::collection(
             $request->user()
-            ->groups()
-            ->with('group_users.user')
-            ->get()
+                ->groups()
+                ->with('group_users.user')
+                ->get()
         );
             
         return Inertia::render('Debts', [
@@ -78,7 +80,7 @@ class DebtController extends Controller
         } 
         
         $debt = Debt::create([
-            'group_id' => $validated['group_id'],
+            'group_id' => $group->id,
             'user_id' => $validated['user_id'],
             'name' => $validated['name'],
             'amount' => Money::of($validated['amount'], $validated['currency']),

--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -29,7 +29,7 @@ class DebtController extends Controller
         $debts = Inertia::scroll(fn() => 
             DebtResource::collection(
                 $user->debts()->where('user_id', $user->id)
-                    ->orWhereHas('shares', function ($query) use ($user) {
+                    ->orWhereHas('shares.group_user', function ($query) use ($user) {
                         $query->where('user_id', $user->id);
                     })
                     ->latest()

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -22,7 +22,9 @@ class GroupController extends Controller
             GroupResource::collection(
                 $request->user()
                     ->groups()
-                    ->with(['group_users.user', 'group_users.aliases'])
+                    ->with([
+                        'group_users.user', 'group_users.aliases'
+                    ])
                     ->paginate(5)
                 )
             );

--- a/app/Http/Controllers/ShareController.php
+++ b/app/Http/Controllers/ShareController.php
@@ -4,16 +4,13 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\StoreShareRequest;
 use App\Http\Requests\UpdateShareRequest;
-use App\Http\Requests\SendShareRequest;
 use Illuminate\Http\Request;
 use App\Models\Share;
 use App\Models\Debt;
-use Illuminate\Support\Facades\Validator;
-use App\Events\ShareUpdated;
+use App\Models\GroupUser;
 use App\Services\ShareService;
 use App\Services\BalanceService;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Support\Facades\Auth;
 use Brick\Money\Money;
 
 /**
@@ -50,15 +47,15 @@ class ShareController extends Controller
             return redirect()->route('debt.index')->withErrors(['debt_id' => 'You do not have permission to add a share to this debt.']);
         }
 
-        $debt = Debt::findOrFail($validated['debt_id']);
+        $share_group_user = GroupUser::findOrFail($validated['group_user_id']);
 
         $share = Share::create([
             'debt_id' => $validated['debt_id'],
-            'user_id' => $validated['user_id'],
+            'group_user_id' => $validated['group_user_id'],
             'name' => $validated['name'],
             'amount' => Money::of($validated['amount'], $validated['currency']),
-            'sent' => $debt->user_id === $validated['user_id'] ? 1 : 0,
-            'seen' => $debt->user_id === $validated['user_id'] ? 1 : 0,
+            'sent' => $debt->user_id === $share_group_user->user_id ? 1 : 0,
+            'seen' => $debt->user_id === $share_group_user->user_id ? 1 : 0,
         ]);
 
         $shareService->addToDebt($share);
@@ -196,7 +193,10 @@ class ShareController extends Controller
     public function destroy(Request $request, Share $share, ShareService $shareService): RedirectResponse
     {
         if ($request->user()->cannot('delete', $share)) {
-            return redirect()->route('debt.index')->withErrors(['id' => 'You do not have permission to delete this share.']);
+            return redirect()->route('debt.index')
+                ->withErrors([
+                    'id' => 'You do not have permission to delete this share.'
+                ]);
         }
 
         // delete the share

--- a/app/Http/Requests/StoreShareRequest.php
+++ b/app/Http/Requests/StoreShareRequest.php
@@ -23,7 +23,7 @@ class StoreShareRequest extends FormRequest
     {
         return [
             'debt_id' => ['required', 'exists:debts,id'],
-            'user_id' => ['required', 'exists:users,id'],
+            'group_user_id' => ['required', 'exists:group_users,id'],
             'name' => ['sometimes', 'string'],
             'amount' => ['required', 'numeric', 'min:0.01'],
             'name' => ['nullable', 'string'],
@@ -34,7 +34,7 @@ class StoreShareRequest extends FormRequest
     public function messages()
     {
         return [
-            'user_id' => 'Please select a user from the dropdown',
+            'group_user_id' => 'Please select a user from the dropdown',
             'amount.min' => 'Please enter a valid amount',
         ];
     }

--- a/app/Http/Resources/ShareResource.php
+++ b/app/Http/Resources/ShareResource.php
@@ -19,7 +19,7 @@ class ShareResource extends JsonResource
             'id' => $this->id,
             'amount' => $this->amount,
             'debt_id' => $this->debt_id,
-            'user_id' => $this->user_id,
+            'group_user_id' => $this->group_user_id,
             'name' => $this->name,
             'sent' => $this->sent,
             'seen' => $this->seen,

--- a/app/Listeners/DebtCreatedListener.php
+++ b/app/Listeners/DebtCreatedListener.php
@@ -22,10 +22,10 @@ class DebtCreatedListener implements ShouldQueue
      */
     public function handle(DebtCreated $event): void
     {
-        foreach ($event->debt->users as $user) {
+        foreach ($event->debt->group_users as $group_user) {
             // automatically broadcasts on the user channel in channels.php
             // otherwise, you broadcast it in the event
-            $user->notify(new DebtCreatedNotification($event->debt));
+            $group_user->user->notify(new DebtCreatedNotification($event->debt));
         };
     }
 }

--- a/app/Models/Alias.php
+++ b/app/Models/Alias.php
@@ -7,7 +7,6 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use App\Models\GroupUser;
-use App\Models\User;
 
 class Alias extends Model
 {

--- a/app/Models/Debt.php
+++ b/app/Models/Debt.php
@@ -71,15 +71,15 @@ class Debt extends Model
      * 
      * @return \Illuminate\Database\Eloquent\Relations\HasManyThrough
      */
-    public function users(): HasManyThrough
+    public function group_users(): HasManyThrough
     {
         return $this->hasManyThrough(
-            User::class,    // end goal
+            GroupUser::class,    // end goal
             Share::class,   // middleman
             'debt_id',      // foreign key on middle man 
             'id',           // foreign key on end goal
             'id',           // local key on start
-            'user_id'       // local key on middleman
+            'group_user_id'       // local key on middleman
 
             // so it's kinda like
             // start->middle local->foreign

--- a/app/Models/Share.php
+++ b/app/Models/Share.php
@@ -20,7 +20,7 @@ class Share extends Model
     use SoftDeletes;
 
     protected $fillable = [
-        'user_id',
+        'group_user_id',
         'debt_id',
         'name',
         'amount',
@@ -49,7 +49,6 @@ class Share extends Model
      */
     public function group_user()
     {
-        // takes the two foreign keys and figures out the relationship (laravel magic)
         return $this->belongsTo(GroupUser::class); 
     }
 }

--- a/app/Models/Share.php
+++ b/app/Models/Share.php
@@ -43,23 +43,13 @@ class Share extends Model
     }
 
     /**
-     * User that owns the share.
-     * 
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
-     */
-    public function user(): BelongsTo
-    {
-        return $this->belongsTo(User::class);
-    }
-
-    /**
      * Group user that owns the share.
      * 
-     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function group_user()
     {
         // takes the two foreign keys and figures out the relationship (laravel magic)
-        return $this->hasOne(GroupUser::class, 'user_id', 'user_id'); 
+        return $this->belongsTo(GroupUser::class); 
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -137,11 +137,11 @@ class User extends Authenticatable
     /**
      * Shares owner by a user.
      * 
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     * @return \Illuminate\Database\Eloquent\Relations\HasManyThrough
      */
-    public function shares(): HasMany
+    public function shares(): HasManyThrough
     {
-        return $this->hasMany(Share::class);
+        return $this->hasManyThrough(Share::class, GroupUser::class, 'user_id', 'group_user_id');
     }
 
     /**

--- a/app/Observers/GroupUserObserver.php
+++ b/app/Observers/GroupUserObserver.php
@@ -35,12 +35,10 @@ class GroupUserObserver
         foreach ($groupUser->comments as $comment) {
             $comment->delete();
         }
-        // todo:
-        // this has now opened a massive can of worms
-        // that is prompting me to rethink the db structure
-        // may have to change uses of user_id on share, comment and maybe debt
-        // to group_user_id
-        // either that, or end up with a lot of stupid queries
+
+        foreach ($groupUser->shares as $share) {
+            $share->delete();
+        }
     }
 
     /**

--- a/app/Policies/CommentPolicy.php
+++ b/app/Policies/CommentPolicy.php
@@ -30,8 +30,8 @@ class CommentPolicy
      */
     public function create(User $user, Debt $debt): bool
     {
-        return $debt->users()
-            ->where('users.id', $user->id)
+        return $debt->group_users()
+            ->where('group_users.user_id', $user->id)
             ->exists();
     }
 

--- a/app/Policies/SharePolicy.php
+++ b/app/Policies/SharePolicy.php
@@ -40,7 +40,7 @@ class SharePolicy
      */
     public function updateName(User $user, Share $share): bool
     {
-        return $user->id === $share->user_id || $user->id === $share->debt->user_id;
+        return $user->id === $share->group_user->user_id || $user->id === $share->debt->user_id;
     }
 
     /**
@@ -58,7 +58,7 @@ class SharePolicy
      */
     public function updateSent(User $user, Share $share): bool
     {
-        return $user->id === $share->user_id;
+        return $user->id === $share->group_user->user_id;
     }
 
     /**

--- a/app/Services/BalanceService.php
+++ b/app/Services/BalanceService.php
@@ -15,7 +15,7 @@ class BalanceService
      */
     public function addToGroupUserBalance($share): void
     {
-        if ($share->user_id === $share->debt->user_id) {
+        if ($share->group_user->user_id === $share->debt->user_id) {
             return;
         } else {
             $debt_owner = GroupUser::where('user_id', $share->debt->user_id)->first();
@@ -39,7 +39,7 @@ class BalanceService
      */
     public function updateGroupUserBalance($share, $difference): void
     {
-        if ($share->user_id === $share->debt->user_id) {
+        if ($share->group_user->user_id === $share->debt->user_id) {
             return;
         } else {
             $debt_owner = GroupUser::where('user_id', $share->debt->user_id)->first();
@@ -62,7 +62,7 @@ class BalanceService
      */
     public function subtractFromGroupUserBalance($share, $difference): void
     {
-        if ($share->user_id === $share->debt->user_id) {
+        if ($share->group_user->user_id === $share->debt->user_id) {
             return;
         } else {
             $debt_owner = GroupUser::where('user_id', $share->debt->user_id)->first();

--- a/app/Services/ShareService.php
+++ b/app/Services/ShareService.php
@@ -28,11 +28,11 @@ class ShareService
         foreach ($data as $share) {
             $share = Share::create([
                 'debt_id' => $debt->id,
-                'user_id' => $share['user_id'],
+                'group_user_id' => $share['group_user_id'],
                 'name' => $share['name'],
                 'amount' => Money::of($share['amount'], $debt->currency),
-                'sent' => $debt->user_id === $share['user_id'] ? 1 : 0,
-                'seen' => $debt->user_id === $share['user_id'] ? 1 : 0,
+                'sent' => $debt->user_id === auth()->user()->id ? 1 : 0,
+                'seen' => $debt->user_id === auth()->user()->id ? 1 : 0,
             ]);
 
             $this->balanceService->addToGroupUserBalance($share);    

--- a/app/Services/ShareService.php
+++ b/app/Services/ShareService.php
@@ -25,12 +25,13 @@ class ShareService
     public function createDebtShares($data, $debt): void
     {
         // create shares
-        foreach ($data as $share) {
+        foreach ($data as $user_share_data) {
+
             $share = Share::create([
                 'debt_id' => $debt->id,
-                'group_user_id' => $share['group_user_id'],
-                'name' => $share['name'],
-                'amount' => Money::of($share['amount'], $debt->currency),
+                'group_user_id' => $user_share_data['group_user_id'],
+                'name' => $user_share_data['name'],
+                'amount' => Money::of($user_share_data['amount'], $debt->currency),
                 'sent' => $debt->user_id === auth()->user()->id ? 1 : 0,
                 'seen' => $debt->user_id === auth()->user()->id ? 1 : 0,
             ]);

--- a/database/factories/DebtFactory.php
+++ b/database/factories/DebtFactory.php
@@ -75,8 +75,7 @@ class DebtFactory extends Factory
                 'debt_id' => $debt->id,
                 'amount' => $money[$key],
                 // debt owner share automatically set to 'sent'
-                // 'sent' => $group_user->user_id === $debt->user_id ? 1 : rand(0, 1),
-                'sent' => rand(0,1),
+                'sent' => $group_user->user->id === $debt->user_id ? 1 : rand(0, 1),
                 'seen' => 0,
             ]);
         }

--- a/database/factories/DebtFactory.php
+++ b/database/factories/DebtFactory.php
@@ -54,12 +54,11 @@ class DebtFactory extends Factory
 
     public function withComments() {
         return $this->afterCreating(function(Debt $debt) {
-            // todo: fix this when doing user->share relationship
-            foreach ($debt->users as $user) {
+            foreach ($debt->group_users as $group_user) {
                 Comment::factory()->create([
                     'debt_id' => $debt->id,
-                    'group_user_id' => $user->group_user->id,
-                    'content' => "Comment by {$user->group_user->user->name}"
+                    'group_user_id' => $group_user->id,
+                    'content' => "Comment by {$group_user->user->name}"
                 ]);
             }
         });
@@ -71,8 +70,8 @@ class DebtFactory extends Factory
 
         foreach ($group_users as $key => $group_user) {
             // create the share
-            $share = Share::factory()->calcTotal()->create([
-                'user_id' => $group_user->user->id,
+            Share::factory()->calcTotal()->create([
+                'group_user_id' => $group_user->id,
                 'debt_id' => $debt->id,
                 'amount' => $money[$key],
                 // debt owner share automatically set to 'sent'
@@ -96,8 +95,8 @@ class DebtFactory extends Factory
             $share_amount = $count === 1 ? $total : $split;
 
             // create the share
-            $share = Share::factory()->calcTotal()->create([
-                'user_id' => $group_user->user->id,
+            Share::factory()->calcTotal()->create([
+                'group_user_id' => $group_user->id,
                 'debt_id' => $debt->id,
                 'amount' => Money::ofMinor($share_amount, $debt->currency),
                 // debt owner share automatically set to 'sent'

--- a/database/factories/ShareFactory.php
+++ b/database/factories/ShareFactory.php
@@ -34,6 +34,7 @@ class ShareFactory extends Factory
      */
     public function calcTotal() {
         return $this->afterCreating(function(Share $share) {
+
             $share_group_user = $share->group_user;
             $debt_group_user = $share->debt->user->group_users->where('group_id', $share->debt->group_id)->first();
             
@@ -49,7 +50,7 @@ class ShareFactory extends Factory
             // as 'seen' is just cosmetic, randomise whether or not
             // as 'sent' share is also seen
             if ($share->sent) {
-                $share->seen =  $share->user_id === $share->debt->user_id ? 1 : rand(0,1);
+                $share->seen =  $share->group_user_id === $share->debt->user_id ? 1 : rand(0,1);
                 $share->save();
             }
         });

--- a/database/migrations/2025_01_08_161901_create_debts_table.php
+++ b/database/migrations/2025_01_08_161901_create_debts_table.php
@@ -14,8 +14,6 @@ return new class extends Migration
         Schema::create('debts', function (Blueprint $table) {
             $table->id();
             $table->foreignId('group_id')->constrained();
-            // debt owner/creator, renamed in a later migration
-            $table->foreignId('collector_group_user_id'); 
             $table->string('name');
             $table->float('amount', 2);
             $table->boolean('split_even');

--- a/database/migrations/2025_01_08_161902_create_shares_table.php
+++ b/database/migrations/2025_01_08_161902_create_shares_table.php
@@ -13,9 +13,8 @@ return new class extends Migration
     {
         Schema::create('shares', function (Blueprint $table) {
             $table->id();
-            // renamed to user_id in  later migration
-            $table->foreignId('user_id')->constrained();
             $table->foreignId('debt_id')->constrained();
+            $table->foreignId('group_user_id')->constrained();
             $table->float('amount', 2);
             $table->boolean('sent');
             $table->boolean('seen');

--- a/database/migrations/2025_03_19_101456_change_group_user_id_to_user_id_on_multiple_tables.php
+++ b/database/migrations/2025_03_19_101456_change_group_user_id_to_user_id_on_multiple_tables.php
@@ -11,11 +11,6 @@ return new class extends Migration
      */
     public function up(): void
     {
-        // drop old column name & re-add with key constraints
-        Schema::table('debts', function (Blueprint $table) {
-            $table->dropColumn('collector_group_user_id');
-        });
-
         Schema::table('debts', function (Blueprint $table) {
             $table->foreignId('user_id')->after('group_id')->constrained();
         }); 
@@ -26,8 +21,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('debts', function (Blueprint $table) {
-            $table->renameColumn('user_id', 'collector_group_user_id');
-        });
+
     }
 };

--- a/resources/js/Components/Debts/AddDebt/Form/AddDebtForm.vue
+++ b/resources/js/Components/Debts/AddDebt/Form/AddDebtForm.vue
@@ -58,8 +58,8 @@ function setSelectedGroup(groupId) {
 
     // userares is a preliminary version of a Share
     // with just the required info
-    store.addDebtForm.user_shares = selectedGroup.value.group_users.map(group_user => ({
-        user_id: group_user.user_id,
+    store.addDebtForm.user_shares = selectedGroup.value.group_users.map((group_user) => ({
+        group_user_id: group_user.id,
         name: '',
         amount: 0,
     }));

--- a/resources/js/Components/Debts/AddDebt/Form/AddDebtFormShare.vue
+++ b/resources/js/Components/Debts/AddDebt/Form/AddDebtFormShare.vue
@@ -12,7 +12,7 @@ const props = defineProps({
 });
 
 const share = ref(store.addDebtForm.user_shares.find((userShare) => 
-    userShare.user_id == props.group_user.user_id
+    userShare.group_user_id == props.group_user.id
 ));
 
 function setShareAmount() {
@@ -32,12 +32,14 @@ function toggleShareChecked(toggle) {
     share.value.checked = toggle;
 
     store.addDebtForm.user_shares.find((userShare) => 
-        userShare.user_id == share.value.user_id).checked = share.value.checked;
+        userShare.group_user_id == share.value.group_user_id).checked = share.value.checked;
 
     store.splitEven();
 }
 
-onMounted(() => {});
+onMounted(() => {
+    console.log(share.value);
+});
 
 </script>
 <template>

--- a/resources/js/Components/Shares/AddShare.vue
+++ b/resources/js/Components/Shares/AddShare.vue
@@ -42,15 +42,15 @@ onMounted(() => {
             @success="refresh & refresh()"
         >
             <select 
-                name="user_id"
-                id="user_id"
+                name="group_user_id"
+                id="group_user_id"
                 class="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
             >
                 <option value="" disabled selected>Select a user</option>
                 <option 
                     v-for="group_user in group_users" 
                     :key="group_user.id" 
-                    :value="group_user.user.id"
+                    :value="group_user.id"
                     
                 >
                     {{ group_user.user.name }}

--- a/resources/js/Components/Shares/Share.vue
+++ b/resources/js/Components/Shares/Share.vue
@@ -58,7 +58,7 @@ onMounted(() => {
             <!-- sent/seen/controls/owner badge container -->
             <div class="flex flex-row items-center" >
                 <!-- sent & seen -->
-                <div v-if="props.share.user_id !== props.debt.user_id" class="flex flex-row items-center">
+                <div v-if="props.share.group_user.user.id !== props.debt.user_id" class="flex flex-row items-center">
                     <SentSeenButton
                         operation="sent"
                         :share="share"

--- a/tests/Feature/Http/Controllers/DebtControllerTest.php
+++ b/tests/Feature/Http/Controllers/DebtControllerTest.php
@@ -3,14 +3,10 @@
 use App\Models\User;
 Use App\Models\Group;
 use App\Models\Debt;
-use App\Models\Share;
-use App\Models\GroupUser;
 use Inertia\Testing\AssertableInertia as Assert;
 use Carbon\Carbon;
-use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Event;
 use App\Events\DebtCreated;
-use App\Listeners\DebtCreatedNotification;
 
 beforeEach(function () {
     // create a handful of users so those involved can be randomised

--- a/tests/Feature/Http/Controllers/DebtControllerTest.php
+++ b/tests/Feature/Http/Controllers/DebtControllerTest.php
@@ -57,7 +57,7 @@ test('debts, shares and comments all appear with permissions paginated', functio
 });
 
 test('user can add a debt with different value shares', function() {
-    $user_shares = selectRandomGroupUsers($this->users, 100, false);
+    $user_shares = selectRandomGroupUsers($this->group->group_users, 100, false);
 
     Event::fake();
 
@@ -95,16 +95,16 @@ test('user can add a debt with different value shares', function() {
     // loop over the values that were posted to check the splits are correct on each share
     foreach ($user_shares as $share) {
         $this->assertDatabaseHas('shares', [
-            'user_id' => $share['user_id'],
+            'group_user_id' => $share['group_user_id'],
             'debt_id' => $debt->id,
             'amount' => $share['amount'] * 100,
-            'name' => 'share for user ' . $share['user_id'],
+            'name' => 'share for user ' . $share['group_user_id'],
         ]);
     }
 });
 
 test('user can add a debt that is split even', function() {
-    $user_shares = selectRandomGroupUsers($this->users, 100, true);
+    $user_shares = selectRandomGroupUsers($this->group->group_users, 100, true);
 
     Event::fake();
 
@@ -140,10 +140,10 @@ test('user can add a debt that is split even', function() {
     // loop over the values that were posted to check the splits are correct on each share
     foreach ($user_shares as $share) {
         $this->assertDatabaseHas('shares', [
-            'user_id' => $share['user_id'],
+            'group_user_id' => $share['group_user_id'],
             'debt_id' => $debt->id,
             'amount' => $share['amount'] * 100,
-            'name' => 'share for user ' . $share['user_id'],
+            'name' => 'share for user ' . $share['group_user_id'],
         ]);
     }
 });
@@ -273,7 +273,7 @@ test('deleting a debt deletes the relevant shares', function() {
     foreach ($shares as $share) {
         $this->assertDatabaseHas('shares', [
             'id' => $share->id,
-            'user_id' => $share->user_id,
+            'group_user_id' => $share->group_user_id,
             'debt_id' => $debt->id,
             'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
         ]);
@@ -317,7 +317,7 @@ test('updating the amount on a split even debt updates the shares', function() {
     foreach ($shares as $key => $share) {
         $this->assertDatabaseHas('shares', [
             'id' => $share->id,
-            'user_id' => $share->user_id,
+            'group_user_id' => $share->group_user_id,
             'debt_id' => $debt->id,
             'amount' => $split[$key]->getMinorAmount()->toInt(),
         ]);

--- a/tests/Feature/Http/Controllers/GroupUserControllerTest.php
+++ b/tests/Feature/Http/Controllers/GroupUserControllerTest.php
@@ -3,7 +3,7 @@
 use App\Models\User;
 Use App\Models\Group;
 use App\Models\Debt;
-use App\Models\GroupUser;
+use App\Models\Alias;
 use App\Models\Comment;
 use Carbon\Carbon;
 
@@ -78,5 +78,49 @@ test('deleting a group user also delets their comments', function() {
         'id' => $comment->id,
         'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
         'group_user_id' => $this->group->group_users[0]->id,
+    ]);
+});
+
+test('deleting a group user also delets their shares', function() {
+    $this->actingAs($this->user);
+
+    $debt = Debt::factory()->withShares()->create([
+        'group_id' => $this->group->id,
+        'user_id' => $this->user->id,
+    ]);
+
+    $share = $debt->shares->where('group_user_id', $this->group->group_users[0]->id)->first();
+
+    $response = $this->delete(route('group-users.destroy', $this->group->group_users[0]));
+
+    $response->assertStatus(302)
+        ->assertSessionHas('status', 'Group User deleted successfully.');
+
+    $this->assertDatabaseHas('shares', [
+        'id' => $share->id,
+        'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
+        'group_user_id' => $share->group_user_id,
+    ]);
+});
+
+test('deleting a group user also delets their aliases', function() {
+    $this->actingAs($this->user);
+
+    $group_user = $this->group->group_users->firstWhere('id', '!=', $this->user->id);
+
+    $alias = Alias::factory()->create([
+        'user_id' => $this->user->id,
+        'group_user_id' => $group_user->id,
+    ]);
+
+    $response = $this->delete(route('group-users.destroy', $group_user));
+
+    $response->assertStatus(302)
+        ->assertSessionHas('status', 'Group User deleted successfully.');
+
+    $this->assertDatabaseHas('aliases', [
+        'id' => $alias->id,
+        'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
+        'group_user_id' => $alias->group_user_id,
     ]);
 });

--- a/tests/Feature/Http/Controllers/ShareControllerTest.php
+++ b/tests/Feature/Http/Controllers/ShareControllerTest.php
@@ -22,7 +22,8 @@ beforeEach(function () {
         'user_id' => $this->user->id,
     ]);
 
-    $this->group = Group::where('user_id', $this->user->id)->get()[0];
+    $this->group = Group::where('user_id', $this->user->id)->first();
+    $this->group_users = $this->group->group_users;
 
     $this->actingAs($this->user);
 });
@@ -33,7 +34,7 @@ test("user can select 'sent' on their own share", function () {
         'group_id' => $this->group->id,
     ]);
 
-    $share = $debt->shares->where('user_id', $this->user->id)->first();
+    $share = $debt->shares->where('group_user_id', $this->group_users[0]->id)->first();
     
     $response = $this->patch(route('share.sent', $share), [
         'id' => $share->id,
@@ -57,7 +58,7 @@ test("user can not select 'sent' on a share they do not own", function () {
 
     // get a share that's not mine
     $share = $debt->shares->reject(fn($share) => 
-        $share->user_id === $this->user->id)->first();
+        $share->group_user_id === $this->group_users[0]->id)->first();
 
     // try to update it
     $response = $this->patch(route('share.sent', $share), [
@@ -220,7 +221,7 @@ test("user can update the name on a share for a debt they own", function() {
         'group_id' => $this->group->id,
     ]);
     
-    $share = $debt->shares->where('user_id', $this->user->id)->first();
+    $share = $debt->shares->where('group_user_id', $this->group_users[0]->id)->first();
 
     // update it
     $response = $this->patch(route('share.update', $share), [
@@ -236,7 +237,7 @@ test("user can update the name on a share for a debt they own", function() {
 
     $this->assertDatabaseHas('shares', [
         'id' => $share->id,
-        'user_id' => $share->user_id,
+        'group_user_id' => $share->group_user_id,
         'name' => 'new name for this share'
     ]);
 });
@@ -248,7 +249,7 @@ test("user can update the amount on a share for a debt they own", function() {
         'split_even' => 0,
     ]);
     
-    $share = $debt->shares->where('user_id', $this->user->id)->first();
+    $share = $debt->shares->where('group_user_id', $this->group_users[0]->id)->first();
 
     // the 'new' amount is basically what the user sees,
     // e..g if they add a fiver it's just 5
@@ -273,7 +274,7 @@ test("user can update the amount on a share for a debt they own", function() {
 
     $this->assertDatabaseHas('shares', [
         'id' => $share->id,
-        'user_id' => $share->user_id,
+        'group_user_id' => $share->group_user_id,
         'amount' => $new->getMinorAmount()->toInt(),
     ]);
 
@@ -292,7 +293,7 @@ test("user can add a share for themselves for a debt they own", function() {
 
     $response = $this->post(route('share.store'), [
         'debt_id' => $debt->id,
-        'user_id' => $this->user->id,
+        'group_user_id' => $this->group_users[0]->id,
         'amount' => 500,
         'name' => 'new share',
         'currency' => 'GBP',
@@ -304,7 +305,7 @@ test("user can add a share for themselves for a debt they own", function() {
 
     $this->assertDatabaseHas('shares', [
         'debt_id' => $debt->id,
-        'user_id' => $this->user->id,
+        'group_user_id' => $this->group_users[0]->id,
         'amount' => 500 * 100,
     ]);
 });
@@ -316,12 +317,12 @@ test("user can add a share for another user for a debt they own", function() {
         'split_even' => 0,
     ]);
 
-    $other_user = $debt->users->reject(fn($user) => 
-        $user->id === $this->user->id)->first();
+    $other_group_user = $debt->group_users->reject(fn($group_user) => 
+        $group_user->id === $this->group_users[0]->id)->first();
 
     $response = $this->post(route('share.store'), [
         'debt_id' => $debt->id,
-        'user_id' => $other_user->id,
+        'group_user_id' => $other_group_user->id,
         'amount' => 750,
         'name' => 'new share for other user',
         'currency' => 'GBP',
@@ -333,7 +334,7 @@ test("user can add a share for another user for a debt they own", function() {
 
     $this->assertDatabaseHas('shares', [
         'debt_id' => $debt->id,
-        'user_id' => $other_user->id,
+        'group_user_id' => $other_group_user->id,
         'amount' => 750 * 100,
     ]);
 });
@@ -352,7 +353,7 @@ test("user can not add a share for a debt they do not own", function() {
 
     $response = $this->post(route('share.store'), [
         'debt_id' => $debt->id,
-        'user_id' => $this->user->id,
+        'group_user_id' => $this->group_users[0]->id,
         'amount' => 500,
         'name' => 'new share',
         'currency' => 'GBP',
@@ -363,7 +364,7 @@ test("user can not add a share for a debt they do not own", function() {
 
     $this->assertDatabaseMissing('shares', [
         'debt_id' => $debt->id,
-        'user_id' => $this->user->id,
+        'group_user_id' => $this->group_users[0]->id,
         'amount' => 500,
     ]);
 });
@@ -394,7 +395,8 @@ test("user can not update the name or amount on a share for a debt they do not o
         'group_id' => $this->group->id,
     ]);
     
-    $share = $debt->shares->first();
+    $share = $debt->shares->reject(fn($share) => 
+        $share->group_user_id === $this->group_users[0]->id)->first();
  
     $new = $share->amount->plus(Money::of(10, 'GBP'));
 

--- a/tests/Feature/TotalBalanceTest.php
+++ b/tests/Feature/TotalBalanceTest.php
@@ -151,43 +151,38 @@ test("adding a standard share for yourself doesn't add it to your balance", func
 
 test("adding a standard share for another user recalculates both your balances", function() {
     $debt = Debt::factory()->withShares()->create([
-            'group_id' => Group::where('user_id', $this->self->id)->first()->id,
-            'user_id' => $this->self->id,
-            'split_even' => 0,
-            'amount' => Money::of(100, 'GBP'),
-        ]);
+        'user_id' => $this->self->id,
+        'group_id' => $this->group->id,
+        'split_even' => 0,
+    ]);
 
-    $other_user = $debt->users->reject(fn($user) => 
-        $user->id === $this->self->id)->first();
-
-    $other_user_original_balance = $other_user->user_balance;
-    $self_original_balance = $this->self->user_balance;
+    $other_group_user = $debt->group_users->reject(fn($group_user) => 
+        $group_user->user->id === $this->self->id)->first();
 
     $response = $this->post(route('share.store'), [
         'debt_id' => $debt->id,
-        'user_id' => $other_user->id,
+        'group_user_id' => $other_group_user->id,
         'amount' => 1,
         'name' => 'new share',
     ]);
 
     $response->assertStatus(302);
 
-    $users = collect([$other_user, $this->self]);
+    $users = collect([$other_group_user->user, $this->self]);
     
-    checkUserBalances($users);
+    $this->assertTrue(checkUserBalances($users));
 });
 
 test("updating the amount of a standard share for yourself doesn't recalculate your balance", function() {
     $debt = Debt::factory()->withShares()->create([
-            'group_id' => Group::where('user_id', $this->self->id)->first()->id,
-            'user_id' => $this->self->id,
-            'split_even' => 0,
-            'amount' => Money::of(100, 'GBP'),
-        ]);
+        'user_id' => $this->self->id,
+        'group_id' => $this->group->id,
+        'split_even' => 0,
+    ]);
 
-    $original_balance = $debt->user->user_balance;
+    $own_group_user = $this->group_users->where('user_id', $this->self->id)->first();
 
-    $share = $debt->shares->where('user_id', $this->self->id)->first();
+    $share = $debt->shares->where('group_user_id', $own_group_user->id)->first();
 
     $new_amount = $share->amount->plus(10);
 
@@ -203,7 +198,7 @@ test("updating the amount of a standard share for yourself doesn't recalculate y
 
     $users = collect([$this->self]);
     
-    checkUserBalances($users);
+    $this->assertTrue(checkUserBalances($users));
 });
 
 test("updating the amount of a standard share for another user recalculates both your balances", function() {
@@ -214,16 +209,13 @@ test("updating the amount of a standard share for another user recalculates both
             'amount' => Money::of(100, 'GBP'),
         ]);
 
-    $other_share = $debt->shares->reject(fn($share) => 
-        $share->user_id === $this->self->id)->first();
+    $other_group_user = $debt->group_users->reject(fn($group_user) => 
+        $group_user->user->id === $this->self->id)->first();
 
-    $new_amount = $other_share->amount->plus(20);
+    $other_share = $other_group_user->shares->first();
 
-    $other_user = $other_share->user;
+    $new_amount = $other_share->amount->plus(20);;
     
-    $other_user_original_balance = $other_user->user_balance;
-    $self_original_balance = $this->self->user_balance;
-
     $response = $this->patch(route('share.update', $other_share), [
         'id' => $other_share->id,
         'debt_id' => $debt->id,
@@ -233,9 +225,9 @@ test("updating the amount of a standard share for another user recalculates both
 
     $response->assertStatus(302);
    
-    $users = collect([$other_user, $this->self]);
+    $users = collect([$other_group_user->user, $this->self]);
     
-    checkUserBalances($users);
+    $this->assertTrue(checkUserBalances($users));
 });
 
 test("deleting a standard share for yourself doesn't recalculate the user's balance", function() {
@@ -246,9 +238,9 @@ test("deleting a standard share for yourself doesn't recalculate the user's bala
             'amount' => Money::of(100, 'GBP'),
         ]);
 
-    $original_balance = $debt->user->user_balance;
+    $own_group_user = $this->group_users->where('user_id', $this->self->id)->first();
 
-    $share = $debt->shares->where('user_id', $this->self->id)->first();
+    $share = $debt->shares->where('group_user_id', $own_group_user->id)->first();
   
     $response = $this->delete(route('share.destroy', $share));
 
@@ -256,7 +248,7 @@ test("deleting a standard share for yourself doesn't recalculate the user's bala
    
     $users = collect([$this->self]);
     
-    checkUserBalances($users);
+    $this->assertTrue(checkUserBalances($users));
 });
 
 test("deleting a standard share for another user recalculates both your balances", function() {
@@ -267,21 +259,18 @@ test("deleting a standard share for another user recalculates both your balances
             'amount' => Money::of(100, 'GBP'),
         ]);
 
-    $other_share = $debt->shares->reject(fn($share) => 
-        $share->user_id === $this->self->id)->first();
+    $other_group_user = $debt->group_users->reject(fn($group_user) => 
+        $group_user->user->id === $this->self->id)->first();
 
-    $other_user = $other_share->user;
+    $other_share = $other_group_user->shares->first();
     
-    $other_user_original_balance = $other_user->user_balance;
-    $self_original_balance = $this->self->user_balance;
-
     $response = $this->delete(route('share.destroy', $other_share));
 
     $response->assertStatus(302);
    
-    $users = collect([$other_user, $this->self]);
+    $users = collect([$other_group_user->user, $this->self]);
     
-    checkUserBalances($users);
+    $this->assertTrue(checkUserBalances($users));
 });
 
 /**
@@ -302,10 +291,14 @@ test("updating a split even share recalculates the user's balance", function() {
 
 function checkUserBalances($users) {
     foreach ($users as $user) {
-        $group_users = GroupUser::where('user_id', $user->id);
-        $sum = $group_users->sum('balance');
+        
+        // first, the actual user_balance
         $user_balance = $user->user_balance;
 
+        // then figure out the sum of the individual group_user->balances
+        $group_users = GroupUser::where('user_id', $user->id);
+        $sum = $group_users->sum('balance');
+        
         // if $user_balance is null/0, it won't be accessed as a money object
         if ($user->user_balance == null) {
             return $sum == $user_balance;

--- a/tests/Feature/TotalBalanceTest.php
+++ b/tests/Feature/TotalBalanceTest.php
@@ -7,9 +7,17 @@ use Brick\Money\Money;
 use Illuminate\Support\Facades\Event;
 
 beforeEach(function () {
-    $this->seed();
-    $this->users = User::all();
+    $this->users = User::factory(5)->create();
     $this->self = $this->users[0];
+
+    Group::factory(1)->withGroupUsers()->create([
+        'user_id' => $this->self->id,
+    ]);
+
+    $this->group = Group::first();
+
+    $this->group_users = $this->group->group_users;
+
     $this->actingAs($this->self);
 });
 
@@ -17,18 +25,18 @@ beforeEach(function () {
 // $sum, however is just a sum of the db values, therefore isn't hit by the
 // accessor in the same way
 test("the seeded db calculates all user's user balance correctly", function() {
+    $this->seed();
     $this->assertTrue(checkUserBalances($this->users));
 });
 
 test("adding a standard debt recalculates the user balances", function() {
     Event::fake();
     $debt_total = 100;
-    $group = Group::where('user_id', $this->self->id)->first();
 
-    $user_shares = selectRandomGroupUsers($group->users, $debt_total, false);
+    $user_shares = selectRandomGroupUsers($this->group->users, $debt_total, false);
 
     $response = $this->post(route('debt.store'), [
-        'group_id' => $group->id,
+        'group_id' => $this->group->id,
         'user_id' => $this->self->id,
         'name' => 'test debt 123',
         'amount' => $debt_total,
@@ -36,10 +44,10 @@ test("adding a standard debt recalculates the user balances", function() {
         'user_shares' => $user_shares,
         'currency' => 'GBP',
     ]);
-
+    
     $response->assertStatus(302);
 
-    $this->assertTrue(checkUserBalances($group->users));
+    $this->assertTrue(checkUserBalances($this->users));
 });
 
 test("deleting a standard debt recalculates the user's balance", function() {

--- a/tests/Feature/TotalBalanceTest.php
+++ b/tests/Feature/TotalBalanceTest.php
@@ -33,7 +33,7 @@ test("adding a standard debt recalculates the user balances", function() {
     Event::fake();
     $debt_total = 100;
 
-    $user_shares = selectRandomGroupUsers($this->group->users, $debt_total, false);
+    $user_shares = selectRandomGroupUsers($this->group_users, $debt_total, false);
 
     $response = $this->post(route('debt.store'), [
         'group_id' => $this->group->id,
@@ -44,22 +44,25 @@ test("adding a standard debt recalculates the user balances", function() {
         'user_shares' => $user_shares,
         'currency' => 'GBP',
     ]);
-    
+
     $response->assertStatus(302);
 
     $this->assertTrue(checkUserBalances($this->users));
 });
 
 test("deleting a standard debt recalculates the user's balance", function() {
-    $debt = Debt::where('split_even', 0)->first();
-
-    $response = $this->delete(route('debt.destroy', $debt), [
-        'id' => $debt->id
+    $debt = Debt::factory()->withShares()->create([
+        'user_id' => $this->self->id,
+        'group_id' => $this->group->id,
+        'split_even' => 0,
     ]);
+
+    $users = $debt->group_users->pluck('user');
+    $response = $this->delete(route('debt.destroy', $debt));
 
     $response->assertStatus(302);
 
-    $this->assertTrue(checkUserBalances($debt->group->users));
+    $this->assertTrue(checkUserBalances($users));
 });
 
 test("updating a standard debt recalculates the user's balance", function() {
@@ -73,12 +76,11 @@ test("updating a standard debt recalculates the user's balance", function() {
 test("adding a split even debt recalculates the user's balance", function() {
     Event::fake();
     $debt_total = 100;
-    $group = Group::where('user_id', $this->self->id)->first();
 
-    $user_shares = selectRandomGroupUsers($group->users, $debt_total, false);
+    $user_shares = selectRandomGroupUsers($this->group_users, $debt_total, false);
 
     $response = $this->post(route('debt.store'), [
-        'group_id' => $group->id,
+        'group_id' => $this->group->id,
         'user_id' => $this->self->id,
         'name' => 'test debt 123',
         'amount' => $debt_total,
@@ -89,27 +91,31 @@ test("adding a split even debt recalculates the user's balance", function() {
 
     $response->assertStatus(302);
 
-    $this->assertTrue(checkUserBalances($group->users));
+    $this->assertTrue(checkUserBalances($this->users));
 });
 
 test("deleting a split even debt recalculates the user's balance", function() {
-    $debt = Debt::where('split_even', 1)->first();
+    $debt = Debt::factory()->withShares()->create([
+        'user_id' => $this->self->id,
+        'group_id' => $this->group->id,
+        'split_even' => 1,
+    ]);
 
+    $users = $debt->group_users->pluck('user');
     $response = $this->delete(route('debt.destroy', $debt));
 
     $response->assertStatus(302);
 
-    $this->assertTrue(checkUserBalances($debt->group->users));
+    $this->assertTrue(checkUserBalances($users));
 });
 
 test("updating a split even debt recalculates the user's balance", function() {
     Event::fake();
     $debt = Debt::factory()->withShares()->create([
-            'group_id' => Group::where('user_id', $this->self->id)->first()->id,
-            'user_id' => $this->self->id,
-            'split_even' => 1,
-            'amount' => Money::of(100, 'GBP'),
-        ]);
+        'user_id' => $this->self->id,
+        'group_id' => $this->group->id,
+        'split_even' => 1,
+    ]);
 
     $response = $this->patch(route('debt.update', $debt), [
         'id' => $debt->id,
@@ -124,11 +130,10 @@ test("updating a split even debt recalculates the user's balance", function() {
 
 test("adding a standard share for yourself doesn't add it to your balance", function() {
     $debt = Debt::factory()->withShares()->create([
-            'group_id' => Group::where('user_id', $this->self->id)->first()->id,
-            'user_id' => $this->self->id,
-            'split_even' => 0,
-            'amount' => Money::of(100, 'GBP'),
-        ]);
+        'user_id' => $this->self->id,
+        'group_id' => $this->group->id,
+        'split_even' => 0,
+    ]);
 
     $original_balance = $debt->user->user_balance;
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -52,30 +52,30 @@ function something()
  * the last user remaining takes the last share
  * return the key value pair of user_ids and share amounts
  */
-function selectRandomGroupUsers($users, $debt_total, $split_even) {
-    $users = $users->random(rand(2, $users->count()));
+function selectRandomGroupUsers($group_users, $debt_total, $split_even) {
+    $group_users = $group_users->random(rand(2, $group_users->count()));
 
     if (!$split_even) {
-        while($users->count() > 0) {
+        while($group_users->count() > 0) {
             // if there's only one user left, they take the remaining debt
-            if ($users->count() === 1) {
-                $user = $users->pop();
+            if ($group_users->count() === 1) {
+                $group_user = $group_users->pop();
 
-                $user_shares[] = [
-                    'user_id' => $user->id,
-                    'name' => 'share for user ' . $user->id,
+                $group_user_shares[] = [
+                    'group_user_id' => $group_user->id,
+                    'name' => 'share for user ' . $group_user->id,
                     'amount' => $debt_total,
                 ];
             // otherwise, we take the last user and give them a random chunk of the debt
             // then subtract that from the debt total
             } else {
-                $user = $users->pop();
+                $group_user = $group_users->pop();
 
-                $share_amount = rand(1, $debt_total / $users->count());
+                $share_amount = rand(1, $debt_total / $group_users->count());
 
-                $user_shares[] = [
-                    'user_id' => $user->id,
-                    'name' => 'share for user ' . $user->id,
+                $group_user_shares[] = [
+                    'group_user_id' => $group_user->id,
+                    'name' => 'share for user ' . $group_user->id,
                     'amount' => $share_amount,
                 ];
 
@@ -84,18 +84,18 @@ function selectRandomGroupUsers($users, $debt_total, $split_even) {
         }
     } else {
         // because the rounding is done on the frontend, we have to replicate it here
-        $share_amount = floor(($debt_total / $users->count()) * 100) / 100;
-        $remainder = $debt_total - ($share_amount * $users->count());
-        foreach ($users as $user) {
-            $user_shares[] = [
-                'user_id' => $user->id,
-                'name' => 'share for user ' . $user->id,
+        $share_amount = floor(($debt_total / $group_users->count()) * 100) / 100;
+        $remainder = $debt_total - ($share_amount * $group_users->count());
+        foreach ($group_users as $group_user) {
+            $group_user_shares[] = [
+                'group_user_id' => $group_user->id,
+                'name' => 'share for user ' . $group_user->id,
                 'amount' => $share_amount,
             ];
         }
 
-        $user_shares[0]['amount'] += $remainder;
+        $group_user_shares[0]['amount'] += $remainder;
     }
 
-    return $user_shares;
+    return $group_user_shares;
 }


### PR DESCRIPTION
Similar to the previous PR, this is for changing user->shares to group_user shares, and all the extra changes required off the back of that. 

- Made all the relevant syntax changes across the board.
- debt->user relationship now debt->group_user.
- share->group_user debt is now simplified, no need for laravel magic anymore.
- user->shares is now a `HasManyThrough` relationship, with `group_user` as the pivot.
- Fixed all relevant tests

Extras:
- Slight improvement in query for `debts` index, only calling on `name` and `id` for users.
- Bunch of old, unused namespace cleanups.
- `GroupUserObserver` now deletes shares on group user deletion.
- Made forgotten necessary changes to comment policy following the last PR.
- Cleaned up some old migrations as there's no real bearing in having a proper history of mig changes.
- Added a couple of extra tests around group user deletion