### PR TITLE
GroupUser improvements

### DIFF
--- a/app/Http/Controllers/GroupUserController.php
+++ b/app/Http/Controllers/GroupUserController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\GroupUser;
+use App\Models\Group;
 use Illuminate\Http\RedirectResponse;
 
 class GroupUserController extends Controller
@@ -62,6 +63,9 @@ class GroupUserController extends Controller
      * Share deletion & balance adjustments are handled in the GroupUserObserver.
      *
      * Alias & Comment deletion is handled in the GroupUserObserver.
+     *
+     * If the user is removing themselves from a group, allocate the selected
+     * user id as group owner.
      */
     public function destroy(Request $request, GroupUser $group_user): RedirectResponse
     {
@@ -70,6 +74,12 @@ class GroupUserController extends Controller
         } 
             
         $group_user->delete();
+
+        if ($request->get('new_owner')) {
+            Group::findOrFail($group_user->group_id)->update([
+                'user_id' => $request->get('new_owner'),
+            ]);
+        }
 
         return redirect()->route('group.index')->with('status', 'Group User deleted successfully.');
     }

--- a/app/Policies/GroupUserPolicy.php
+++ b/app/Policies/GroupUserPolicy.php
@@ -4,7 +4,6 @@ namespace App\Policies;
 
 use App\Models\GroupUser;
 use App\Models\User;
-use Illuminate\Auth\Access\Response;
 
 class GroupUserPolicy
 {
@@ -37,18 +36,19 @@ class GroupUserPolicy
      */
     public function update(User $user, GroupUser $groupUser): bool
     {
-        // user can delete group_user if user owns the group
         // this currently doesn't get used anywhere, as the only use is for aliases
         return $user->id === $groupUser->group->user_id;
     }
 
     /**
      * Determine whether the user can delete the model.
+     *
+     * User can delete a group user if they own that group,
+     * or if they are removing (deleting) themselves from the group.
      */
     public function delete(User $user, GroupUser $groupUser): bool
     {
-        // user can delete group_user if user owns the group
-        return $user->id === $groupUser->group->user_id;
+        return $user->id === $groupUser->group->user_id || $user->id === $groupUser->user_id;
     }
 
     /**

--- a/resources/js/Components/Debts/AddDebt/Form/AddDebtForm.vue
+++ b/resources/js/Components/Debts/AddDebt/Form/AddDebtForm.vue
@@ -123,6 +123,7 @@ async function addDebt() {
             <div v-if="selectedGroup">
                 <UserPicker
                     :group_users="selectedGroup.group_users"
+                    label="This will be the owner of the debt"
                     :errors="debtStore.debtForm.errors.user_id"
                     @userSelected="setDebtOwner"
                 >

--- a/resources/js/Components/Forms/UserPicker.vue
+++ b/resources/js/Components/Forms/UserPicker.vue
@@ -6,6 +6,9 @@ const props = defineProps({
     group_users: {
         type: Object,
     },
+    label: {
+        type: String,
+    },
     errors: {
         type: String,
     }
@@ -16,10 +19,10 @@ const props = defineProps({
     <div class="py-2">
         <label 
             for="user-picker" 
-            class="block text-sm font-medium text-gray-700"
+            class="block text-sm font-medium text-gray-700 mb-2"
             id="user-label"
         >
-            This will be the owner of the debt
+            {{ label }}
         </label>
         <select
             @change="$emit('userSelected', $event.target.value)" 

--- a/resources/js/Components/GroupUsers/GroupUser.vue
+++ b/resources/js/Components/GroupUsers/GroupUser.vue
@@ -134,7 +134,7 @@ onMounted(() => {
         <Modal :show="confirmingGroupUserDeletion" @close="confirmingGroupUserDeletion = false">
             <div class="p-6 flex flex-col">
                 <h2 class="text-lg font-medium text-gray-900 mb-2">
-                    Are you sure you want remove {{ usePage().props.auth.user.id === props.group_user.user_id ? 'yourself' : group_user.user.name }} from "<i>{{ group.name }}</i>"?
+                    Are you sure you want remove {{ usePage().props.auth.user.id === props.group_user.user_id ? 'yourself' : group_user.user.name }} from "<i>{{ group.name }}</i>"? Deleting this user will remove their debts & shares.
                 </h2>
                 <!-- pass in all users but self, feels silly to set it as a variable when it's not always used -->
                 <UserPicker

--- a/resources/js/Components/GroupUsers/GroupUser.vue
+++ b/resources/js/Components/GroupUsers/GroupUser.vue
@@ -107,7 +107,7 @@ onMounted(() => {
                     <div class="flex flex-row mt-4 justify-center sm:justify-end w-full">
                         <SecondaryButton
                             type="button"
-                            @click="isEditing = false"
+                            @click="isEditing = false;refresh & refresh()"
                         >
                             Cancel
                         </SecondaryButton>
@@ -160,7 +160,7 @@ onMounted(() => {
                 >
                     <div class="flex flex-row mt-4 justify-center sm:justify-end w-full">
                         <SecondaryButton 
-                            @click="confirmingGroupUserDeletion = false;"
+                            @click="confirmingGroupUserDeletion = false"
                         >
                             Cancel
                         </SecondaryButton>

--- a/resources/js/Components/GroupUsers/GroupUser.vue
+++ b/resources/js/Components/GroupUsers/GroupUser.vue
@@ -11,6 +11,7 @@ import SecondaryButton from '@/Components/Misc/SecondaryButton.vue';
 import DangerButton from '@/Components/Misc/DangerButton.vue';
 import TextInput from '@/Components/Forms/TextInput.vue';
 import UserProfileIcon from '../Users/UserProfileIcon.vue';
+import UserPicker from '@/Components/Forms/UserPicker.vue';
 
 const props = defineProps({
     group_user: {
@@ -25,20 +26,28 @@ const props = defineProps({
 const refresh = inject('collapsibleRefresh');
 const confirmingGroupUserDeletion = ref(false);
 const isEditing = ref(false);
+const newOwner = ref(null);
 
+/**
+ * Initially, all aliases are loaded with the user, so the correct one needs to be
+ * paired to the user as a computed property, based on who is logged in.
+ */
 const alias = computed({
-    // if there are group user aliases, find the one for the logged in user
-    // otherwise, return object with alias property & empty string
     get() {
         return props.group_user.aliases.find(
             alias => alias.user_id === Number(usePage().props.auth.user.id)
         ) || { alias: '' };
     },
-    // set the alias object to the input value
     set(value) {
         this.alias = value;
     }
 });
+
+
+function setGroupOwner(userId) {
+    newOwner.value = userId;
+    console.log(newOwner.value);
+}
 
 onMounted(() => {
 
@@ -125,16 +134,32 @@ onMounted(() => {
         <Modal :show="confirmingGroupUserDeletion" @close="confirmingGroupUserDeletion = false">
             <div class="p-6 flex flex-col">
                 <h2
+                    v-if="usePage().props.auth.user.id !== props.group_user.user_id"
                     class="text-lg font-medium text-gray-900"
                 >
                     Are you sure you want remove <i>{{ group_user.user.name }}</i> from "<i>{{ group.name }}</i>"?
+                </h2>
+                <h2
+                    v-else
+                >
+                    You are the owner of this group, please select a new user to be the owner:
+                    <!-- pass in all users but self, feels silly to set it as a variable when it's not always used -->
+                    <UserPicker
+                        :group_users="props.group.group_users.filter((group_user) => group_user.user_id !== usePage().props.auth.user.id)"
+                        @userSelected="setGroupOwner"
+                        >
+                    </UserPicker>
                 </h2>
                 <Form
                     class="mt-6 flex flex-col justify-end"
                     :action="route('group-users.destroy', props.group_user)"
                     method="delete"
                     #default="{ errors }"
-                    @success="confirmingGroupUserDeletion = false;refresh & refresh()"
+                    :transform="data => ({
+                        ...data,
+                        new_owner: newOwner,
+                    })"
+                    @success="confirmingGroupUserDeletion = false;refresh & refresh();newOwner.value = null"
                     :options="{
                         preserveScroll: true,
                     }"

--- a/resources/js/Components/GroupUsers/GroupUser.vue
+++ b/resources/js/Components/GroupUsers/GroupUser.vue
@@ -133,23 +133,17 @@ onMounted(() => {
         </div>
         <Modal :show="confirmingGroupUserDeletion" @close="confirmingGroupUserDeletion = false">
             <div class="p-6 flex flex-col">
-                <h2
-                    v-if="usePage().props.auth.user.id !== props.group_user.user_id"
-                    class="text-lg font-medium text-gray-900"
-                >
-                    Are you sure you want remove <i>{{ group_user.user.name }}</i> from "<i>{{ group.name }}</i>"?
+                <h2 class="text-lg font-medium text-gray-900 mb-2">
+                    Are you sure you want remove {{ usePage().props.auth.user.id === props.group_user.user_id ? 'yourself' : group_user.user.name }} from "<i>{{ group.name }}</i>"?
                 </h2>
-                <h2
-                    v-else
+                <!-- pass in all users but self, feels silly to set it as a variable when it's not always used -->
+                <UserPicker
+                    v-if="props.group.can.delete && usePage().props.auth.user.id === props.group_user.user_id"
+                    :group_users="props.group.group_users.filter((group_user) => group_user.user_id !== usePage().props.auth.user.id)"
+                    label="You are the owner of this group, please select a new user to be the owner:"
+                    @userSelected="setGroupOwner"
                 >
-                    You are the owner of this group, please select a new user to be the owner:
-                    <!-- pass in all users but self, feels silly to set it as a variable when it's not always used -->
-                    <UserPicker
-                        :group_users="props.group.group_users.filter((group_user) => group_user.user_id !== usePage().props.auth.user.id)"
-                        @userSelected="setGroupOwner"
-                        >
-                    </UserPicker>
-                </h2>
+                </UserPicker>
                 <Form
                     class="mt-6 flex flex-col justify-end"
                     :action="route('group-users.destroy', props.group_user)"


### PR DESCRIPTION
The aim of this PR is to improve the functionalities of group users, changes:

- Added conditional `UserPicker` to delete group user modal, determined by if the user is removing themselves & is the owner of a group.
- Updated policies to reflect this.
- `UserPicker` now accepts a label prop.

