### PR TITLE
Bugfix for debt notifications breaking (but it's actually just improving CSS on InfiniteScroll controls)

### DIFF
--- a/app/Notifications/DebtCreatedNotification.php
+++ b/app/Notifications/DebtCreatedNotification.php
@@ -54,7 +54,7 @@ class DebtCreatedNotification extends Notification implements ShouldQueue
             'name' => $this->debt->name,
             'amount' => $this->debt->amount,
             'group_name' => $this->debt->group->name,
-            'owner' => $this->debt->groupUser->user,
+            'owner' => $notifiable,
         ];
     }
 }

--- a/resources/js/Components/Debts/Debt.vue
+++ b/resources/js/Components/Debts/Debt.vue
@@ -69,7 +69,7 @@ onMounted(() => {
             </div>
             <div v-if="!isEditing" class="flex flex-col items-center w-full">
                 <h2 class="h3"> 
-                    {{ props.debt.name }}{{ props.debt.id }}
+                    {{ props.debt.name }}
                 </h2>
                 <h2 class="h3">
                     {{ debtCurrency.symbol }}{{ props.debt.amount.amount }}

--- a/resources/js/Components/Misc/InfiniteScrollControls.vue
+++ b/resources/js/Components/Misc/InfiniteScrollControls.vue
@@ -36,6 +36,7 @@ const scrollToTop = () => {
 
 onMounted(() => {
     window.addEventListener('scroll', onScroll);
+    console.log(usePage().props);
 })
 
 </script>
@@ -59,15 +60,21 @@ onMounted(() => {
             <!-- slot is for whatever your prop string is, what will be looped over in parent -->
             <slot />
             <template #next="{ loading, fetch, hasMore }">
-                <div class="flex flex-row items-center justify-center">
+                <div class="grid grid-cols-3 items-center">
+                    <div>
+
+                    </div>
                     <button
                         v-if="hasMore"
                         @click="fetch"
                         :disabled="loading"
-                        class="bottom font-semibold"
+                        class="bottom font-semibold justify-self-center w-full"
                     >
                         {{ loading ? 'Loading...' : 'Load more' }}
                     </button>
+                    <p class="font-semibold justify-self-end tracking-tight">
+                        {{ usePage().props[data].data.length }} of {{ usePage().props[data].meta.total }}
+                    </p>
                 </div>
             </template>
         </InfiniteScroll>
@@ -78,23 +85,27 @@ onMounted(() => {
     position: fixed;
     box-shadow: 0 10px 6px rgba(0, 0, 0, 0.1);
     padding: 6px;
-    background-color: hsl(0, 0%, 100%);
+    background-color:black;
+    color: white;
     border-radius: 4px;
 }
 
 .top:hover {
-    background-color: #FBFBFB;
+    background-color: rgb(55 65 81);
+    border: 2px solid  rgb(55 65 81);
 }
 
 .bottom {
     padding: 6px;
-    background-color: hsl(0, 0%, 100%);
+    background-color: black;
     border-radius: 4px;
     border: 2px solid black;
+    color: white
 }
 
 .bottom:hover {
-    background-color: #FBFBFB;
+    background-color: rgb(55 65 81);
+    border: 2px solid  rgb(55 65 81);
 }
 
 .fade-enter-active,


### PR DESCRIPTION
This PR was to originally investigate a bug that was only happening in production; debt notifs were not firing. Changed `$this->debt->groupUser->user` to `$notifiable` (same thing, but reads nicer) but also ran `optimize:clear` in production then restarted reverb & queues after deploying the small change, they hadn't been done since the big merge earlier in the week. Instead, used this PR to make the `InfiniteScroll` controls appearances a bit nicer. Changelog:

- Made 'owner' property in debt notification more readable
- Removed some old debug
- Improved CSS on `InfiniteScroll` controls