### PR TITLE
Improve seeders and factories

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -44,7 +44,7 @@ class CommentController extends Controller
                     ]);
         }
 
-        $group_user = $request->user()->group_users()->where('group_id', $debt->group_id)->first();
+        $group_user = $request->user()->groupUsers()->where('group_id', $debt->group_id)->first();
 
         Comment::create([
             'debt_id' => $validated['debt_id'],

--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -44,7 +44,7 @@ class CommentController extends Controller
                     ]);
         }
 
-        $group_user = $request->user()->groupUsers()->where('group_id', $debt->group_id)->first();
+        $group_user = $request->user()->group_users->where('group_id', $debt->group_id)->first();
 
         Comment::create([
             'debt_id' => $validated['debt_id'],

--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -48,7 +48,7 @@ class DebtController extends Controller
         $groups = GroupResource::collection(
             $request->user()
                 ->groups()
-                ->with('group_users.user')
+                ->with('groupUsers.user')
                 ->get()
         );
             

--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -139,7 +139,7 @@ class DebtController extends Controller
         // update data
         $debt->update([
             'name' => $validated['name'],
-            'amount' => Money::of($validated['amount'], $debt->currency),
+            'amount' => $validated['amount'],
         ]);
 
         DebtUpdated::dispatch($debt);

--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -30,7 +30,7 @@ class DebtController extends Controller
             DebtResource::collection(
                 // query builder to get the debts where the user is the owner
                 // or has a share in the debt via group_user
-                Debt::whereIn('group_user_id', $user->group_users->pluck('id')->toArray())
+                Debt::whereIn('group_user_id', $user->groupUsers->pluck('id')->toArray())
                     ->orWhereHas('shares.group_user', function ($query) use ($user) {
                         $query->where('user_id', $user->id);
                     })
@@ -39,7 +39,7 @@ class DebtController extends Controller
                     ->with([
                         'shares.group_user.user:id,name',
                         'comments.group_user.user:id,name',
-                        'group.group_users.user',
+                        'group.groupUsers.user',
                     ])
                     ->paginate(5)
             )

--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -30,7 +30,7 @@ class DebtController extends Controller
             DebtResource::collection(
                 // query builder to get the debts where the user is the owner
                 // or has a share in the debt via group_user
-                Debt::whereIn('group_user_id', $user->groupUsers->pluck('id')->toArray())
+                Debt::whereIn('group_user_id', $user->group_users->pluck('id')->toArray())
                     ->orWhereHas('shares.group_user', function ($query) use ($user) {
                         $query->where('user_id', $user->id);
                     })

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -21,12 +21,12 @@ class GroupController extends Controller
         $groups = Inertia::scroll(fn () =>
             GroupResource::collection(
                 Group::where('user_id', $request->user()->id)
-                    ->orWhereHas('group_users', function ($query) use ($request) {
+                    ->orWhereHas('groupUsers', function ($query) use ($request) {
                         $query->where('user_id', $request->user()->id);
                     })
                     ->with([
-                        'group_users.user', 
-                        'group_users.aliases',
+                        'groupUsers.user',
+                        'groupUsers.aliases',
                     ])
                     ->paginate(5)
                 )

--- a/app/Http/Resources/GroupResource.php
+++ b/app/Http/Resources/GroupResource.php
@@ -31,7 +31,7 @@ class GroupResource extends JsonResource
             // over time, more of these will likely be filled out
             // as & when  more relationships are needed
             'group_users' => GroupUserResource::collection(
-                $this->whenLoaded('group_users')
+                $this->whenLoaded('groupUsers')
             ),
         ];
     }

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -35,7 +35,7 @@ class Group extends Model
      * 
      * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function group_users(): HasMany
+    public function groupUsers(): HasMany
     {
         return $this->hasMany(GroupUser::class);
     }

--- a/app/Observers/GroupObserver.php
+++ b/app/Observers/GroupObserver.php
@@ -28,7 +28,7 @@ class GroupObserver
      */
     public function deleted(Group $group): void
     {
-        foreach ($group->group_users as $group_users) {
+        foreach ($group->groupUsers as $group_users) {
             $group_users->delete();
         }
 

--- a/app/Policies/CommentPolicy.php
+++ b/app/Policies/CommentPolicy.php
@@ -26,13 +26,15 @@ class CommentPolicy
     }
 
     /**
-     * Determine whether the user can create models.
+     * User can comment on a debt if they have a share ($debt->group_users relationship) in the debt, 
+     * or own the debt itself (no share, but all other shares owe them).
      */
     public function create(User $user, Debt $debt): bool
     {
         return $debt->group_users()
             ->where('group_users.user_id', $user->id)
-            ->exists();
+            ->exists() || 
+            $debt->group_user_id === $user->id;
     }
 
     /**

--- a/database/factories/CommentFactory.php
+++ b/database/factories/CommentFactory.php
@@ -3,7 +3,7 @@
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
-use App\Models\Comment;
+use App\Models\Debt;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Comment>
@@ -13,22 +13,17 @@ class CommentFactory extends Factory
     /**
      * Define the model's default state.
      *
+     * As a comment can't be made without a group_user_id, default to a random one relative to the debt id.
+     *
      * @return array<string, mixed>
      */
     public function definition(): array
     {
         return [
             'content' => $this->faker->sentence(),
+            'group_user_id' => function (array $attributes) {
+                return Debt::find($attributes['debt_id'])->group->groupUsers->random()->id;
+            },
         ];
-    }
-
-    /**
-     * As a comment can't be created without a debt, randomise who created it.
-     */
-    public function configure(): static
-    {
-        return $this->afterMaking(function(Comment $comment) {
-            $comment->group_user_id = $comment->debt->group->groupUsers->random()->id;
-        });
     }
 }

--- a/database/factories/CommentFactory.php
+++ b/database/factories/CommentFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\Comment;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Comment>
@@ -19,5 +20,15 @@ class CommentFactory extends Factory
         return [
             'content' => $this->faker->sentence(),
         ];
+    }
+
+    /**
+     * As a comment can't be created without a debt, randomise who created it.
+     */
+    public function configure(): static
+    {
+        return $this->afterMaking(function(Comment $comment) {
+            $comment->group_user_id = $comment->debt->group->groupUsers->random()->id;
+        });
     }
 }

--- a/database/factories/DebtFactory.php
+++ b/database/factories/DebtFactory.php
@@ -43,7 +43,7 @@ class DebtFactory extends Factory
 
     public function withShares() {
         return $this->afterCreating(function(Debt $debt) {
-            $group_users = $debt->group->group_users;
+            $group_users = $debt->group->groupUsers;
 
             if ($debt->split_even) {
                 $this->splitEvenShares($debt, $group_users);

--- a/database/factories/DebtFactory.php
+++ b/database/factories/DebtFactory.php
@@ -3,13 +3,9 @@
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
-use App\Models\GroupUser;
+use App\Models\Group;
 use App\Models\Debt;
-use App\Models\User;
 use App\Models\Share;
-use App\Models\Comment;
-use Illuminate\Database\Eloquent\Model;
-use Brick\Money\Money;
 use Faker\Factory as Faker;
 
 /**
@@ -34,33 +30,42 @@ class DebtFactory extends Factory
 
         return [
             'name' => $random_noun,
-            'amount' => rand(100, 1000) * 100,
+            'amount' => rand(100, 10000),
             'split_even' => rand(0,1),
             'cleared' => 0,
             'currency' => 'GBP',
         ];
     }
 
-    public function withShares() {
-        return $this->afterCreating(function(Debt $debt) {
-            $group_users = $debt->group->groupUsers;
-
-            if ($debt->split_even) {
-                $this->splitEvenShares($debt, $group_users);
+    /**
+     * As a debt can be creating bith both/neither/one of group_user_id & group_id,
+     * there are some conditions to run through after the debt has been created.
+     */
+    public function configure(): static
+    {
+        return $this->afterMaking(function (Debt $debt) {
+            if ($debt->group_id) {
+                $debt->group_user_id = $debt->group->groupUsers->random()->id;
+            } elseif ($debt->group_user_id) {
+                $debt->group_id = $debt->group_user->group->id;
             } else {
-                $this->chunkSharesRandomly($debt, $group_users);
+                $group = Group::all()->random();
+
+                $debt->group_id = $group->id;
+                $debt->group_user_id = $debt->group->groupUsers->random()->id;
             }
         });
     }
 
-    public function withComments() {
+    /**
+     * Custom withShares() so some randomisation can be created.
+     */
+    public function withShares() {
         return $this->afterCreating(function(Debt $debt) {
-            foreach ($debt->group_users as $group_user) {
-                Comment::factory()->create([
-                    'debt_id' => $debt->id,
-                    'group_user_id' => $group_user->id,
-                    'content' => "Comment by {$group_user->user->name}"
-                ]);
+            if ($debt->split_even) {
+                $this->splitEvenShares($debt);
+            } else {
+                $this->chunkSharesRandomly($debt);
             }
         });
     }
@@ -68,37 +73,36 @@ class DebtFactory extends Factory
     /**
      * split() is a brick/money method that evenly splits a value into money objects
      */
-    private function splitEvenShares($debt, $group_users) {
-        $money = $debt->amount->split($group_users->count()); 
-  
-        foreach ($group_users as $key => $group_user) {
+    private function splitEvenShares($debt) {
+        $debt_group_users = $debt->group->groupUsers->random(rand(2, $debt->group->groupUsers->count()));
+        $money = $debt->amount->split($debt_group_users->count());
+
+        foreach ($debt_group_users as $key => $debt_group_user) {
             Share::factory()->calcTotal()->create([
-                'group_user_id' => $group_user->id,
+                'group_user_id' => $debt_group_user->id,
                 'debt_id' => $debt->id,
-                'amount' => $money[$key]->getMinorAmount(),
-                'sent' => $group_user->id === $debt->group_user->id ? 1 : rand(0, 1),
-                'seen' => 0,
+                'amount' => $money[$key],
             ]);
         }
     }
 
-    private function chunkSharesRandomly($debt, $group_users) {
+    private function chunkSharesRandomly($debt) {
+        $debt_group_users = $debt->group->groupUsers->random(rand(2, $debt->group->groupUsers->count()));
         $total = $debt->amount->getMinorAmount()->toInt();
-        $count = $group_users->count();
+
+        $count = $debt_group_users->count();
         $chunk = intdiv($total, $count);
         
-        foreach ($group_users as $group_user) {
+        foreach ($debt_group_users as $debt_group_user) {
             // give some variance to chunks 
             $split = rand($chunk - 1000, $chunk + 1000);
             // give the last user the remainder of the debt
             $share_amount = $count === 1 ? $total : $split;
 
             Share::factory()->calcTotal()->create([
-                'group_user_id' => $group_user->id,
+                'group_user_id' => $debt_group_user->id,
                 'debt_id' => $debt->id,
                 'amount' => $share_amount,
-                'sent' => $group_user->id === $debt->group_user->id ? 1 : rand(0, 1),
-                'seen' => 0,
             ]);
            
             // take away the split each time

--- a/database/factories/DebtFactory.php
+++ b/database/factories/DebtFactory.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use App\Models\Group;
 use App\Models\Debt;
 use App\Models\Share;
+use App\Models\Comment;
 use Faker\Factory as Faker;
 
 /**
@@ -62,6 +63,7 @@ class DebtFactory extends Factory
      */
     public function withShares() {
         return $this->afterCreating(function(Debt $debt) {
+
             if ($debt->split_even) {
                 $this->splitEvenShares($debt);
             } else {
@@ -70,6 +72,23 @@ class DebtFactory extends Factory
         });
     }
 
+    /**
+     * Add between 0 and 5 comments to a debt on creation.
+     */
+    public function withComments(): static
+    {
+        return $this->afterCreating(function (Debt $debt) {
+            $count = rand(0, 5);
+
+            if ($count > 0) {
+                Comment::factory()
+                    ->count($count)
+                    ->create([
+                        'debt_id' => $debt->id,
+                    ]);
+            }
+        });
+    }
     /**
      * split() is a brick/money method that evenly splits a value into money objects
      */

--- a/database/factories/DebtFactory.php
+++ b/database/factories/DebtFactory.php
@@ -45,14 +45,14 @@ class DebtFactory extends Factory
     public function configure(): static
     {
         return $this->afterMaking(function (Debt $debt) {
-            if ($debt->group_id) {
-                $debt->group_user_id = $debt->group->groupUsers->random()->id;
-            } elseif ($debt->group_user_id) {
-                $debt->group_id = $debt->group_user->group->id;
-            } else {
+            if (!$debt->group_id && !$debt->group_user_id) {
                 $group = Group::all()->random();
 
                 $debt->group_id = $group->id;
+                $debt->group_user_id = $group->groupUsers->random()->id;
+            } elseif (!$debt->group_id) {
+                $debt->group_id = $debt->group_user->group->id;
+            } elseif (!$debt->group_user_id) {
                 $debt->group_user_id = $debt->group->groupUsers->random()->id;
             }
         });

--- a/database/factories/GroupFactory.php
+++ b/database/factories/GroupFactory.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use App\Models\User;
 use App\Models\Group;
 use App\Models\GroupUser;
+use Illuminate\Database\Eloquent\Factories\Sequence;
 
 use Faker\Factory as Faker;
 /**
@@ -39,20 +40,27 @@ class GroupFactory extends Factory
     }
 
     /**
-     * Add between 0 and 5 comments to a debt on creation.
+     * Takes a param of an int, but without one sets it to randon between 2 and 10.
+     * $count determines number of group users created,
+     * so pick a random $count of a users and make a group user for each.
+     * $sequence->index takes the direct array values, so no duplicates.
+     * This is the equivalent to adding a user to a group.
      */
-    public function withGroupUsers(): static
+    public function withGroupUsers(?int $count = 0): static
     {
-        return $this->afterCreating(function (Group $group) {
-            $count = rand(2, 10);
+        return $this->afterCreating(function (Group $group) use ($count) {
+            $count = $count === 0 ? $count = rand(2, 10) : $count;
 
-            if ($count > 0) {
-                GroupUser::factory()
-                    ->count($count)
-                    ->create([
-                        'group_id' => $group->id,
-                    ]);
-            }
+            GroupUser::factory()
+                ->count($count)
+                ->state(new Sequence(
+                    fn (Sequence $sequence) => ['user_id' => User::all()
+                        ->random($count)
+                        ->pluck('id')[$sequence->index]]
+                ))
+                ->create([
+                    'group_id' => $group->id,
+                ]);
         });
     }
 }

--- a/database/factories/GroupFactory.php
+++ b/database/factories/GroupFactory.php
@@ -4,6 +4,8 @@ namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use App\Models\User;
+use App\Models\Group;
+use App\Models\GroupUser;
 
 use Faker\Factory as Faker;
 /**
@@ -34,5 +36,23 @@ class GroupFactory extends Factory
 
     private function getWords($path) {
         return file(base_path($path), FILE_IGNORE_NEW_LINES);
+    }
+
+    /**
+     * Add between 0 and 5 comments to a debt on creation.
+     */
+    public function withGroupUsers(): static
+    {
+        return $this->afterCreating(function (Group $group) {
+            $count = rand(2, 10);
+
+            if ($count > 0) {
+                GroupUser::factory()
+                    ->count($count)
+                    ->create([
+                        'group_id' => $group->id,
+                    ]);
+            }
+        });
     }
 }

--- a/database/factories/GroupFactory.php
+++ b/database/factories/GroupFactory.php
@@ -3,11 +3,7 @@
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
-use Illuminate\Support\Facades\File;
 use App\Models\User;
-use App\Models\Group;
-use App\Models\GroupUser;
-use Illuminate\Support\Arr;
 
 use Faker\Factory as Faker;
 /**
@@ -32,7 +28,7 @@ class GroupFactory extends Factory
 
         return [
             'name' => "The {$random_verb} {$random_noun}",
-            'user_id' => Arr::random(User::all()->pluck('id')->toArray()),
+            'user_id' => User::all()->random()->id,
         ];
     }
 

--- a/database/factories/GroupFactory.php
+++ b/database/factories/GroupFactory.php
@@ -49,14 +49,19 @@ class GroupFactory extends Factory
     public function withGroupUsers(?int $count = 0): static
     {
         return $this->afterCreating(function (Group $group) use ($count) {
-            $count = $count === 0 ? $count = rand(2, 10) : $count;
+            $count = $count === 0 ? rand(2, 10) : $count;
+
+            $user_ids = User::whereNot('id', $group->user_id)
+                ->get()
+                ->random($count)
+                ->pluck('id');
 
             GroupUser::factory()
                 ->count($count)
                 ->state(new Sequence(
-                    fn (Sequence $sequence) => ['user_id' => User::all()
-                        ->random($count)
-                        ->pluck('id')[$sequence->index]]
+                    fn (Sequence $sequence) => [
+                            'user_id' => $user_ids[$sequence->index]
+                        ]
                 ))
                 ->create([
                     'group_id' => $group->id,

--- a/database/factories/GroupFactory.php
+++ b/database/factories/GroupFactory.php
@@ -32,23 +32,8 @@ class GroupFactory extends Factory
 
         return [
             'name' => "The {$random_verb} {$random_noun}",
+            'user_id' => Arr::random(User::all()->pluck('id')->toArray()),
         ];
-    }
-
-    public function withGroupUsers() {
-        return $this->afterCreating(function(Group $group) {
-            $user_ids = User::whereNot('id', $group->user_id)
-                ->pluck('id')
-                ->shuffle()
-                ->take(random_int(2,10));
-
-            foreach ($user_ids as $user_id) {
-                GroupUser::factory()->create([
-                    'group_id' => $group->id,
-                    'user_id' => $user_id,
-                  ]);
-            }
-        });
     }
 
     private function getWords($path) {

--- a/database/factories/GroupUserFactory.php
+++ b/database/factories/GroupUserFactory.php
@@ -14,13 +14,16 @@ class GroupUserFactory extends Factory
 {
     /**
      * Define the model's default state.
+     * No data necessary to be passed in if being created via withGroupUsers, 
+     * as part of group creation.
+     * Otherwise, user_id and group_id must be provided.
      *
      * @return array<string, mixed>
      */
     public function definition(): array
     {
         return [
-            'user_id' => User::all()->random()->id,
+
         ];
     }
 

--- a/database/factories/GroupUserFactory.php
+++ b/database/factories/GroupUserFactory.php
@@ -6,7 +6,6 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use App\Models\GroupUser;
 use App\Models\Alias;
 use App\Models\User;
-use Illuminate\Support\Arr;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\GroupUser>
@@ -21,7 +20,7 @@ class GroupUserFactory extends Factory
     public function definition(): array
     {
         return [
-            'user_id' => Arr::random(User::all()->pluck('id')->toArray()),
+            'user_id' => User::all()->random()->id,
         ];
     }
 

--- a/database/factories/ShareFactory.php
+++ b/database/factories/ShareFactory.php
@@ -25,7 +25,20 @@ class ShareFactory extends Factory
         
         return [
             'name' => rand(0,1) ? $random_noun : '',
+            'sent' => 0,
+            'seen' => 0,
         ];
+    }
+
+    /**
+     * Some randomisation on whether or not a share is seeded as sent & seen.
+     */
+    public function configure(): static
+    {
+        return $this->afterCreating(function(Share $share) {
+            $share->sent = $share->debt->group_user_id === $share->group_user_id ? 1 : rand(0, 1);
+            $share->seen = $share->sent ? rand(0, 1) : 0;
+        });
     }
 
     /**

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -85,7 +85,7 @@ class DatabaseSeeder extends Seeder
         foreach ($groups as $group) {
 
             // random amount of group_users in the group
-            $group_users = $group->group_users;
+            $group_users = $group->groupUsers;
             $random_group_users = $group_users->shuffle()->take(random_int(1, 3));  
             
             // a debt for each user
@@ -117,7 +117,7 @@ class DatabaseSeeder extends Seeder
                 for ($i = 0; $i < $num_comments; $i++) {
                     Comment::factory()->create([
                         'debt_id' => $debt->id,
-                        'group_user_id' => Arr::random($debt->group->group_users->pluck('id')->toArray()),
+                        'group_user_id' => Arr::random($debt->group->groupUsers->pluck('id')->toArray()),
                     ]);
                 }
 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -8,12 +8,6 @@ use App\Models\User;
 use App\Models\Group;
 use App\Models\GroupUser;
 use App\Models\Debt;
-use App\Models\Share;
-use App\Models\Comment;
-use Illuminate\Database\Eloquent\Model;
-
-use Faker\Factory as Faker;
-use Illuminate\Support\Arr;
 
 class DatabaseSeeder extends Seeder
 {
@@ -26,7 +20,6 @@ class DatabaseSeeder extends Seeder
         $this->createUsers();
         $this->createGroupsWithGroupUsers();
         $this->createDebtsWithSharesAndComments();
-        // $this->createComments();
     }
 
     /**
@@ -78,6 +71,9 @@ class DatabaseSeeder extends Seeder
         $this->command->info("50 groups each with 5 group users created \n");
     }
 
+    /**
+     * Create 1000 debts, with a random amount of comments, at least one for me.
+     */
     public function createDebtsWithSharesAndComments()
     {
         $self = User::first();
@@ -87,7 +83,14 @@ class DatabaseSeeder extends Seeder
             ->hasComments(rand(0,5))
             ->create([
                 'group_user_id' => GroupUser::where('user_id', $self->id)->first()->id,
-                'split_even' => 1,
             ]);
+
+        Debt::factory()
+            ->count(1000)
+            ->withShares()
+            ->hasComments(rand(0,5))
+            ->create();
+
+        $this->command->info("1000 debts created across groups \n");
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -25,7 +25,7 @@ class DatabaseSeeder extends Seeder
     {
         $this->createUsers();
         $this->createGroupsWithGroupUsers();
-        // $this->createDebtsWithShares();
+        $this->createDebtsWithSharesAndComments();
         // $this->createComments();
     }
 
@@ -78,52 +78,16 @@ class DatabaseSeeder extends Seeder
         $this->command->info("50 groups each with 5 group users created \n");
     }
 
-    public function createDebtsWithShares()
+    public function createDebtsWithSharesAndComments()
     {
-        $groups = Group::all();
-        
-        foreach ($groups as $group) {
+        $self = User::first();
 
-            // random amount of group_users in the group
-            $group_users = $group->groupUsers;
-            $random_group_users = $group_users->shuffle()->take(random_int(1, 3));  
-            
-            // a debt for each user
-            foreach ($random_group_users as $group_user) {
-                Debt::factory()->withShares()->create([
-                    'group_id' => $group->id,
-                    'group_user_id' => $group_user->id,
-                ]);
-               
-                $this->command->info("Debt added for group {$group->id} by {$group_user->user->name}");
-            }
-
-            $this->command->info("{$random_group_users->count()} debts added for group {$group->id}\n");
-        } 
+        Debt::factory()
+            ->withShares()
+            ->hasComments(rand(0,5))
+            ->create([
+                'group_user_id' => GroupUser::where('user_id', $self->id)->first()->id,
+                'split_even' => 1,
+            ]);
     }
-
-    public function createComments()
-    {
-        $debts = Debt::all();
-
-        foreach ($debts as $debt) {
-            // 50/50 on whether or not we add a comment
-            $add_comments = random_int(0,1);
-            
-            if ($add_comments) {
-                // random number of comments
-                $num_comments = random_int(1, 5);
-
-                for ($i = 0; $i < $num_comments; $i++) {
-                    Comment::factory()->create([
-                        'debt_id' => $debt->id,
-                        'group_user_id' => Arr::random($debt->group->groupUsers->pluck('id')->toArray()),
-                    ]);
-                }
-
-                $this->command->info("{$num_comments} comments added for debt {$debt->id}");
-            }
-        }
-    }
-
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use App\Models\Group;
 use App\Models\GroupUser;
 use App\Models\Debt;
+use App\Models\Comment;
 
 class DatabaseSeeder extends Seeder
 {
@@ -80,7 +81,7 @@ class DatabaseSeeder extends Seeder
 
         Debt::factory()
             ->withShares()
-            ->hasComments(rand(0,5))
+            ->withComments()
             ->create([
                 'group_user_id' => GroupUser::where('user_id', $self->id)->first()->id,
             ]);
@@ -88,9 +89,9 @@ class DatabaseSeeder extends Seeder
         Debt::factory()
             ->count(1000)
             ->withShares()
-            ->hasComments(rand(0,5))
+            ->withComments()
             ->create();
 
-        $this->command->info("1000 debts created across groups \n");
+        $this->command->info("1000 debts with 0-5 comments created across groups \n");
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 use App\Models\User;
 use App\Models\Group;
@@ -17,6 +17,7 @@ use Illuminate\Support\Arr;
 
 class DatabaseSeeder extends Seeder
 {
+    use WithoutModelEvents;
     /**
      * Seed the application's database.
      */
@@ -24,52 +25,45 @@ class DatabaseSeeder extends Seeder
     {
         $this->createUsers();
         $this->createGroupsWithGroupUsers();
-        $this->createDebtsWithShares();
-        $this->createComments();
+        // $this->createDebtsWithShares();
+        // $this->createComments();
     }
 
+    /**
+     * Create self & 100 users
+     */
     public function createUsers()
     {
-        // add self
-        $self = User::factory()->create([
+        User::factory()->create([
             'name' => 'Dom Elves',
             'email' => 'dom_elves@hotmail.co.uk',
             'password' => 'password',
         ]);
 
-        // now a bunch of users so a group can be created
-        User::factory(100)->create(); 
-        $this->command->info("created 100 users \n");
+        User::factory()
+            ->count(100)
+            ->create();
 
-        // a group to be in
-        $group = Group::factory()->withGroupUsers()->create([
-            'user_id' => $self->id,
-        ]);
-
-        // debt and shares for the group
-        Debt::factory()->withShares()->create([
-            'group_id' => $group->id,
-            'group_user_id' => $self->group_users->first()->id
-        ]);
-
-        Group::factory(5)->withGroupUsers()->create([
-            'user_id' => $self->id,
-        ]);
+        $this->command->info("self & 100 users created \n");
     }
 
+    /**
+     * Create at least one group for self & 50 other groups with random amount of users.
+     */
     public function createGroupsWithGroupUsers()
     {
-        // take random user ids
-        $random_user_ids = Arr::random(User::pluck('id')->toArray(), 10);
-
-        // create groups with group users for them
-        foreach ($random_user_ids as $random_id) {
-            Group::factory(10)->withGroupUsers()->create([
-                'user_id' => $random_id,
+        Group::factory()
+            ->hasGroupUsers(5)
+            ->create([
+                'user_id' => User::first()->id,
             ]);
-        } 
 
-        $this->command->info("created 10 groups \n");
+        Group::factory()
+            ->count(50)
+            ->hasGroupUsers(rand(2,10))
+            ->create();
+        
+        $this->command->info("50 groups each with 5 group users created \n");
     }
 
     public function createDebtsWithShares()

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -43,24 +43,19 @@ class DatabaseSeeder extends Seeder
 
     /**
      * Create at least one group with myself & some users,
-     * and create 50 groups with 2-10 users.
+     * and create 50 groups, withGroupUsers() adds 2-10 by default, unless specified.
      */
     public function createGroupsWithGroupUsers()
     {
         $group = Group::factory()
+            ->withGroupUsers()
             ->create([
                 'user_id' => User::first()->id,
-            ]);
-        
-        GroupUser::factory()
-            ->create([
-                'user_id' => User::first()->id,
-                'group_id' => $group->id,
             ]);
 
         GroupUser::factory()
-            ->count(rand(2,10))
             ->create([
+                'user_id' => User::first()->id,
                 'group_id' => $group->id,
             ]);
 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -48,21 +48,33 @@ class DatabaseSeeder extends Seeder
     }
 
     /**
-     * Create at least one group for self & 50 other groups with random amount of users.
+     * Create at least one group with myself & some users,
+     * and create 50 groups with 2-10 users.
      */
     public function createGroupsWithGroupUsers()
     {
-        Group::factory()
-            ->hasGroupUsers(5)
+        $group = Group::factory()
             ->create([
                 'user_id' => User::first()->id,
+            ]);
+        
+        GroupUser::factory()
+            ->create([
+                'user_id' => User::first()->id,
+                'group_id' => $group->id,
+            ]);
+
+        GroupUser::factory()
+            ->count(rand(2,10))
+            ->create([
+                'group_id' => $group->id,
             ]);
 
         Group::factory()
             ->count(50)
             ->hasGroupUsers(rand(2,10))
             ->create();
-        
+
         $this->command->info("50 groups each with 5 group users created \n");
     }
 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -66,7 +66,7 @@ class DatabaseSeeder extends Seeder
 
         Group::factory()
             ->count(50)
-            ->hasGroupUsers(rand(2,10))
+            ->withGroupUsers()
             ->create();
 
         $this->command->info("50 groups each with 5 group users created \n");

--- a/database/seeders/DevelopmentSeeder.php
+++ b/database/seeders/DevelopmentSeeder.php
@@ -75,7 +75,7 @@ class DevelopmentSeeder extends Seeder
         foreach ($groups as $group) {
 
             // random amount of group_users in the group
-            $group_users = $group->group_users;
+            $group_users = $group->groupUsers;
             $random_group_users = $group_users->shuffle()->take(random_int(1, 3));  
             
             // a debt for each user

--- a/resources/js/Components/Debts/Debt.vue
+++ b/resources/js/Components/Debts/Debt.vue
@@ -90,6 +90,10 @@ onMounted(() => {
                     :options="{
                         preserveScroll: true,
                     }"
+                    :transform="data => ({
+                        ...data,
+                        amount: data.amount * 100,
+                    })"
                 >
                     <div class="flex flex-col">
                         <div class="flex flex-row">

--- a/resources/js/Components/Invites/InviteToGroup.vue
+++ b/resources/js/Components/Invites/InviteToGroup.vue
@@ -25,7 +25,6 @@ const props = defineProps({
 });
 
 function addRecipient(recipientEmail) {
-    
     if (recipientEmail === '') {
         recipientError.value = 'Please enter an email address.';
     } else if (!mailRegex.value.test(recipientEmail)) {
@@ -93,7 +92,7 @@ function removeRecipient(emailAddress) {
                     :action="route('invite.send')" 
                     method="post" 
                     #default="{ errors }"
-                    @success="openModal = false"
+                    @success="openModal = false;"
                     resetOnSuccess
                     :transform="data => ({ 
                         ...data, 
@@ -116,10 +115,11 @@ function removeRecipient(emailAddress) {
                             ></i>
                         </span>
                     </div>
-                    <!-- recipient errors -->
+                    <!-- recipient errors, structured like this as to not print body error twice -->
                     <div class="my-2">
                         <InputError v-if="errors.pending" :message="errors.pending" />
                         <InputError v-if="errors.existing" :message="errors.existing" />
+                        <InputError v-if="errors.recipients" :message="errors.recipients" />
                     </div>
                     <!-- message -->
                     <div class="mb-4">

--- a/tests/Feature/Http/Controllers/AliasControllerTest.php
+++ b/tests/Feature/Http/Controllers/AliasControllerTest.php
@@ -9,8 +9,8 @@ beforeEach(function () {
     $this->users = User::factory(5)->create();
     $this->user = $this->users[0];
 
-    Group::factory(1)
-        ->hasGroupUsers(5)
+    $this->group = Group::factory()
+        ->withGroupUsers(5)
         ->create([
             'user_id' => $this->user->id,
         ]);

--- a/tests/Feature/Http/Controllers/AliasControllerTest.php
+++ b/tests/Feature/Http/Controllers/AliasControllerTest.php
@@ -5,7 +5,6 @@ use App\Models\Group;
 use App\Models\Alias;
 
 beforeEach(function () {
-    // create a handful of users so those involved can be randomised
     $this->users = User::factory(10)->create();
     $this->user = $this->users[0];
 

--- a/tests/Feature/Http/Controllers/AliasControllerTest.php
+++ b/tests/Feature/Http/Controllers/AliasControllerTest.php
@@ -9,10 +9,11 @@ beforeEach(function () {
     $this->users = User::factory(5)->create();
     $this->user = $this->users[0];
 
-    // a group for them to go in
-    Group::factory(1)->withGroupUsers()->create([
-        'user_id' => $this->user->id,
-    ]);
+    Group::factory(1)
+        ->hasGroupUsers(5)
+        ->create([
+            'user_id' => $this->user->id,
+        ]);
 
     $this->group = Group::where('user_id', $this->user->id)->first();
 
@@ -20,7 +21,7 @@ beforeEach(function () {
 });
 
 test('user can add an alias for another user', function() {
-    $other_group_user = $this->group->group_users->reject(fn($group_user) => 
+    $other_group_user = $this->group->groupUsers->reject(fn($group_user) => 
         $group_user->user_id === $this->user->id)->first();
 
     $response = $this->post(route('alias.store'), [
@@ -42,7 +43,7 @@ test('user can add an alias for another user', function() {
 });
 
 test('user can update an alias for another user', function() {
-    $other_group_user = $this->group->group_users->reject(fn($group_user) => 
+    $other_group_user = $this->group->groupUsers->reject(fn($group_user) => 
         $group_user->user_id === $this->user->id)->first();
     
     $alias = Alias::create([

--- a/tests/Feature/Http/Controllers/AliasControllerTest.php
+++ b/tests/Feature/Http/Controllers/AliasControllerTest.php
@@ -6,7 +6,7 @@ use App\Models\Alias;
 
 beforeEach(function () {
     // create a handful of users so those involved can be randomised
-    $this->users = User::factory(5)->create();
+    $this->users = User::factory(10)->create();
     $this->user = $this->users[0];
 
     $this->group = Group::factory()
@@ -14,8 +14,6 @@ beforeEach(function () {
         ->create([
             'user_id' => $this->user->id,
         ]);
-
-    $this->group = Group::where('user_id', $this->user->id)->first();
 
     $this->actingAs($this->user);
 });

--- a/tests/Feature/Http/Controllers/CommentControllerTest.php
+++ b/tests/Feature/Http/Controllers/CommentControllerTest.php
@@ -9,16 +9,15 @@ use Inertia\Testing\AssertableInertia as Assert;
 use Carbon\Carbon;
 
 beforeEach(function () {
-    // create a couple of users
-    $users = User::factory(2)->create();
-    $this->user = $users[0];
+    User::factory(10)->create();
+    $this->user = User::first();
 
-    // a group for them to go in
-    Group::factory(1)->withGroupUsers()->create([
-        'user_id' => $this->user->id,
-    ]);
+    $this->group = Group::factory()
+        ->hasGroupUsers(5)
+        ->create([
+            'user_id' => $this->user->id,
+        ]);
 
-    $this->group = Group::where('user_id', $this->user->id)->first();
     // the group user of the user that will be commenting etc
     $this->group_user = $this->user->group_users->where('group_id', $this->group->id)->first();
 

--- a/tests/Feature/Http/Controllers/CommentControllerTest.php
+++ b/tests/Feature/Http/Controllers/CommentControllerTest.php
@@ -5,20 +5,18 @@ Use App\Models\Group;
 use App\Models\Debt;
 use App\Models\GroupUser;
 use App\Models\Comment;
-use Inertia\Testing\AssertableInertia as Assert;
 use Carbon\Carbon;
 
 beforeEach(function () {
     $this->users = User::factory(10)->create();
     $this->user = $this->users[0];
 
-    Group::factory()
+    $this->group = Group::factory()
         ->withGroupUsers(5)
         ->create([
             'user_id' => $this->user->id,
         ]);
 
-    $this->group = Group::first();
     $this->group_user = GroupUser::where('user_id', $this->user->id)->first();
 
     $this->debt = Debt::factory()

--- a/tests/Feature/Http/Controllers/CommentControllerTest.php
+++ b/tests/Feature/Http/Controllers/CommentControllerTest.php
@@ -9,25 +9,25 @@ use Inertia\Testing\AssertableInertia as Assert;
 use Carbon\Carbon;
 
 beforeEach(function () {
-    User::factory(10)->create();
-    $this->user = User::first();
+    $this->users = User::factory(10)->create();
+    $this->user = $this->users[0];
 
     $this->group = Group::factory()
-        ->hasGroupUsers(5)
+        ->withGroupUsers(5)
         ->create([
             'user_id' => $this->user->id,
         ]);
 
-    // the group user of the user that will be commenting etc
-    $this->group_user = $this->user->group_users->where('group_id', $this->group->id)->first();
+    $this->group_user = GroupUser::where('user_id', $this->user->id)->first();
 
-    // a debt belonging to one of the users
-    $this->debt = Debt::factory()->withShares()->create([
-        'group_id' => $this->group->id,
-        'group_user_id' => $this->group_user->id,
-    ]);
+    $this->debt = Debt::factory()
+        ->withShares()
+        ->create([
+            'group_id' => $this->group->id,
+            'group_user_id' => $this->group_user->id,
+        ]);
 
-    $this->actingAs($this->user);
+    $this->actingAs($this->group_user->user);
 });
 
 test('user can comment on a debt', function () {

--- a/tests/Feature/Http/Controllers/CommentControllerTest.php
+++ b/tests/Feature/Http/Controllers/CommentControllerTest.php
@@ -12,12 +12,13 @@ beforeEach(function () {
     $this->users = User::factory(10)->create();
     $this->user = $this->users[0];
 
-    $this->group = Group::factory()
+    Group::factory()
         ->withGroupUsers(5)
         ->create([
             'user_id' => $this->user->id,
         ]);
 
+    $this->group = Group::first();
     $this->group_user = GroupUser::where('user_id', $this->user->id)->first();
 
     $this->debt = Debt::factory()

--- a/tests/Feature/Http/Controllers/CommentControllerTest.php
+++ b/tests/Feature/Http/Controllers/CommentControllerTest.php
@@ -20,11 +20,17 @@ beforeEach(function () {
 
     $this->group_user = GroupUser::where('user_id', $this->user->id)->first();
 
+    $this->debt = Debt::factory()
+        ->withShares()
+        ->create([
+            'group_id' => $this->group->id,
+            'group_user_id' => $this->group_user->id,
+        ]);
+
     $this->actingAs($this->group_user->user);
 });
 
 test('user can comment on a debt', function () {
-    dump($this->group->groupUsers->pluck('user_id')->toArray());
     $response = $this->post(route('comment.store'), [
         'debt_id' => $this->debt->id,
         'content' => 'This is a comment',

--- a/tests/Feature/Http/Controllers/CommentControllerTest.php
+++ b/tests/Feature/Http/Controllers/CommentControllerTest.php
@@ -20,17 +20,11 @@ beforeEach(function () {
 
     $this->group_user = GroupUser::where('user_id', $this->user->id)->first();
 
-    $this->debt = Debt::factory()
-        ->withShares()
-        ->create([
-            'group_id' => $this->group->id,
-            'group_user_id' => $this->group_user->id,
-        ]);
-
     $this->actingAs($this->group_user->user);
 });
 
 test('user can comment on a debt', function () {
+    dump($this->group->groupUsers->pluck('user_id')->toArray());
     $response = $this->post(route('comment.store'), [
         'debt_id' => $this->debt->id,
         'content' => 'This is a comment',
@@ -102,7 +96,8 @@ test('user can delete their comment on a debt', function () {
 
 test('user can not edit another user comment on a debt', function () {
     // get a different user & create a comment by them
-    $other_group_user = GroupUser::where('id', '!=', $this->group_user->id)->first();
+    $other_group_user = GroupUser::where('user_id', '!=', $this->group_user->user_id)->first();
+
     $other_user_comment = Comment::create([
         'group_user_id' => $other_group_user->id,
         'debt_id' => $this->debt->id,
@@ -129,7 +124,8 @@ test('user can not edit another user comment on a debt', function () {
 
 // same principle as above test, just slightly different assertions 
 test('user can not delete another user comment on a debt', function () {
-    $other_group_user = GroupUser::where('id', '!=', $this->group_user->id)->first();
+    $other_group_user = GroupUser::where('user_id', '!=', $this->group_user->user_id)->first();
+
     $other_user_comment = Comment::create([
         'group_user_id' => $other_group_user->id,
         'debt_id' => $this->debt->id,

--- a/tests/Feature/Http/Controllers/DebtControllerTest.php
+++ b/tests/Feature/Http/Controllers/DebtControllerTest.php
@@ -16,10 +16,11 @@ beforeEach(function () {
     $this->users = User::factory(5)->create();
     $this->user = $this->users[0];
 
-    // a group for them to go in
-    Group::factory(1)->withGroupUsers()->create([
-        'user_id' => $this->user->id,
-    ]);
+    Group::factory()
+        ->hasGroupUsers(5)
+        ->create([
+            'user_id' => $this->user->id,
+        ]);
 
     $this->group = Group::where('user_id', $this->user->id)->first();
     $this->group_user = GroupUser::where('user_id', $this->user->id)->first();
@@ -57,7 +58,7 @@ test('debts, shares and comments all appear with permissions paginated', functio
 });
 
 test('user can add a debt with different value shares', function() {
-    $user_shares = selectRandomGroupUsers($this->group->group_users, 10000, false);
+    $user_shares = selectRandomGroupUsers($this->group->groupUsers, 10000, false);
     
     Event::fake();
 
@@ -193,7 +194,7 @@ test('user can not add a debt with no group users selected', function() {
 });
 
 test('user can not add a debt with no name', function() {
-    $user_shares = selectRandomGroupUsers($this->group->group_users, 15000, false);
+    $user_shares = selectRandomGroupUsers($this->group->groupUsers, 15000, false);
 
     $response = $this->post(route('debt.store'), [
         'group_id' => $this->group->id,
@@ -217,7 +218,7 @@ test('user can not add a debt with no name', function() {
 });
 
 test('user can not add a debt without a selected currency', function() {
-    $user_shares = selectRandomGroupUsers($this->group->group_users, 20000, false);
+    $user_shares = selectRandomGroupUsers($this->group->groupUsers, 20000, false);
 
     $response = $this->post(route('debt.store'), [
         'group_id' => $this->group->id,
@@ -240,7 +241,7 @@ test('user can not add a debt without a selected currency', function() {
 });
 
 test('user can not add a debt without a selected user', function() {
-    $user_shares = selectRandomGroupUsers($this->group->group_users, 25000, false);
+    $user_shares = selectRandomGroupUsers($this->group->groupUsers, 25000, false);
 
     $response = $this->post(route('debt.store'), [
         'group_id' => $this->group->id,
@@ -462,7 +463,7 @@ test("user can not add a debt for a group they're not in", function() {
         'user_id' => $this->users[1]->id,
     ]);
 
-    $user_shares = selectRandomGroupUsers($this->group->group_users, 10000, false);
+    $user_shares = selectRandomGroupUsers($this->group->groupUsers, 10000, false);
 
     // save the debt 
     $response = $this->post(route('debt.store'), [

--- a/tests/Feature/Http/Controllers/DebtControllerTest.php
+++ b/tests/Feature/Http/Controllers/DebtControllerTest.php
@@ -12,7 +12,6 @@ use Illuminate\Support\Arr;
 use Brick\Money\Money;
 
 beforeEach(function () {
-    // create a handful of users so those involved can be randomised
     $this->users = User::factory(10)->create();
     $this->user = $this->users[0];
 

--- a/tests/Feature/Http/Controllers/DebtControllerTest.php
+++ b/tests/Feature/Http/Controllers/DebtControllerTest.php
@@ -13,19 +13,18 @@ use Brick\Money\Money;
 
 beforeEach(function () {
     // create a handful of users so those involved can be randomised
-    $this->users = User::factory(5)->create();
+    $this->users = User::factory(10)->create();
     $this->user = $this->users[0];
 
-    Group::factory()
-        ->hasGroupUsers(5)
+    $this->group = Group::factory()
+        ->withGroupUsers(5)
         ->create([
             'user_id' => $this->user->id,
         ]);
 
-    $this->group = Group::where('user_id', $this->user->id)->first();
     $this->group_user = GroupUser::where('user_id', $this->user->id)->first();
 
-    $this->actingAs($this->user);
+    $this->actingAs($this->group_user->user);
 });
 
 test('debts, shares and comments all appear with permissions paginated', function() {
@@ -327,7 +326,7 @@ test('updating the amount on a split even debt updates the shares', function() {
   
     $response = $this->patch(route('debt.update', $debt), [
         'name' => $debt->name,
-        'amount' => $new_amount->getAmount()->toInt(),
+        'amount' => $new_amount->getMinorAmount()->toInt(),
     ]);
 
     $response->assertStatus(302)
@@ -364,7 +363,7 @@ test('user can update the name of a debt', function() {
 
     $response = $this->patch(route('debt.update', $debt), [
         'name' => 'i have been changed',
-        'amount' => $debt->amount->getAmount()->toInt(),
+        'amount' => $debt->amount->getMinorAmount()->toInt(),
     ]);
 
     $response->assertStatus(302)
@@ -390,7 +389,7 @@ test('user can not change the name of a debt they do not own', function() {
     ]);
 
     $response = $this->patch(route('debt.update', $debt), [
-        'amount' => $debt->amount->getAmount()->toInt(),
+        'amount' => $debt->amount->getMinorAmount()->toInt(),
         'name' => 'i have been changed',
     ]);
 

--- a/tests/Feature/Http/Controllers/GroupControllerTest.php
+++ b/tests/Feature/Http/Controllers/GroupControllerTest.php
@@ -10,22 +10,26 @@ use App\Observers\GroupObserver;
 
 beforeEach(function () {
     // create a handful of users so those involved can be randomised
-    $this->users = User::factory(5)->create();
+    $this->users = User::factory(10)->create();
     $this->user = $this->users[0];
 
-    // a group for them to go in
-    Group::factory(1)->withGroupUsers()->create([
-        'user_id' => $this->user->id,
-    ]);
+    Group::factory()
+        ->hasGroupUsers(5)
+        ->create([
+            'user_id' => $this->user->id,
+        ]);
 
     $this->group = Group::where('user_id', $this->user->id)->first();
     $this->actingAs($this->user);
 });
 
 test('user groups, users, group users appear with permissions and are paginated', function() {
-    Group::factory(10)->withGroupUsers()->create([
-        'user_id' => $this->user->id,
-    ]);
+    Group::factory()
+        ->count(10)
+        ->hasGroupUsers(5)
+        ->create([
+            'user_id' => $this->user->id,
+        ]);
 
     $this->get('/groups')
         ->assertInertia(fn (Assert $page) =>
@@ -121,7 +125,7 @@ test('user can delete group they own', function() {
 
 test('deleting a group deletes the relevant group users, debts, shares and comments', function() {
     $group = Group::where('user_id', $this->user->id)->first();
-    $group_users = $group->group_users;
+    $group_users = $group->groupUsers;
     
     $debts = Debt::factory(5)->withShares()->withComments()->create([
         'group_user_id' => $group_users[0]->id,

--- a/tests/Feature/Http/Controllers/GroupControllerTest.php
+++ b/tests/Feature/Http/Controllers/GroupControllerTest.php
@@ -7,7 +7,6 @@ use Inertia\Testing\AssertableInertia as Assert;
 use Carbon\Carbon;
 
 beforeEach(function () {
-    // create a handful of users so those involved can be randomised
     $this->users = User::factory(10)->create();
     $this->user = $this->users[0];
 

--- a/tests/Feature/Http/Controllers/GroupControllerTest.php
+++ b/tests/Feature/Http/Controllers/GroupControllerTest.php
@@ -2,31 +2,28 @@
 
 use App\Models\User;
 use App\Models\Group;
-use App\Models\GroupUser;
 use App\Models\Debt;
 use Inertia\Testing\AssertableInertia as Assert;
 use Carbon\Carbon;
-use App\Observers\GroupObserver;
 
 beforeEach(function () {
     // create a handful of users so those involved can be randomised
     $this->users = User::factory(10)->create();
     $this->user = $this->users[0];
 
-    Group::factory()
-        ->hasGroupUsers(5)
+    $this->group = Group::factory()
+        ->withGroupUsers(5)
         ->create([
             'user_id' => $this->user->id,
         ]);
 
-    $this->group = Group::where('user_id', $this->user->id)->first();
     $this->actingAs($this->user);
 });
 
 test('user groups, users, group users appear with permissions and are paginated', function() {
     Group::factory()
         ->count(10)
-        ->hasGroupUsers(5)
+        ->withGroupUsers(5)
         ->create([
             'user_id' => $this->user->id,
         ]);

--- a/tests/Feature/Http/Controllers/GroupUserControllerTest.php
+++ b/tests/Feature/Http/Controllers/GroupUserControllerTest.php
@@ -12,14 +12,13 @@ beforeEach(function () {
     $this->users = User::factory(10)->create();
     $this->user = $this->users[0];
 
-    Group::factory()
-        ->hasGroupUsers(5)
+    $this->group = Group::factory()
+        ->withGroupUsers(5)
         ->create([
             'user_id' => $this->user->id,
         ]);
 
-    $this->group = Group::first();
-        $this->group_user = $this->group->groupUsers->where('user_id', $this->user->id)->first();
+    $this->group_user = $this->group->groupUsers->where('user_id', $this->user->id)->first();
 });
 
 test('user can remove group users from a group they own', function() {

--- a/tests/Feature/Http/Controllers/GroupUserControllerTest.php
+++ b/tests/Feature/Http/Controllers/GroupUserControllerTest.php
@@ -8,7 +8,6 @@ use App\Models\Comment;
 use Carbon\Carbon;
 
 beforeEach(function () {
-   // create a handful of users so those involved can be randomised
     $this->users = User::factory(10)->create();
     $this->user = $this->users[0];
 

--- a/tests/Feature/Http/Controllers/GroupUserControllerTest.php
+++ b/tests/Feature/Http/Controllers/GroupUserControllerTest.php
@@ -9,28 +9,29 @@ use Carbon\Carbon;
 
 beforeEach(function () {
    // create a handful of users so those involved can be randomised
-    $this->users = User::factory(5)->create();
+    $this->users = User::factory(10)->create();
     $this->user = $this->users[0];
 
-    // a group for them to go in
-    Group::factory(1)->withGroupUsers()->create([
-        'user_id' => $this->user->id,
-    ]);
+    Group::factory()
+        ->hasGroupUsers(5)
+        ->create([
+            'user_id' => $this->user->id,
+        ]);
 
     $this->group = Group::first();
-        $this->group_user = $this->group->group_users->where('user_id', $this->user->id)->first();
+        $this->group_user = $this->group->groupUsers->where('user_id', $this->user->id)->first();
 });
 
 test('user can remove group users from a group they own', function() {
     $this->actingAs($this->user);
 
-    $response = $this->delete(route('group-users.destroy', $this->group->group_users[2]));
+    $response = $this->delete(route('group-users.destroy', $this->group->groupUsers[2]));
 
     $response->assertStatus(302)
         ->assertSessionHas('status', 'Group User deleted successfully.');
 
     $this->assertDatabaseHas('group_users', [
-        'id' => $this->group->group_users[2]->id,
+        'id' => $this->group->groupUsers[2]->id,
         'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
     ]);
 });
@@ -38,11 +39,12 @@ test('user can remove group users from a group they own', function() {
 test('user can not remove group users from a group they do not own', function() {
     $this->actingAs($this->user);
 
-    $group = Group::factory(1)->withGroupUsers()->create([
-        'user_id' => $this->users[2]->id,
-    ]);
+    $group = Group::factory()
+        ->create([
+            'user_id' => $this->users[2]->id,
+        ]);
 
-    $group_user = $group[0]->group_users->firstWhere('id', '!=', $this->user->id);
+    $group_user = $group->groupUsers->firstWhere('id', '!=', $this->user->id);
 
     $response = $this->delete(route('group-users.destroy', $group_user));
 
@@ -65,12 +67,12 @@ test('deleting a group user also deletes their comments', function() {
 
     // todo: change this after fixing debt factory later
     $comment = Comment::factory()->create([
-        'group_user_id' => $this->group->group_users[2]->id,
+        'group_user_id' => $this->group->groupUsers[2]->id,
         'debt_id' => $debt->id,
         'content' => 'comment'
     ]);
 
-    $response = $this->delete(route('group-users.destroy', $this->group->group_users[2]));
+    $response = $this->delete(route('group-users.destroy', $this->group->groupUsers[2]));
 
     $response->assertStatus(302)
         ->assertSessionHas('status', 'Group User deleted successfully.');
@@ -78,7 +80,7 @@ test('deleting a group user also deletes their comments', function() {
     $this->assertDatabaseHas('comments', [
         'id' => $comment->id,
         'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
-        'group_user_id' => $this->group->group_users[2]->id,
+        'group_user_id' => $this->group->groupUsers[2]->id,
     ]);
 });
 
@@ -90,9 +92,9 @@ test('deleting a group user also deletes their shares', function() {
         'group_user_id' => $this->group_user->id,
     ]);
 
-    $share = $debt->shares->where('group_user_id', $this->group->group_users[2]->id)->first();
+    $share = $debt->shares->where('group_user_id', $this->group->groupUsers[2]->id)->first();
 
-    $response = $this->delete(route('group-users.destroy', $this->group->group_users[2]));
+    $response = $this->delete(route('group-users.destroy', $this->group->groupUsers[2]));
 
     $response->assertStatus(302)
         ->assertSessionHas('status', 'Group User deleted successfully.');
@@ -109,10 +111,10 @@ test('deleting a group user also deletes their aliases', function() {
 
     $alias = Alias::factory()->create([
         'user_id' => $this->user->id,
-        'group_user_id' => $this->group->group_users[2]->id,
+        'group_user_id' => $this->group->groupUsers[2]->id,
     ]);
 
-    $response = $this->delete(route('group-users.destroy', $this->group->group_users[2]));
+    $response = $this->delete(route('group-users.destroy', $this->group->groupUsers[2]));
 
     $response->assertStatus(302)
         ->assertSessionHas('status', 'Group User deleted successfully.');
@@ -120,7 +122,7 @@ test('deleting a group user also deletes their aliases', function() {
     $this->assertDatabaseHas('aliases', [
         'id' => $alias->id,
         'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
-        'group_user_id' => $this->group->group_users[2]->id,
+        'group_user_id' => $this->group->groupUsers[2]->id,
     ]);
 });
 
@@ -142,7 +144,7 @@ test('user can delete themselves from a group and select a new group owner', fun
     $this->actingAs($this->user);
 
     $response = $this->delete(route('group-users.destroy', $this->group_user), [
-        'new_owner_group_user_id' => $this->group->group_users[2]->id,
+        'new_owner_group_user_id' => $this->group->groupUsers[2]->id,
     ]);
 
     $response->assertStatus(302)
@@ -155,6 +157,6 @@ test('user can delete themselves from a group and select a new group owner', fun
 
     $this->assertDatabaseHas('groups', [
         'id' => $this->group_user->group->id,
-        'user_id' => $this->group->group_users[2]->user->id,
+        'user_id' => $this->group->groupUsers[2]->user->id,
     ]);
 });

--- a/tests/Feature/Http/Controllers/InviteControllerTest.php
+++ b/tests/Feature/Http/Controllers/InviteControllerTest.php
@@ -2,10 +2,7 @@
 
 use App\Models\User;
 Use App\Models\Group;
-use App\Models\Debt;
-use App\Models\Share;
 use App\Models\Invite;
-use App\Models\GroupUser;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Mail;
 use App\Mail\InviteToGroup;
@@ -15,17 +12,14 @@ use App\Jobs\ExpireInvite;
 use Illuminate\Support\Facades\URL;
 
 beforeEach(function () {
-   // create a handful of users so those involved can be randomised
     $this->users = User::factory(10)->create();
     $this->user = $this->users[0];
 
-    Group::factory()
+    $this->group = Group::factory()
         ->withGroupUsers(5)
         ->create([
             'user_id' => $this->user->id,
         ]);
-
-    $this->group = Group::where('user_id', $this->user->id)->get()[0];
 });
 
 test('user can invite someone to the group if they are the owner', function() {

--- a/tests/Feature/Http/Controllers/InviteControllerTest.php
+++ b/tests/Feature/Http/Controllers/InviteControllerTest.php
@@ -16,13 +16,14 @@ use Illuminate\Support\Facades\URL;
 
 beforeEach(function () {
    // create a handful of users so those involved can be randomised
-    $this->users = User::factory(5)->create();
+    $this->users = User::factory(10)->create();
     $this->user = $this->users[0];
 
-    // a group for them to go in
-    Group::factory(1)->withGroupUsers()->create([
-        'user_id' => $this->user->id,
-    ]);
+    Group::factory()
+        ->hasGroupUsers(5)
+        ->create([
+            'user_id' => $this->user->id,
+        ]);
 
     $this->group = Group::where('user_id', $this->user->id)->get()[0];
 });
@@ -251,9 +252,11 @@ test('a user can not send an invite link to a user who is already in the group',
 test('user clicking on the invite link after accepting it logs them in and redirects them to groups', function() {
     $user = $this->group->users->first();
 
-    $group = Group::factory()->withGroupUsers()->create([
-                'user_id' => $this->user,
-            ]);
+    $group = Group::factory()
+        ->hasGroupUsers(5)
+        ->create([
+            'user_id' => $this->user->id,
+        ]);
     
     $invite = Invite::factory()->create([
         'group_id' => $group->id,

--- a/tests/Feature/Http/Controllers/InviteControllerTest.php
+++ b/tests/Feature/Http/Controllers/InviteControllerTest.php
@@ -20,7 +20,7 @@ beforeEach(function () {
     $this->user = $this->users[0];
 
     Group::factory()
-        ->hasGroupUsers(5)
+        ->withGroupUsers(5)
         ->create([
             'user_id' => $this->user->id,
         ]);
@@ -253,7 +253,7 @@ test('user clicking on the invite link after accepting it logs them in and redir
     $user = $this->group->users->first();
 
     $group = Group::factory()
-        ->hasGroupUsers(5)
+        ->withGroupUsers(5)
         ->create([
             'user_id' => $this->user->id,
         ]);

--- a/tests/Feature/Http/Controllers/ShareControllerTest.php
+++ b/tests/Feature/Http/Controllers/ShareControllerTest.php
@@ -3,27 +3,21 @@
 use App\Models\User;
 Use App\Models\Group;
 use App\Models\Debt;
-use App\Models\Share;
 use App\Models\GroupUser;
-use Inertia\Testing\AssertableInertia as Assert;
+use App\Models\Share;
 use Carbon\Carbon;
-use Illuminate\Support\Facades\Event;
-use App\Events\ShareDeleted;
 use Brick\Money\Money;
-use Brick\Math\RoundingMode;
 
 beforeEach(function () {
-   // create a handful of users so those involved can be randomised
     $this->users = User::factory(10)->create();
     $this->user = $this->users[0];
 
-    Group::factory()
-        ->hasGroupUsers(5)
+    $this->group = Group::factory()
+        ->withGroupUsers(5)
         ->create([
             'user_id' => $this->user->id,
         ]);
 
-    $this->group = Group::where('user_id', $this->user->id)->first();
     $this->group_users = $this->group->groupUsers;
     $this->group_user = GroupUser::where('user_id', $this->user->id)->first();
 
@@ -31,13 +25,19 @@ beforeEach(function () {
 });
 
 test("user can select 'sent' on their own share", function () {
-    $debt = Debt::factory()->withShares()->create([
+    $debt = Debt::factory()
+        ->withShares()
+        ->create([
+            'group_user_id' => $this->group_user->id,
+            'group_id' => $this->group->id,
+        ]);
+
+    $share = Share::factory()->create([
         'group_user_id' => $this->group_user->id,
-        'group_id' => $this->group->id,
+        'debt_id' => $debt->id,
+        'amount' => 500,
     ]);
 
-    $share = $debt->shares->where('group_user_id', $this->group_user->id)->first();
-    
     $response = $this->patch(route('share.sent', $share), [
         'id' => $share->id,
         'sent' => !$share->sent,
@@ -45,7 +45,6 @@ test("user can select 'sent' on their own share", function () {
 
     $response->assertStatus(302)->assertSessionHasNoErrors();
 
-    // confirm status
     $this->assertDatabaseHas('shares', [
         'id' => $share->id,
         'sent' => !$share->sent,
@@ -251,7 +250,11 @@ test("user can update the amount on a share for a debt they own", function() {
         'split_even' => 0,
     ]);
     
-    $share = $debt->shares->where('group_user_id', $this->group_user->id)->first();
+    $share = Share::factory()->create([
+        'group_user_id' => $this->group_user->id,
+        'debt_id' => $debt->id,
+        'amount' => 500,
+    ]);
 
     // the 'new' amount is basically what the user sees,
     // e..g if they add a fiver it's just 5

--- a/tests/Feature/Http/Controllers/ShareControllerTest.php
+++ b/tests/Feature/Http/Controllers/ShareControllerTest.php
@@ -14,16 +14,17 @@ use Brick\Math\RoundingMode;
 
 beforeEach(function () {
    // create a handful of users so those involved can be randomised
-    $this->users = User::factory(5)->create();
+    $this->users = User::factory(10)->create();
     $this->user = $this->users[0];
 
-    // a group for them to go in
-    Group::factory(1)->withGroupUsers()->create([
-        'user_id' => $this->user->id,
-    ]);
+    Group::factory()
+        ->hasGroupUsers(5)
+        ->create([
+            'user_id' => $this->user->id,
+        ]);
 
     $this->group = Group::where('user_id', $this->user->id)->first();
-    $this->group_users = $this->group->group_users;
+    $this->group_users = $this->group->groupUsers;
     $this->group_user = GroupUser::where('user_id', $this->user->id)->first();
 
     $this->actingAs($this->user);

--- a/tests/Feature/TotalBalanceTest.php
+++ b/tests/Feature/TotalBalanceTest.php
@@ -7,15 +7,17 @@ use Brick\Money\Money;
 use Illuminate\Support\Facades\Event;
 
 beforeEach(function () {
-    $this->users = User::factory(5)->create();
+    $this->users = User::factory(10)->create();
     $this->self = $this->users[0];
 
-    Group::factory(1)->withGroupUsers()->create([
-        'user_id' => $this->self->id,
-    ]);
+    Group::factory(1)
+        ->hasGroupUsers(5)
+        ->create([
+            'user_id' => $this->self->id,
+        ]);
 
     $this->group = Group::first();
-    $this->group_users = $this->group->group_users;
+    $this->group_users = $this->group->groupUsers;
     $this->group_user = $this->group_users->where('user_id', $this->self->id)->first();
 
     $this->actingAs($this->self);

--- a/tests/Feature/TotalBalanceTest.php
+++ b/tests/Feature/TotalBalanceTest.php
@@ -22,9 +22,6 @@ beforeEach(function () {
     $this->actingAs($this->self);
 });
 
-// $user_balance is x100 as it is accessed, therefore is /100 for user benefit
-// $sum, however is just a sum of the db values, therefore isn't hit by the
-// accessor in the same way
 test("the seeded db calculates all user's user balance correctly", function() {
     $this->seed();
     $this->assertTrue(checkUserBalances($this->users));
@@ -118,10 +115,12 @@ test("updating a split even debt recalculates the user's balance", function() {
         'split_even' => 1,
     ]);
 
+    $new_amount = $debt->amount->plus(10);
+
     $response = $this->patch(route('debt.update', $debt), [
         'id' => $debt->id,
         'name' => $debt->name,
-        'amount' => $debt->amount->getAmount()->toInt() + 10,
+        'amount' => $new_amount->getMinorAmount()->toInt(),
     ]);
     
     $response->assertStatus(302);

--- a/tests/Feature/TotalBalanceTest.php
+++ b/tests/Feature/TotalBalanceTest.php
@@ -10,13 +10,12 @@ beforeEach(function () {
     $this->users = User::factory(10)->create();
     $this->self = $this->users[0];
 
-    Group::factory(1)
-        ->hasGroupUsers(5)
+    $this->group = Group::factory()
+        ->withGroupUsers(5)
         ->create([
             'user_id' => $this->self->id,
         ]);
 
-    $this->group = Group::first();
     $this->group_users = $this->group->groupUsers;
     $this->group_user = $this->group_users->where('user_id', $this->self->id)->first();
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -65,7 +65,6 @@ function something()
  * 
  * @param \Illuminate\Database\Eloquent\Collection $group_users
  * @param int $debt_total
- * @param boolean $split_even
  */
 function selectRandomGroupUsers($group_users, $debt_total) {
     


### PR DESCRIPTION
The aim of this PR is to fix up the mess that is the current main db seeder, as well as various model factories across the board. Likely going to make them a bit more laravel-ey. Changelog:

- `CommentFactory` now defaults to a random group_user in the debt if one isn't provided.
- On the back of this, `DebtFactory` `withComments()` method has been simplified.
- `DebtFactory` now covers various edge cases in `afterMaking()` (which comes before `afterCreating()!` for if one/both/neither a group_id/group_user_id are provided when the factory is called.
- And on the back of this, the `withShares()` and subsequent methods for split even and standard debts have been improved. 
- The debt factory `withGroupUsers()` method now has better randomisation and is improved using `Sequences`.
- Sent/seen randomisation of a share has been moved to the `ShareFactory`.
- `beforeEach()` method in test suite has been standardised to be at least 10 users and 5 group users, across the board. Extras on a case by case basis are there if necessary.
- Lots of simplification of brick money usage in test suite, as well as groupUser relationship name updates.

Extras:

- Fix somehow incorrect relationship call rather than lazy load in `CommentController` index method.
- Renamed group->group_users to group->groupUsers across the board so laravel-ey magic can be used in factories (even though I didn't end up using it, still better practice. Eventually, this will be done for all model relationships.)
- Simplified use of `Money` objects, as my understand is now a bit better. Minor units are stored in db, e.g. £44 is 4400 and  the cash cast is used to convert them. What was causing confusion was that money can equally be saved as units without the need to be converted (which is what happens when an actual user is doing it). Money only really is necessary when splits etc are being worked out, as Money basically just handles the decimals.
- Fixed create on `CommentPolicy` to allow users that own a debt but not have a share in it to comment on the debt. Problem was this was causing test flakiness.
- Added a `* 100` when updating the amount on a debt as adding a debt uses Dinero.js to work out splits (like brick money, but for the frontend) so it automatically becomes minor units, this isn't necessary in just updating a debt so we can simply multiply the user input by 100.
- Added missing recipients error in invite modal.
- Lots of cleaning up dead namespaces.