### PR TITLE
Limiting capabilities of split even debts

### DIFF
--- a/resources/js/Components/Shares/Share.vue
+++ b/resources/js/Components/Shares/Share.vue
@@ -121,7 +121,7 @@ onMounted(() => {
                     />
                 </div>
                 <InputError class="mt-2" :message="errors.name" />
-                <div v-if="props.share.can.update_amount" class="flex flex-row">
+                <div v-if="props.share.can.update_amount && !props.debt.split_even" class="flex flex-row">
                     <label 
                         for="ShareAmount"
                         style="display:none;"


### PR DESCRIPTION
The aim of this PR is to make the changes on a decision; limiting the capabilities of 'split even' debts. The idea is to to restrict a split even debt to the following operations:

- A 'split even' debt can be added by the user.
- That user alone can add/remove shares. Following this, other user shares will be recalculated.
- That user alone can edit the amount on the debt, this will recalculate the share amount for each user.
- Individual share amount can not be changed at any time.

I was getting too bogged down in thinking of endless edge cases, e.g. a user wants to record a debt where "everyone owes a fiver but this person owes a tenner". I could add a checkbox as an appendage of sorts, but then that would require a new share property of 'appended' or something similar. It'd quickly become too confusing and just full of if/else statements serving little actual purpose. So, the idea now is that split even debts are severely limited and 'standard' debts are endlessly flexible.