### PR TITLE
group_user to groupUser changes

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -44,7 +44,7 @@ class CommentController extends Controller
                     ]);
         }
 
-        $group_user = $request->user()->group_users->where('group_id', $debt->group_id)->first();
+        $group_user = $request->user()->groupUsers->where('group_id', $debt->group_id)->first();
 
         Comment::create([
             'debt_id' => $validated['debt_id'],

--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -31,13 +31,13 @@ class DebtController extends Controller
                 // query builder to get the debts where the user is the owner
                 // or has a share in the debt via group_user
                 Debt::whereIn('group_user_id', $user->groupUsers->pluck('id')->toArray())
-                    ->orWhereHas('shares.group_user', function ($query) use ($user) {
+                    ->orWhereHas('shares.groupUser', function ($query) use ($user) {
                         $query->where('user_id', $user->id);
                     })
                     ->distinct()
                     ->latest()
                     ->with([
-                        'shares.group_user.user:id,name',
+                        'shares.groupUser.user:id,name',
                         'comments.group_user.user:id,name',
                         'group.groupUsers.user',
                     ])

--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -38,7 +38,7 @@ class DebtController extends Controller
                     ->latest()
                     ->with([
                         'shares.groupUser.user:id,name',
-                        'comments.group_user.user:id,name',
+                        'comments.groupUser.user:id,name',
                         'group.groupUsers.user',
                     ])
                     ->paginate(5)

--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -30,7 +30,7 @@ class DebtController extends Controller
             DebtResource::collection(
                 // query builder to get the debts where the user is the owner
                 // or has a share in the debt via group_user
-                Debt::whereIn('group_user_id', $user->group_users->pluck('id')->toArray())
+                Debt::whereIn('group_user_id', $user->groupUsers->pluck('id')->toArray())
                     ->orWhereHas('shares.group_user', function ($query) use ($user) {
                         $query->where('user_id', $user->id);
                     })

--- a/app/Http/Controllers/ShareController.php
+++ b/app/Http/Controllers/ShareController.php
@@ -54,8 +54,8 @@ class ShareController extends Controller
             'group_user_id' => $validated['group_user_id'],
             'name' => $validated['name'],
             'amount' => Money::of($validated['amount'], $validated['currency']),
-            'sent' => $debt->group_user_id === $share_group_user->id ? 1 : 0,
-            'seen' => $debt->group_user_id === $share_group_user->id ? 1 : 0,
+            'sent' => $debt->groupUser_id === $share_group_user->id ? 1 : 0,
+            'seen' => $debt->groupUser_id === $share_group_user->id ? 1 : 0,
         ]);
 
         $shareService->addToDebt($share);

--- a/app/Http/Resources/CommentResource.php
+++ b/app/Http/Resources/CommentResource.php
@@ -4,7 +4,6 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
-use App\Http\Resources\UserResource;
 
 class CommentResource extends JsonResource
 {
@@ -31,7 +30,7 @@ class CommentResource extends JsonResource
 
             // relationships
             'group_user' => new GroupUserResource(
-                $this->whenLoaded('group_user')
+                $this->whenLoaded('groupUser')
             ),
         ];
     }

--- a/app/Http/Resources/ShareResource.php
+++ b/app/Http/Resources/ShareResource.php
@@ -35,7 +35,7 @@ class ShareResource extends JsonResource
 
             // relationships
             'group_user' => new GroupUserResource(
-                $this->whenLoaded('group_user')
+                $this->whenLoaded('groupUser')
             ),
         ];
     }

--- a/app/Listeners/DebtCreatedListener.php
+++ b/app/Listeners/DebtCreatedListener.php
@@ -25,7 +25,7 @@ class DebtCreatedListener implements ShouldQueue
         foreach ($event->debt->shares as $share) {
             // automatically broadcasts on the user channel in channels.php
             // otherwise, you broadcast it in the event
-            $share->group_user->user->notify(new DebtCreatedNotification($event->debt));
+            $share->groupUser->user->notify(new DebtCreatedNotification($event->debt));
         };
     }
 }

--- a/app/Models/Alias.php
+++ b/app/Models/Alias.php
@@ -25,7 +25,7 @@ class Alias extends Model
      * 
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function group_user(): BelongsTo
+    public function groupUser(): BelongsTo
     {
         return $this->belongsTo(GroupUser::class);
     }

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -38,7 +38,7 @@ class Comment extends Model
      * 
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function group_user(): BelongsTo
+    public function groupUser(): BelongsTo
     {
         return $this->belongsTo(GroupUser::class);
     }

--- a/app/Models/Debt.php
+++ b/app/Models/Debt.php
@@ -61,7 +61,7 @@ class Debt extends Model
      * 
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function group_user(): BelongsTo
+    public function groupUser(): BelongsTo
     {
         return $this->belongsTo(GroupUser::class);
     }

--- a/app/Models/Debt.php
+++ b/app/Models/Debt.php
@@ -71,7 +71,7 @@ class Debt extends Model
      * 
      * @return \Illuminate\Database\Eloquent\Relations\HasManyThrough
      */
-    public function group_users(): HasManyThrough
+    public function groupUsers(): HasManyThrough
     {
         return $this->hasManyThrough(
             GroupUser::class,    // end goal

--- a/app/Models/Share.php
+++ b/app/Models/Share.php
@@ -47,7 +47,7 @@ class Share extends Model
      * 
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function group_user()
+    public function groupUser()
     {
         return $this->belongsTo(GroupUser::class); 
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -72,7 +72,7 @@ class User extends Authenticatable
      * 
      * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function group_users(): HasMany
+    public function groupUsers(): HasMany
     {
         return $this->hasMany(GroupUser::class);
     }
@@ -85,10 +85,10 @@ class User extends Authenticatable
     protected function userBalance(): Attribute
     {
         return Attribute::get(function () {
-            if ($this->group_users->isEmpty()) {
+            if ($this->groupUsers->isEmpty()) {
                 return Money::of(0, 'GBP');
             } else {
-                return $this->group_users->reduce(function (?Money $carry, GroupUser $group_user) {
+                return $this->groupUsers->reduce(function (?Money $carry, GroupUser $group_user) {
                     // sets the carry as the first group_user balance
                     if ($carry === null) {
                         return $group_user->balance;

--- a/app/Notifications/DebtCreatedNotification.php
+++ b/app/Notifications/DebtCreatedNotification.php
@@ -54,7 +54,7 @@ class DebtCreatedNotification extends Notification implements ShouldQueue
             'name' => $this->debt->name,
             'amount' => $this->debt->amount,
             'group_name' => $this->debt->group->name,
-            'owner' => $this->debt->group_user->user,
+            'owner' => $this->debt->groupUser->user,
         ];
     }
 }

--- a/app/Policies/CommentPolicy.php
+++ b/app/Policies/CommentPolicy.php
@@ -34,7 +34,7 @@ class CommentPolicy
         return $debt->groupUsers()
             ->where('group_users.user_id', $user->id)
             ->exists() || 
-            $debt->group_user->user_id === $user->id;
+            $debt->groupUser->user_id === $user->id;
     }
 
     /**

--- a/app/Policies/CommentPolicy.php
+++ b/app/Policies/CommentPolicy.php
@@ -42,7 +42,7 @@ class CommentPolicy
      */
     public function update(User $user, Comment $comment): bool
     {
-        return $user->id === $comment->group_user->user_id;
+        return $user->id === $comment->groupUser->user_id;
     }
 
     /**
@@ -50,7 +50,7 @@ class CommentPolicy
      */
     public function delete(User $user, Comment $comment): bool
     {
-        return $user->id === $comment->group_user->user_id;
+        return $user->id === $comment->groupUser->user_id;
     }
 
     /**

--- a/app/Policies/CommentPolicy.php
+++ b/app/Policies/CommentPolicy.php
@@ -26,15 +26,15 @@ class CommentPolicy
     }
 
     /**
-     * User can comment on a debt if they have a share ($debt->group_users relationship) in the debt, 
+     * User can comment on a debt if they have a share ($debt->groupUsers relationship) in the debt, 
      * or own the debt itself (no share, but all other shares owe them).
      */
     public function create(User $user, Debt $debt): bool
     {
-        return $debt->group_users()
+        return $debt->groupUsers()
             ->where('group_users.user_id', $user->id)
             ->exists() || 
-            $debt->group_user_id === $user->id;
+            $debt->group_user->user_id === $user->id;
     }
 
     /**

--- a/app/Policies/DebtPolicy.php
+++ b/app/Policies/DebtPolicy.php
@@ -42,7 +42,7 @@ class DebtPolicy
      */
     public function update(User $user, Debt $debt): bool
     {
-        return $user->id === $debt->group_user->user_id;
+        return $user->id === $debt->groupUser->user_id;
     }
 
     /**
@@ -50,7 +50,7 @@ class DebtPolicy
      */
     public function delete(User $user, Debt $debt): bool
     {
-        return $user->id === $debt->group_user->user_id;
+        return $user->id === $debt->groupUser->user_id;
     }
 
     /**

--- a/app/Policies/SharePolicy.php
+++ b/app/Policies/SharePolicy.php
@@ -40,7 +40,7 @@ class SharePolicy
      */
     public function updateName(User $user, Share $share): bool
     {
-        return $user->id === $share->group_user->user_id || $user->id === $share->debt->groupUser->user_id;
+        return $user->id === $share->groupUser->user_id || $user->id === $share->debt->groupUser->user_id;
     }
 
     /**
@@ -58,7 +58,7 @@ class SharePolicy
      */
     public function updateSent(User $user, Share $share): bool
     {
-        return $user->id === $share->group_user->user_id;
+        return $user->id === $share->groupUser->user_id;
     }
 
     /**

--- a/app/Policies/SharePolicy.php
+++ b/app/Policies/SharePolicy.php
@@ -31,7 +31,7 @@ class SharePolicy
      */
     public function create(User $user, Debt $debt): bool
     {
-        return $user->id === $debt->group_user->user_id;
+        return $user->id === $debt->groupUser->user_id;
     }
 
     /**
@@ -40,7 +40,7 @@ class SharePolicy
      */
     public function updateName(User $user, Share $share): bool
     {
-        return $user->id === $share->group_user->user_id || $user->id === $share->debt->group_user->user_id;
+        return $user->id === $share->group_user->user_id || $user->id === $share->debt->groupUser->user_id;
     }
 
     /**
@@ -49,7 +49,7 @@ class SharePolicy
      */
     public function updateAmount(User $user, Share $share): bool
     {
-        return $user->id === $share->debt->group_user->user_id;
+        return $user->id === $share->debt->groupUser->user_id;
     }
 
     /**
@@ -67,7 +67,7 @@ class SharePolicy
      */
     public function updateSeen(User $user, Share $share): bool
     {
-        return $user->id === $share->debt->group_user->user_id;
+        return $user->id === $share->debt->groupUser->user_id;
     }
 
     /**
@@ -76,7 +76,7 @@ class SharePolicy
      */
     public function delete(User $user, Share $share): bool
     {
-        return $user->id === $share->debt->group_user->user_id;
+        return $user->id === $share->debt->groupUser->user_id;
     }
 
     /**

--- a/app/Services/BalanceService.php
+++ b/app/Services/BalanceService.php
@@ -18,7 +18,7 @@ class BalanceService
         if ($share->group_user->id === $share->debt->group_user_id) {
             return;
         } else {
-            $debt_owner = $share->debt->group_user;
+            $debt_owner = $share->debt->groupUser;
         
             $debt_owner->balance = $debt_owner->balance->plus($share->amount);
             $debt_owner->save();

--- a/app/Services/BalanceService.php
+++ b/app/Services/BalanceService.php
@@ -15,7 +15,7 @@ class BalanceService
      */
     public function addToGroupUserBalance($share): void
     {
-        if ($share->group_user->id === $share->debt->group_user_id) {
+        if ($share->groupUser->id === $share->debt->group_user_id) {
             return;
         } else {
             $debt_owner = $share->debt->groupUser;
@@ -23,8 +23,8 @@ class BalanceService
             $debt_owner->balance = $debt_owner->balance->plus($share->amount);
             $debt_owner->save();
 
-            $share->group_user->balance = $share->group_user->balance->minus($share->amount);
-            $share->group_user->save();
+            $share->groupUser->balance = $share->groupUser->balance->minus($share->amount);
+            $share->groupUser->save();
         }
     }
 
@@ -39,16 +39,16 @@ class BalanceService
      */
     public function updateGroupUserBalance($share, $difference): void
     {
-        if ($share->group_user->id === $share->debt->group_user_id) {
+        if ($share->groupUser->id === $share->debt->group_user_id) {
             return;
         } else {
-            $debt_owner = $share->group_user;
+            $debt_owner = $share->groupUser;
 
             $debt_owner->balance = $debt_owner->balance->plus($difference);
             $debt_owner->save();
 
-            $share->group_user->balance = $share->group_user->balance->minus($difference);
-            $share->group_user->save();
+            $share->groupUser->balance = $share->groupUser->balance->minus($difference);
+            $share->groupUser->save();
         }
     }
 
@@ -62,16 +62,16 @@ class BalanceService
      */
     public function subtractFromGroupUserBalance($share, $difference): void
     {
-        if ($share->group_user->id === $share->debt->group_user_id) {
+        if ($share->groupUser->id === $share->debt->group_user_id) {
             return;
         } else {
-            $debt_owner = $share->group_user;
+            $debt_owner = $share->groupUser;
 
             $debt_owner->balance = $debt_owner->balance->minus($difference);
             $debt_owner->save();
 
-            $share->group_user->balance = $share->group_user->balance->plus($difference);
-            $share->group_user->save();
+            $share->groupUser->balance = $share->groupUser->balance->plus($difference);
+            $share->groupUser->save();
         }
     }
 }

--- a/app/Services/ShareService.php
+++ b/app/Services/ShareService.php
@@ -32,8 +32,8 @@ class ShareService
                 'group_user_id' => $user_share_data['group_user_id'],
                 'name' => $user_share_data['share_name'],
                 'amount' => $user_share_data['amount'],
-                'sent' => $debt->group_user->user_id === auth()->user()->id ? 1 : 0,
-                'seen' => $debt->group_user->user_id === auth()->user()->id ? 1 : 0,
+                'sent' => $debt->groupUser->user_id === auth()->user()->id ? 1 : 0,
+                'seen' => $debt->groupUser->user_id === auth()->user()->id ? 1 : 0,
             ]);
 
             $this->balanceService->addToGroupUserBalance($share);    

--- a/database/factories/DebtFactory.php
+++ b/database/factories/DebtFactory.php
@@ -51,7 +51,7 @@ class DebtFactory extends Factory
                 $debt->group_id = $group->id;
                 $debt->group_user_id = $group->groupUsers->random()->id;
             } elseif (!$debt->group_id) {
-                $debt->group_id = $debt->group_user->group->id;
+                $debt->group_id = $debt->groupUser->group->id;
             } elseif (!$debt->group_user_id) {
                 $debt->group_user_id = $debt->group->groupUsers->random()->id;
             }

--- a/database/factories/ShareFactory.php
+++ b/database/factories/ShareFactory.php
@@ -49,7 +49,7 @@ class ShareFactory extends Factory
         return $this->afterCreating(function(Share $share) {
 
             $share_group_user = $share->group_user;
-            $debt_group_user = $share->debt->group_user;
+            $debt_group_user = $share->debt->groupUser;
             
             if ($share_group_user->id != $debt_group_user->id) {
                 // same as in BalanceService, calc user balance depending on debt

--- a/database/factories/ShareFactory.php
+++ b/database/factories/ShareFactory.php
@@ -48,7 +48,7 @@ class ShareFactory extends Factory
     public function calcTotal() {
         return $this->afterCreating(function(Share $share) {
 
-            $share_group_user = $share->group_user;
+            $share_group_user = $share->groupUser;
             $debt_group_user = $share->debt->groupUser;
             
             if ($share_group_user->id != $debt_group_user->id) {

--- a/resources/js/Components/Shares/Share.vue
+++ b/resources/js/Components/Shares/Share.vue
@@ -41,7 +41,7 @@ function setSentSeenMessage(message) {
 }
 
 onMounted(() => {
-
+    
 })
 
 </script>

--- a/tests/Feature/Http/Controllers/DebtControllerTest.php
+++ b/tests/Feature/Http/Controllers/DebtControllerTest.php
@@ -399,7 +399,7 @@ test('user can not change the name of a debt they do not own', function() {
     $this->assertDatabaseHas('debts', [
         'id' => $debt->id,
         'group_id' => $debt->group_id,
-        'group_user_id' => $debt->group_user->id,
+        'group_user_id' => $debt->groupUser->id,
         'name' => $debt->name,
         'amount' => $debt->amount->getMinorAmount()->toInt(),
     ]);
@@ -425,7 +425,7 @@ test('user can not change the amount of a debt they do not own', function() {
     $this->assertDatabaseHas('debts', [
         'id' => $debt->id,
         'group_id' => $debt->group_id,
-        'group_user_id' => $debt->group_user->id,
+        'group_user_id' => $debt->groupUser->id,
         'name' => $debt->name,
         'amount' => $debt->amount->getMinorAmount()->toInt(),
     ]);
@@ -449,7 +449,7 @@ test('user can not delete a debt they do not own', function() {
     $this->assertDatabaseHas('debts', [
         'id' => $debt->id,
         'group_id' => $debt->group_id,
-        'group_user_id' => $debt->group_user->id,
+        'group_user_id' => $debt->groupUser->id,
         'amount' => $debt->amount->getMinorAmount()->toInt(),
     ]);
 });

--- a/tests/Feature/Http/Controllers/ShareControllerTest.php
+++ b/tests/Feature/Http/Controllers/ShareControllerTest.php
@@ -322,7 +322,7 @@ test("user can add a share for another user for a debt they own", function() {
         'split_even' => 0,
     ]);
 
-    $other_group_user = $debt->group_users->reject(fn($group_user) => 
+    $other_group_user = $debt->groupUsers->reject(fn($group_user) => 
         $group_user->id === $this->group_user->id)->first();
 
     $response = $this->post(route('share.store'), [

--- a/tests/Feature/Http/Controllers/ShareControllerTest.php
+++ b/tests/Feature/Http/Controllers/ShareControllerTest.php
@@ -222,9 +222,12 @@ test("user can update the name on a share for a debt they own", function() {
         'group_id' => $this->group->id,
     ]);
     
-    $share = $debt->shares->where('group_user_id', $this->group_user->id)->first();
+    $share = Share::factory()->create([
+        'group_user_id' => $this->group_user->id,
+        'debt_id' => $debt->id,
+        'amount' => 500,
+    ]);
 
-    // update it
     $response = $this->patch(route('share.update', $share), [
         'id' => $share->id,
         'debt_id' => $debt->id,

--- a/tests/Feature/TotalBalanceTest.php
+++ b/tests/Feature/TotalBalanceTest.php
@@ -55,7 +55,7 @@ test("deleting a standard debt recalculates the user's balance", function() {
         'split_even' => 0,
     ]);
 
-    $users = $debt->group_users->pluck('user');
+    $users = $debt->groupUsers->pluck('user');
     $response = $this->delete(route('debt.destroy', $debt));
 
     $response->assertStatus(302);
@@ -99,7 +99,7 @@ test("deleting a split even debt recalculates the user's balance", function() {
         'split_even' => 1,
     ]);
 
-    $users = $debt->group_users->pluck('user');
+    $users = $debt->groupUsers->pluck('user');
     $response = $this->delete(route('debt.destroy', $debt));
 
     $response->assertStatus(302);
@@ -156,7 +156,7 @@ test("adding a standard share for another user recalculates both your balances",
         'split_even' => 0,
     ]);
 
-    $other_group_user = $debt->group_users->reject(fn($group_user) => 
+    $other_group_user = $debt->groupUsers->reject(fn($group_user) => 
         $group_user->user->id === $this->self->id)->first();
 
     $response = $this->post(route('share.store'), [
@@ -209,7 +209,7 @@ test("updating the amount of a standard share for another user recalculates both
             'amount' => Money::of(100, 'GBP'),
         ]);
 
-    $other_group_user = $debt->group_users->reject(fn($group_user) => 
+    $other_group_user = $debt->groupUsers->reject(fn($group_user) => 
         $group_user->user->id === $this->self->id)->first();
 
     $other_share = $other_group_user->shares->first();
@@ -259,7 +259,7 @@ test("deleting a standard share for another user recalculates both your balances
             'amount' => Money::of(100, 'GBP'),
         ]);
 
-    $other_group_user = $debt->group_users->reject(fn($group_user) => 
+    $other_group_user = $debt->groupUsers->reject(fn($group_user) => 
         $group_user->user->id === $this->self->id)->first();
 
     $other_share = $other_group_user->shares->first();

--- a/tests/Feature/TotalBalanceTest.php
+++ b/tests/Feature/TotalBalanceTest.php
@@ -135,7 +135,7 @@ test("adding a standard share for yourself doesn't add it to your balance", func
         'split_even' => 0,
     ]);
 
-    $original_balance = $debt->group_user->user->user_balance;
+    $original_balance = $debt->groupUser->user->user_balance;
 
     $response = $this->post(route('share.store'), [
         'debt_id' => $debt->id,

--- a/tests/Feature/TotalBalanceTest.php
+++ b/tests/Feature/TotalBalanceTest.php
@@ -3,6 +3,7 @@ use App\Models\User;
 use App\Models\GroupUser;
 use App\Models\Group;
 use App\Models\Debt;
+use App\Models\Share;
 use Brick\Money\Money;
 use Illuminate\Support\Facades\Event;
 
@@ -180,9 +181,11 @@ test("updating the amount of a standard share for yourself doesn't recalculate y
         'split_even' => 0,
     ]);
 
-    $own_group_user = $this->group_users->where('user_id', $this->self->id)->first();
-
-    $share = $debt->shares->where('group_user_id', $own_group_user->id)->first();
+    $share = Share::factory()->create([
+        'group_user_id' => $this->group_user->id,
+        'debt_id' => $debt->id,
+        'amount' => 500,
+    ]);
 
     $new_amount = $share->amount->plus(10);
 
@@ -238,9 +241,11 @@ test("deleting a standard share for yourself doesn't recalculate the user's bala
             'amount' => Money::of(100, 'GBP'),
         ]);
 
-    $own_group_user = $this->group_users->where('user_id', $this->self->id)->first();
-
-    $share = $debt->shares->where('group_user_id', $own_group_user->id)->first();
+    $share = Share::factory()->create([
+        'group_user_id' => $this->group_user->id,
+        'debt_id' => $debt->id,
+        'amount' => 500,
+    ]);
   
     $response = $this->delete(route('share.destroy', $share));
 


### PR DESCRIPTION
The aim of this PR is to change model relationships from `->group_user` to `->groupUser` across the board. This is in order to make everything a bit more laravel-y so magic relationships etc. can be utilised. 

Relationships changed for the following models:
  - Debt
  - Share
  - Comment
  - User
  - Alias

Extras:
- Fixed an incorrect id call from `debt->group_user_id`  to `debt->group_user->user_id`.
- Fixes for some flaky tests missed from previous PR.

