### PR TITLE
A few small fixes that don't warrant their own PRs

### DIFF
--- a/resources/js/Components/Debts/AddDebt/Form/AddDebtForm.vue
+++ b/resources/js/Components/Debts/AddDebt/Form/AddDebtForm.vue
@@ -35,6 +35,10 @@ const selectedGroup = ref(null);
  * Set the shares with the values from the group users of the selected group.
  */
 watch(() => debtStore.debtForm.group_id, (groupId) => {
+    if (!groupId) {
+        return;
+    }
+
     selectedGroup.value = props.groups.find((group) => group.id == groupId);
 
     debtStore.debtForm.user_shares = selectedGroup.value.group_users.map((group_user) => ({

--- a/resources/js/Components/Debts/Debt.vue
+++ b/resources/js/Components/Debts/Debt.vue
@@ -43,8 +43,16 @@ const debtDiscrepancy = computed(() => {
     return Math.round((props.debt.amount.amount - total) * 100);
 });
 
-onMounted(() => {
+/**
+ * If the debt owner doesn't have a share but recorded the debt, they are owed all of it.
+ * Using this computer property, we can show a plate that does nothing, for clarity.
+ */
+const debtOwnerHasNoShare = computed(() => {
+    return !props.debt.shares.map((share) => share.group_user_id).includes(props.debt.group_user_id);
+});
 
+onMounted(() => {
+    console.log(props.debt.id, props.debt.shares.map((share) => share.group_user_id).includes(props.debt.group_user_id));
 })
 
 </script>
@@ -168,6 +176,14 @@ onMounted(() => {
         </div>
         <!-- shares -->
         <Collapsible v-model="showShares" class="flex-flex-col">
+            <div v-if="debtOwnerHasNoShare" class="plate justify-between">
+                <p class="font-semibold">
+                    {{ props.debt.group.group_users.find((group_user) => group_user.id === props.debt.group_user_id).user.name }}
+                </p>
+                <p class="text-xs font-semibold bg-black text-white p-1 border rounded mr-6">
+                    OWNER
+                </p>
+            </div>
             <Share
                 v-for="share in debt.shares"
                 :share="share"

--- a/resources/js/Components/Debts/Debt.vue
+++ b/resources/js/Components/Debts/Debt.vue
@@ -180,9 +180,14 @@ onMounted(() => {
                 <p class="font-semibold">
                     {{ props.debt.group.group_users.find((group_user) => group_user.id === props.debt.group_user_id).user.name }}
                 </p>
-                <p class="text-xs font-semibold bg-black text-white p-1 border rounded mr-6">
-                    OWNER
-                </p>
+                <div style="width:103px" class="flex justify-center">
+                    <p class="text-xs font-semibold bg-black text-white p-1 border rounded">
+                        OWNER
+                    </p>
+                    <div style="width:32px">
+                        <!-- this is where the controls would go, just a hacky way to cover the space -->
+                    </div>
+                </div>
             </div>
             <Share
                 v-for="share in debt.shares"

--- a/resources/js/Components/Debts/Debt.vue
+++ b/resources/js/Components/Debts/Debt.vue
@@ -52,7 +52,7 @@ const debtOwnerHasNoShare = computed(() => {
 });
 
 onMounted(() => {
-    console.log(props.debt.id, props.debt.shares.map((share) => share.group_user_id).includes(props.debt.group_user_id));
+
 })
 
 </script>

--- a/resources/js/Components/Misc/InfiniteScrollControls.vue
+++ b/resources/js/Components/Misc/InfiniteScrollControls.vue
@@ -42,8 +42,24 @@ onMounted(() => {
 <template>
     <div>
         <InfiniteScroll :data="data" :buffer="500" :manual-after="1">
-            <template #previous="{ loading, hasPrevious }">
+            <template #previous="{ loading, fetch, hasPrevious }">
                 <div class="flex flex-row items-center justify-center">
+                    <div class="grid grid-cols-3 items-center">
+                        <div>
+                            <!-- void -->
+                        </div>
+                        <button
+                            v-if="hasPrevious"
+                            @click="fetch"
+                            :disabled="loading"
+                            class="bottom font-semibold justify-self-center w-full"
+                        >
+                            {{ loading ? 'Loading...' : 'Load previous' }}
+                        </button>
+                        <div>
+                        <!-- void -->
+                        </div>
+                    </div>
                     <Transition name="fade">
                         <button
                             v-if="scrollY > pageHeight"

--- a/resources/js/Components/Shares/Share.vue
+++ b/resources/js/Components/Shares/Share.vue
@@ -35,6 +35,23 @@ const debtCurrency = computed(() => {
     return currencies.find((currency) => currency.code === props.currency)
 });
 
+/**
+ * Whether or not a user can make changes to a share is set by SharePolicy.
+ * This is just to determine whether or not to show the controls to the user.
+ * It's mostly the same, just essentially when a share is sent & seen it's finally "locked"
+ */
+const showShareControls = computed(() => {
+    switch (true) {
+        case props.share.can.update_name:
+        case props.share.can.update_amount:
+        case props.share.can.delete:
+        case props.share.sent && props.share.seen:
+            return true;
+        default:
+            return false;
+    }
+})
+
 function setSentSeenMessage(message) {
     sentSeenMessage.value = message.sent ?? message.seen;
     refresh & refresh();
@@ -79,7 +96,7 @@ onMounted(() => {
                 <Controls
                     item="Share"
                     :key="props.share.id"
-                    :visible="props.share.can.update_name || props.share.can.delete"
+                    :visible="showShareControls"
                     :updatable="props.share.can.update_name"
                     :deletable="props.share.can.delete"
                     @edit="isEditing = !isEditing;refresh & refresh()"

--- a/resources/js/Stores/DebtStore.js
+++ b/resources/js/Stores/DebtStore.js
@@ -86,8 +86,7 @@ export const useDebtStore = defineStore('debtStore', {
                 })).post(route('debt.store'), {
                     preserveScroll: true,
                     onSuccess: () => {
-                        this.debtForm.name = '';
-                        this.debtForm.amount = 0;
+                        this.debtForm.reset();
                         router.reload({ only: ['auth'] });
                         resolve();
                     },


### PR DESCRIPTION
Not much to say in this PR, just a few small bits that don't really warrant their own PR:

- There was a small bug where if you added a debt and then opened the modal again, the group picker would be on the group you added a debt for, but shares wouldn't show. Changed the debt submission `onSuccess()` to reset the entire form afterwards, and addeda  condition to the watcher that simply returns if group is set to null.
- Added a computed property and 'fake share' to the `Debt` component; this now shows the owner of the debt if they added the debt and do not have a share in it.
- I thought there was a bug with infinite scroll. If you loaded & scrolled down to page 4 (at which point pages 1-4 are loaded) then refreshed, you would be loaded into page 3 & 4 (scroll loads 2 pages of 10). This was just a behaviour misunderstanding on my part, as it assumes you have some sort of 'load previous' button. So rather than have it load all pages on refresh of not being on pages 1 & 2, you can now 'load previous' and refresh doesn't load unnecessary pages.
- Changed share sent/seen to work off of a computed property