### PR TITLE
Improve use of infinite scroll

### DIFF
--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -41,7 +41,7 @@ class DebtController extends Controller
                         'comments.groupUser.user:id,name',
                         'group.groupUsers.user',
                     ])
-                    ->paginate(20)
+                    ->paginate(10)
             )
         );
 

--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -41,7 +41,7 @@ class DebtController extends Controller
                         'comments.groupUser.user:id,name',
                         'group.groupUsers.user',
                     ])
-                    ->paginate(5)
+                    ->paginate(20)
             )
         );
 

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -28,7 +28,7 @@ class GroupController extends Controller
                         'groupUsers.user',
                         'groupUsers.aliases',
                     ])
-                    ->paginate(5)
+                    ->paginate(10)
                 )
             );
 

--- a/resources/js/Components/Misc/InfiniteScrollControls.vue
+++ b/resources/js/Components/Misc/InfiniteScrollControls.vue
@@ -1,6 +1,7 @@
 <script setup>
 
-import { InfiniteScroll } from '@inertiajs/vue3';
+import { InfiniteScroll, usePage } from '@inertiajs/vue3';
+import { onMounted, watch, ref } from 'vue';
 
 const props = defineProps({
     data: {
@@ -9,17 +10,30 @@ const props = defineProps({
     }
 });
 
+/**
+ * Basic logic to make the "back to top" button appear depending on scrollpos
+ */
+const scrollY = ref(0)
+
+function onScroll() {
+  scrollY.value = window.scrollY
+}
+
 const scrollToTop = () => {
   window.scrollTo({ top: 0, behavior: 'smooth' });
 };
+
+onMounted(() => {
+    window.addEventListener('scroll', onScroll)
+})
 
 </script>
 <template>
     <div>
         <InfiniteScroll :data="data" :buffer="500" :manual-after="1">
-            <template #previous="{ loading, hasMore }">
+            <template #previous="{ loading, hasPrevious }">
                 <div class="flex flex-row items-center justify-center">
-                    <button @click="scrollToTop" :disabled="loading" style="position:fixed" class="p-2 rounded border-2 border-solid border-black bg-white">
+                    <button v-if="scrollY > 2000" @click="scrollToTop" :disabled="loading" class="top">
                         {{ loading ? 'Loading...' : 'Back to top' }}
                     </button>
                 </div>
@@ -33,3 +47,16 @@ const scrollToTop = () => {
         </InfiniteScroll>
     </div>
 </template>
+<style scoped>
+    .top {
+        position: fixed;
+        box-shadow: 0 10px 6px rgba(0, 0, 0, 0.1);
+        padding: 6px;
+        background-color: hsl(0, 0%, 100%);
+        border-radius: 4px;
+    }
+
+    .top:hover {
+        background-color: #FBFBFB;
+    }
+</style>

--- a/resources/js/Components/Misc/InfiniteScrollControls.vue
+++ b/resources/js/Components/Misc/InfiniteScrollControls.vue
@@ -1,0 +1,33 @@
+<script setup>
+
+import { InfiniteScroll } from '@inertiajs/vue3';
+
+const props = defineProps({
+    data: {
+        type: String,
+        required: true,
+    }
+});
+
+const scrollToTop = () => {
+  window.scrollTo({ top: 0, behavior: 'smooth' });
+};
+
+</script>
+<template>
+    <div>
+        <InfiniteScroll :data="data" :buffer="500" :manual-after="1">
+            <template #previous="{ loading, hasMore }">
+                <button  @click="scrollToTop" :disabled="loading" style="position:fixed">
+                    {{ loading ? 'Loading...' : 'Back to top' }}
+                </button>
+            </template>
+                <slot />
+            <template #next="{ loading, fetch, hasMore }">
+                <button v-if="hasMore" @click="fetch" :disabled="loading">
+                    {{ loading ? 'Loading...' : 'Load more' }}
+                </button>
+            </template>
+        </InfiniteScroll>
+    </div>
+</template>

--- a/resources/js/Components/Misc/InfiniteScrollControls.vue
+++ b/resources/js/Components/Misc/InfiniteScrollControls.vue
@@ -3,6 +3,12 @@
 import { InfiniteScroll, usePage } from '@inertiajs/vue3';
 import { onMounted, watch, ref } from 'vue';
 
+/**
+ * Pass in the string of the item you're scrolling
+ * assuming it's being returned from the Inertia::scroll method
+ * as that means it'll come back as e.g. debts.data
+ * so you pass in the string to InfiniteScroll to basically tell it what to look for.
+ */
 const props = defineProps({
     data: {
         type: String,
@@ -38,7 +44,8 @@ onMounted(() => {
                     </button>
                 </div>
             </template>
-                <slot />
+            <!-- slot is for whatever your prop string is, what will be looped over in parent -->
+            <slot />
             <template #next="{ loading, fetch, hasMore }">
                 <button v-if="hasMore" @click="fetch" :disabled="loading">
                     {{ loading ? 'Loading...' : 'Load more' }}

--- a/resources/js/Components/Misc/InfiniteScrollControls.vue
+++ b/resources/js/Components/Misc/InfiniteScrollControls.vue
@@ -17,7 +17,12 @@ const props = defineProps({
 });
 
 /**
- * Basic logic to make the "back to top" button appear depending on scrollpos
+ * If the user scrolls past the height of the page, eventually show top controls.
+ */
+const pageHeight = ref(window.innerHeight);
+
+/**
+ * Basic logic to make the "back to top" button appear depending on scrollpos.
  */
 const scrollY = ref(0)
 
@@ -30,7 +35,7 @@ const scrollToTop = () => {
 };
 
 onMounted(() => {
-    window.addEventListener('scroll', onScroll)
+    window.addEventListener('scroll', onScroll);
 })
 
 </script>
@@ -41,7 +46,7 @@ onMounted(() => {
                 <div class="flex flex-row items-center justify-center">
                     <Transition name="fade">
                         <button
-                            v-if="scrollY > 2000"
+                            v-if="scrollY > pageHeight"
                             @click="scrollToTop"
                             :disabled="loading"
                             class="top font-semibold"

--- a/resources/js/Components/Misc/InfiniteScrollControls.vue
+++ b/resources/js/Components/Misc/InfiniteScrollControls.vue
@@ -18,9 +18,11 @@ const scrollToTop = () => {
     <div>
         <InfiniteScroll :data="data" :buffer="500" :manual-after="1">
             <template #previous="{ loading, hasMore }">
-                <button  @click="scrollToTop" :disabled="loading" style="position:fixed">
-                    {{ loading ? 'Loading...' : 'Back to top' }}
-                </button>
+                <div class="flex flex-row items-center justify-center">
+                    <button @click="scrollToTop" :disabled="loading" style="position:fixed" class="p-2 rounded border-2 border-solid border-black bg-white">
+                        {{ loading ? 'Loading...' : 'Back to top' }}
+                    </button>
+                </div>
             </template>
                 <slot />
             <template #next="{ loading, fetch, hasMore }">

--- a/resources/js/Components/Misc/InfiniteScrollControls.vue
+++ b/resources/js/Components/Misc/InfiniteScrollControls.vue
@@ -39,31 +39,66 @@ onMounted(() => {
         <InfiniteScroll :data="data" :buffer="500" :manual-after="1">
             <template #previous="{ loading, hasPrevious }">
                 <div class="flex flex-row items-center justify-center">
-                    <button v-if="scrollY > 2000" @click="scrollToTop" :disabled="loading" class="top">
-                        {{ loading ? 'Loading...' : 'Back to top' }}
-                    </button>
+                    <Transition name="fade">
+                        <button
+                            v-if="scrollY > 2000"
+                            @click="scrollToTop"
+                            :disabled="loading"
+                            class="top font-semibold"
+                        >
+                            {{ loading ? 'Loading...' : 'Back to top' }}
+                        </button>
+                    </Transition>
                 </div>
             </template>
             <!-- slot is for whatever your prop string is, what will be looped over in parent -->
             <slot />
             <template #next="{ loading, fetch, hasMore }">
-                <button v-if="hasMore" @click="fetch" :disabled="loading">
-                    {{ loading ? 'Loading...' : 'Load more' }}
-                </button>
+                <div class="flex flex-row items-center justify-center">
+                    <button
+                        v-if="hasMore"
+                        @click="fetch"
+                        :disabled="loading"
+                        class="bottom font-semibold"
+                    >
+                        {{ loading ? 'Loading...' : 'Load more' }}
+                    </button>
+                </div>
             </template>
         </InfiniteScroll>
     </div>
 </template>
 <style scoped>
-    .top {
-        position: fixed;
-        box-shadow: 0 10px 6px rgba(0, 0, 0, 0.1);
-        padding: 6px;
-        background-color: hsl(0, 0%, 100%);
-        border-radius: 4px;
-    }
+.top {
+    position: fixed;
+    box-shadow: 0 10px 6px rgba(0, 0, 0, 0.1);
+    padding: 6px;
+    background-color: hsl(0, 0%, 100%);
+    border-radius: 4px;
+}
 
-    .top:hover {
-        background-color: #FBFBFB;
-    }
+.top:hover {
+    background-color: #FBFBFB;
+}
+
+.bottom {
+    padding: 6px;
+    background-color: hsl(0, 0%, 100%);
+    border-radius: 4px;
+    border: 2px solid black;
+}
+
+.bottom:hover {
+    background-color: #FBFBFB;
+}
+
+.fade-enter-active,
+.fade-leave-active {
+    transition: opacity 0.1s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+    opacity: 0;
+}
 </style>

--- a/resources/js/Pages/Debts.vue
+++ b/resources/js/Pages/Debts.vue
@@ -30,13 +30,6 @@ const showAddDebt = ref(false);
     <AuthenticatedLayout
         :status="status"
     >
-        <!-- <template #header>
-            <h2
-                class="text-xl font-semibold leading-tight text-gray-800"
-            >
-                Dashboard
-            </h2>
-        </template> -->
         <BigButton 
             @click="showAddDebt = !showAddDebt"
         >

--- a/resources/js/Pages/Debts.vue
+++ b/resources/js/Pages/Debts.vue
@@ -44,13 +44,23 @@ onMounted(() => {
         >
             Add a debt
         </BigButton>
-        <InfiniteScroll data="debts" :buffer="100">
+        <InfiniteScroll data="debts" :buffer="500" :manual-after="1">
+            <template #previous="{ loading, fetch, hasMore }">
+                <button v-if="hasMore" @click="fetch" :disabled="loading">
+                    {{ loading ? 'Loading...' : 'Load previous' }}
+                </button>
+            </template>
             <Debt
                 v-for="debt in debts.data"
                 :debt="debt"
                 :key="debt.id"
             >
             </Debt>
+            <template #next="{ loading, fetch, hasMore }">
+                <button v-if="hasMore" @click="fetch" :disabled="loading">
+                    {{ loading ? 'Loading...' : 'Load more' }}
+                </button>
+            </template>
         </InfiniteScroll>
         <Modal :show="showAddDebt" @close="showAddDebt = false" @addDebt="showAddDebt = false">
             <AddDebtForm

--- a/resources/js/Pages/Debts.vue
+++ b/resources/js/Pages/Debts.vue
@@ -23,13 +23,6 @@ const props = defineProps({
 // for toggling form display
 const showAddDebt = ref(false);
 
-const scrollToTop = () => {
-  window.scrollTo({ top: 0, behavior: 'smooth' });
-};
-
-onMounted(() => {
-
-});
 </script>
 
 <template>

--- a/resources/js/Pages/Debts.vue
+++ b/resources/js/Pages/Debts.vue
@@ -6,6 +6,7 @@ import { computed, onMounted, onUnmounted, ref } from 'vue';
 import AddDebtForm from '@/Components/Debts/AddDebt/Form/AddDebtForm.vue';
 import BigButton from '@/Components/Misc/BigButton.vue';
 import Modal from '@/Components/Forms/Modal.vue';
+import InfiniteScrollControls from '@/Components/Misc/InfiniteScrollControls.vue';
 
 const props = defineProps({
     debts: {
@@ -21,6 +22,10 @@ const props = defineProps({
 
 // for toggling form display
 const showAddDebt = ref(false);
+
+const scrollToTop = () => {
+  window.scrollTo({ top: 0, behavior: 'smooth' });
+};
 
 onMounted(() => {
 
@@ -44,24 +49,14 @@ onMounted(() => {
         >
             Add a debt
         </BigButton>
-        <InfiniteScroll data="debts" :buffer="500" :manual-after="1">
-            <template #previous="{ loading, fetch, hasMore }">
-                <button v-if="hasMore" @click="fetch" :disabled="loading">
-                    {{ loading ? 'Loading...' : 'Load previous' }}
-                </button>
-            </template>
+        <InfiniteScrollControls data="debts">
             <Debt
                 v-for="debt in debts.data"
                 :debt="debt"
                 :key="debt.id"
             >
             </Debt>
-            <template #next="{ loading, fetch, hasMore }">
-                <button v-if="hasMore" @click="fetch" :disabled="loading">
-                    {{ loading ? 'Loading...' : 'Load more' }}
-                </button>
-            </template>
-        </InfiniteScroll>
+        </InfiniteScrollControls>
         <Modal :show="showAddDebt" @close="showAddDebt = false" @addDebt="showAddDebt = false">
             <AddDebtForm
                 v-if="showAddDebt"

--- a/resources/js/Pages/Groups.vue
+++ b/resources/js/Pages/Groups.vue
@@ -4,6 +4,7 @@ import Group from '@/Components/Groups/Group.vue';
 import CreateGroup from '@/Components/Groups/CreateGroup.vue';
 import { Head, InfiniteScroll } from '@inertiajs/vue3';
 import { onMounted } from 'vue';
+import InfiniteScrollControls from '@/Components/Misc/InfiniteScrollControls.vue';
 
 const props = defineProps({
     groups: {
@@ -28,13 +29,13 @@ onMounted(() => {
         >
             <CreateGroup>
             </CreateGroup>
-            <InfiniteScroll data="groups" :buffer="100">
+            <InfiniteScrollControls data="groups">
                 <Group
                     v-for="group in groups.data"
                     :group="group"
                     :key="group.id"
                 />
-            </InfiniteScroll>
+            </InfiniteScrollControls>
         </AuthenticatedLayout>
     </div>
 </template>


### PR DESCRIPTION
The aim of this PR is to improve/correct the use of inertia's `InfiniteScroll` component. Investigation showed that I misunderstood how the component was meant to function, I was expecting the actual frontend pagination to be more automatic, e.g. page loads->scroll loads another page; 'infinite scroll'. Unless specific, it will load everything but in a segmented way as dictated in the controller method. So, changelog:

- Records per page for groups & debts increased to 10 from 5.
- `InfiniteScrollControls` component has been created. This component contains `InfiniteScroll` and has a slot for records to be looped over, the same way `InfiniteScroll` does, but the difference is it has "load more" and "back to top" controls ofr the user to interact with. Currently by default, one page is loaded and the user can scroll + click to load another. The component accepts a string which is a replacement for the data you pass into `InfiniteScroll`. It essentially tells `InfiniteScroll` what to look for. This has been implemented for both debts & groups.
