### PR TITLE
Rewriting tests for debts, shares and balance

### DIFF
--- a/app/Http/Controllers/ShareController.php
+++ b/app/Http/Controllers/ShareController.php
@@ -77,7 +77,7 @@ class ShareController extends Controller
     {
         // switch case to handle share policy checks
         switch ($request->user()) {
-            case $request->user()->cannot('updateName', $share) && $request->user()->cannot('updateAmount', $share):
+            case $request->user()->cannot('update', $share):
                 return redirect()
                     ->route('debt.index')
                     ->withErrors([
@@ -89,7 +89,7 @@ class ShareController extends Controller
                     ->withErrors([
                         'name' => "You do not have permission to update the name of this share."
                     ]);
-            case $share->wasChanged('amount') && $request->user()->cannot('updateAmount', $share):
+            case $request->user()->cannot('updateAmount', $share):
                 return redirect()
                     ->route('debt.index')
                     ->withErrors([

--- a/app/Models/Debt.php
+++ b/app/Models/Debt.php
@@ -92,4 +92,18 @@ class Debt extends Model
     {
         return $this->hasMany(Comment::class);
     }
+
+    /**
+     * Ledger entries for the debt.
+     * 
+     * @return \Illuminate\Database\Eloquent\Relations\HasManyThrough
+     */
+    public function ledgerEntries(): HasManyThrough
+    {
+        return $this->hasManyThrough(
+            LedgerEntry::class,
+            Share::class,
+            'debt_id',  
+        );
+    }
 }

--- a/app/Models/Share.php
+++ b/app/Models/Share.php
@@ -51,4 +51,14 @@ class Share extends Model
     {
         return $this->belongsTo(GroupUser::class); 
     }
+
+    /**
+     * Ledger entry for the share.
+     * 
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     */
+    public function ledgerEntry()
+    {
+        return $this->hasOne(LedgerEntry::class);
+    }
 }

--- a/app/Policies/SharePolicy.php
+++ b/app/Policies/SharePolicy.php
@@ -35,6 +35,14 @@ class SharePolicy
     }
 
     /**
+     * Determine whether or not the user can update the share at all
+    */
+    public function update(User $user, Share $share): bool
+    {
+        return $user->id === $share->groupUser->user_id || $user->id === $share->debt->groupUser->user_id;
+    }
+
+    /**
      * Determine whether the user can update the share name
      * Can be done by debt/share owner
      */
@@ -49,6 +57,10 @@ class SharePolicy
      */
     public function updateAmount(User $user, Share $share): bool
     {
+        if ($share->debt->split_even) {
+            return false;
+        } 
+        
         return $user->id === $share->debt->groupUser->user_id;
     }
 

--- a/database/factories/DebtFactory.php
+++ b/database/factories/DebtFactory.php
@@ -56,6 +56,12 @@ class DebtFactory extends Factory
             } elseif (!$debt->group_user_id) {
                 $debt->group_user_id = $debt->group->groupUsers->random()->id;
             }
+        })->afterCreating(function (Debt $debt) {
+            Share::factory()->create([
+                'debt_id' => $debt->id,
+                'group_user_id' => $debt->group_user_id,
+                'amount' => $debt->amount->getMinorAmount()->toInt(),
+            ]);
         });
     }
 

--- a/database/factories/DebtFactory.php
+++ b/database/factories/DebtFactory.php
@@ -79,15 +79,11 @@ class DebtFactory extends Factory
     public function withComments(): static
     {
         return $this->afterCreating(function (Debt $debt) {
-            $count = rand(0, 5);
-
-            if ($count > 0) {
-                Comment::factory()
-                    ->count($count)
-                    ->create([
-                        'debt_id' => $debt->id,
-                    ]);
-            }
+            Comment::factory()
+                ->count(rand(0, 5))
+                ->create([
+                    'debt_id' => $debt->id,
+            ]);
         });
     }
     /**

--- a/resources/js/Components/Debts/AddDebt/Form/AddDebtForm.vue
+++ b/resources/js/Components/Debts/AddDebt/Form/AddDebtForm.vue
@@ -128,7 +128,7 @@ async function addDebt() {
                 <GroupUserPicker
                     :group_users="selectedGroup.group_users"
                     label="This will be the owner of the debt"
-                    :errors="debtStore.debtForm.errors.user_id"
+                    :errors="debtStore.debtForm.errors.group_user_id"
                     @userSelected="setDebtOwner"
                 >
                 </GroupUserPicker>

--- a/resources/js/Components/Debts/Debt.vue
+++ b/resources/js/Components/Debts/Debt.vue
@@ -133,7 +133,7 @@ onMounted(() => {
                                 New Amount
                             </label>
                             <input
-                                v-model="props.debt.amount" 
+                                v-model="props.debt.amount.amount" 
                                 name="amount"
                                 type="number"
                                 step="0.01"

--- a/resources/js/Components/Forms/GroupUserPicker.vue
+++ b/resources/js/Components/Forms/GroupUserPicker.vue
@@ -38,6 +38,6 @@ const props = defineProps({
                 {{ group_user.user.name }}
             </option>>
         </select>
-        <InputError :message="errors" />
+        <InputError  class="mt-2" :message="errors" />
     </div>
 </template>

--- a/resources/js/Components/Shares/SentSeenButton.vue
+++ b/resources/js/Components/Shares/SentSeenButton.vue
@@ -32,7 +32,8 @@ onMounted(() => {})
         #default="{ errors }"
         :options="{
             preserveScroll: true,
-            only: ['this is a hack to prevent full reload', 'auth.user'],
+            // this is to prevent full reloads
+            only: ['auth.user'],
         }"
         :transform="data => ({ 
             ...data, 

--- a/resources/js/Components/Shares/Share.vue
+++ b/resources/js/Components/Shares/Share.vue
@@ -119,7 +119,7 @@ onMounted(() => {
             :transform="data => ({
                 ...data,
                 // same as in Debt, needs minor units
-                amount: data.amount * 100,
+                amount: props.debt.split_even ? props.share.amount.amount * 100 : data.amount * 100,
             })"
         >
             <div class="flex flex-col">
@@ -129,7 +129,7 @@ onMounted(() => {
                         style="display:none;"
                         id="newShareNameLabel"
                     >
-                    New Name
+                        New Name
                     </label>
                     <TextInput
                         name="name"
@@ -153,7 +153,7 @@ onMounted(() => {
                     </label>
                     <input
                         name="amount"
-                        v-model="props.share.amount"
+                        v-model="props.share.amount.amount"
                         type="number"
                         step="0.01"
                         id="newShareAmount"

--- a/tests/Feature/Http/Controllers/DebtControllerTest.php
+++ b/tests/Feature/Http/Controllers/DebtControllerTest.php
@@ -188,11 +188,13 @@ test('user can not delete a debt they do not own', function() {
  * Tests for behaviours to do with adding debts, but the type is irrelevant:
  * - Not able to add a debt with no group selected
  * - Not able to add a debt with no name
+ * - Not able to add a debt with a name longe than 255 chars
  * - Not able to add a debt with no currency
  * - Not able to add a debt with no owner (group user) selected
  * - Not able to add a debt with no shares
  * - Not be able to add a debt that sums to zero
  * - Not able to add a debt with no amount
+ * - Not able to add a debt for a group they're not in
  */
 
 test('user can not add a debt with no group selected', function() {
@@ -239,6 +241,32 @@ test('user can not add a debt with no name', function() {
     $this->assertDatabaseMissing('debts', [
         'group_user_id' => $this->group_user->id,
         'amount' => 101,
+        'created_at' => Carbon::now()->format('Y-m-d H:i:s'),
+    ]);
+});
+
+test('user can not add a debt with a name longer than 255 characters', function() {
+    $user_shares = selectRandomGroupUsers($this->group->groupUsers, 10000, false);
+
+    $response = $this->post(route('debt.store'), [
+        'group_id' => $this->group_user->group->id,
+        'group_user_id' => $this->group_user->id,
+        'name' => str_repeat('a', 256),
+        'amount' => 101,
+        'split_even' => 0,
+        'user_shares' => $user_shares,
+        'currency' => 'GBP',
+    ]);
+
+    $response->assertStatus(302);
+    $response->assertSessionHasErrors([
+        'name' => 'The debt name may not be greater than 255 characters.',
+    ]);
+
+    $this->assertDatabaseMissing('debts', [
+        'group_user_id' => $this->group_user->id,
+        'amount' => 101,
+        'name' => str_repeat('a', 256),
         'created_at' => Carbon::now()->format('Y-m-d H:i:s'),
     ]);
 });
@@ -375,6 +403,38 @@ test('user can not add a debt with no amount', function() {
     ]);   
 });
 
+test('user can not add a debt for a group they are not in', function() {
+    $other_group = Group::factory()->create([
+        'user_id' => $this->other_group_user->user->id,
+    ]);
+
+    $user_shares = selectRandomGroupUsers($this->group->groupUsers, 10000, false);
+
+    $response = $this->post(route('debt.store', [
+        'group_id' => $other_group->id,
+        'group_user_id' => $this->group_user->id,
+        'amount' => 12345,
+        'name' => 'test debt 25',
+        'split_even' => 0,
+        'user_shares' => $user_shares,
+        'currency' => 'GBP',
+    ]));
+
+    $response->assertStatus(302)
+        ->assertSessionHasErrors([
+            'id' => "You do not have permission to create this debt."
+        ]);
+
+    $this->assertDatabaseMissing('debts', [
+        'group_id' => $other_group->id,
+        'group_user_id' => $this->group_user->id,
+        'amount' => 12345,
+        'name' => 'test debt 25',
+        'split_even' => 0,
+        'currency' => 'GBP',
+    ]);
+});
+
 
 // test('user can add a debt with different value shares', function() {
 //     $user_shares = selectRandomGroupUsers($this->group->groupUsers, 10000, false);
@@ -497,91 +557,10 @@ test('user can not add a debt with no amount', function() {
 //     }
 // });
 
-// test('user can not add a debt with no group users selected', function() {
-//     $response = $this->post(route('debt.store'), [
-//         'group_id' => $this->group->id,
-//         'group_user_id' => $this->group_user->id,
-//         'name' => 'test debt',
-//         'amount' => 100,
-//         'split_even' => 0,
-//         'user_shares' => [],
-//         'currency' => 'GBP',
-//     ]);
 
-//     $response->assertStatus(302);
-//     $response->assertSessionHasErrors('user_shares');
-// });
 
-// test('user can not add a debt with no name', function() {
-//     $user_shares = selectRandomGroupUsers($this->group->groupUsers, 15000, false);
 
-//     $response = $this->post(route('debt.store'), [
-//         'group_id' => $this->group->id,
-//         'group_user_id' => $this->group_user->id,
-//         'name' => null,
-//         'amount' => 150,
-//         'split_even' => 0,
-//         'user_shares' => $user_shares,
-//         'currency' => 'GBP',
-//     ]);
 
-//     $response->assertStatus(302);
-//     $response->assertSessionHasErrors('name');
-
-//     $this->assertDatabaseMissing('debts', [
-//         'group_id' => $this->group->id,
-//         'group_user_id' => $this->group_user->id,
-//         'amount' => 150,
-//         'name' => null,
-//     ]);
-// });
-
-// test('user can not add a debt without a selected currency', function() {
-//     $user_shares = selectRandomGroupUsers($this->group->groupUsers, 20000, false);
-
-//     $response = $this->post(route('debt.store'), [
-//         'group_id' => $this->group->id,
-//         'group_user_id' => $this->group_user->id,
-//         'name' => 'i should not exist',
-//         'amount' => 151,
-//         'split_even' => 0,
-//         'user_shares' => $user_shares,
-//         'currency' => '',
-//     ]);
-
-//     $response->assertStatus(302);
-//     $response->assertSessionHasErrors('currency');
-
-//     $this->assertDatabaseMissing('debts', [
-//         'group_id' => $this->group->id,
-//         'group_user_id' => $this->group_user->id,
-//         'name' => 'i should not exist',
-//     ]);
-// });
-
-// test('user can not add a debt without a selected user', function() {
-//     $user_shares = selectRandomGroupUsers($this->group->groupUsers, 25000, false);
-
-//     $response = $this->post(route('debt.store'), [
-//         'group_id' => $this->group->id,
-//         'group_user_id' => '',
-//         'name' => 'i should not exist',
-//         'amount' => 170,
-//         'split_even' => 0,
-//         'user_shares' => $user_shares,
-//         'currency' => 'GBP',
-//     ]);
-
-//     $response->assertStatus(302);
-//     $response->assertSessionHasErrors('group_user_id');
-
-//     $this->assertDatabaseMissing('debts', [
-//         'group_user_id' => $this->group_user->id,
-//         'group_id' => $this->group->id,
-//         'name' => 'i should not exist',
-//     ]);
- 
-// });
 
 
 // test('updating the amount on a split even debt updates the shares', function() {
@@ -708,39 +687,5 @@ test('user can not add a debt with no amount', function() {
 // });
 
 
-// test("user can not add a debt for a group they're not in", function() {
-//     // at this point in the test suite, the ids are in the 70s
-//     // so as all requets as still acting as myself, this should suffice
-//     $group = Group::factory()->create([
-//         'user_id' => $this->users[1]->id,
-//     ]);
-
-//     $user_shares = selectRandomGroupUsers($this->group->groupUsers, 10000, false);
-
-//     // save the debt 
-//     $response = $this->post(route('debt.store'), [
-//         'group_id' => $group->id,
-//         'group_user_id' => $this->group_user->id,
-//         'name' => 'unauthorized debt',
-//         'amount' => 100,
-//         'split_even' => 0,
-//         'user_shares' => $user_shares,
-//         'currency' => 'GBP',
-//     ]);
-   
-//     $response->assertStatus(302)
-//         ->assertSessionHasErrors(['id' => "You do not have permission to create this debt."])
-//         ->assertRedirect('/debts');
-
-//     // assert it does not exist
-//     $this->assertDatabaseMissing('debts', [
-//         'group_id' => $group->id,
-//         'name' => 'unauthorized debt',
-//         'amount' => 10000,
-//         'split_even' => 0,
-//         'cleared' => 0,
-//         'currency' => 'GBP',
-//     ]);
-// });
 
 

--- a/tests/Feature/Http/Controllers/DebtControllerTest.php
+++ b/tests/Feature/Http/Controllers/DebtControllerTest.php
@@ -156,7 +156,32 @@ test('user can delete a debt they own and along with all associated shares and c
 });
 
 test('user can not delete a debt they do not own', function() {
+    $this->actingAs($this->other_group_user->user);
 
+    $response = $this->delete(route('debt.destroy', $this->debt));
+
+    $response->assertStatus(302)
+        ->assertSessionHasErrors([
+            'id' => "You do not have permission to delete this debt."
+        ])
+        ->assertRedirect('/debts');
+
+    $this->assertDatabaseHas('debts', [
+        'id' => $this->debt->id,
+        'group_id' => $this->group->id,
+        'group_user_id' => $this->debt->group_user_id,
+        'name' => $this->debt->name,
+        'amount' => $this->debt->amount->getMinorAmount()->toInt(),
+        'deleted_at' => null,
+    ]);
+
+    foreach ($this->debt->shares as $share) {
+        $this->assertDatabaseHas('shares', [
+            'id' => $share->id,
+            'debt_id' => $this->debt->id,
+            'deleted_at' => null,
+        ]);
+    }
 });
 
 

--- a/tests/Feature/Http/Controllers/DebtControllerTest.php
+++ b/tests/Feature/Http/Controllers/DebtControllerTest.php
@@ -33,8 +33,6 @@ beforeEach(function () {
         'split_even' => 0,
     ]);
 
-    Event::fake();
-
     $this->actingAs($this->group_user->user);
 });
 
@@ -75,6 +73,8 @@ test('debts, shares and comments all appear with permissions paginated', functio
 });
 
 test('user can update the name of a debt they own', function() {
+    Event::fake();
+
     $response = $this->patch(route('debt.update', $this->debt), [
         'name' => 'i have been changed',
         'amount' => $this->debt->amount->getMinorAmount()->toInt(),
@@ -97,6 +97,8 @@ test('user can update the name of a debt they own', function() {
 });
 
 test('user can not update the name on a debt they do not own', function() {
+    Event::fake();
+
     $this->actingAs($this->other_group_user->user);
 
     $response = $this->patch(route('debt.update', $this->debt), [
@@ -121,8 +123,7 @@ test('user can not update the name on a debt they do not own', function() {
     ]);
 });
 
-test('user can delete a debt they own and along with all associated shares and comments', function() {
-    dump($this->debt->comments);    
+test('user can delete a debt they own and along with all associated shares and comments', function() {  
     $response = $this->delete(route('debt.destroy', $this->debt));
 
     $response->assertStatus(302)
@@ -137,15 +138,21 @@ test('user can delete a debt they own and along with all associated shares and c
         'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
     ]);
     
-    $this->assertDatabaseHas('shares', [
-        'debt_id' => $this->debt->id,
-        'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
-    ]);
+    foreach ($this->debt->shares as $share) {
+        $this->assertDatabaseHas('shares', [
+            'id' => $share->id,
+            'debt_id' => $this->debt->id,
+            'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
+        ]);
+    }
 
-    $this->assertDatabaseHas('comments', [
-        'debt_id' => $this->debt->id,
-        'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
-    ]);
+    foreach ($this->debt->comments as $comment) {
+        $this->assertDatabaseHas('comments', [
+            'id' => $comment->id,
+            'debt_id' => $this->debt->id,
+            'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
+        ]);
+    }
 });
 
 test('user can not delete a debt they do not own', function() {

--- a/tests/Feature/Http/Controllers/DebtControllerTest.php
+++ b/tests/Feature/Http/Controllers/DebtControllerTest.php
@@ -509,7 +509,7 @@ test('user can add a split even debt', function() {
     }
 });
 
-test('user can update the amount on a split even debt they own', function() {
+test('user can update the amount on a split even debt they own and the shares update', function() {
     Event::fake();
 
     $debt = Debt::factory()->withShares()->create([
@@ -595,124 +595,47 @@ test('user can add a standard debt with different value shares', function() {
     }
 });
 
+test('user can update the amount on a standard debt they own and the shares do not update', function() {
+    Event::fake();
 
+    $debt = Debt::factory()->withShares()->create([
+        'group_user_id' => $this->group_user->id,
+        'group_id' => $this->group->id,
+        'split_even' => 0,
+        'amount' => 12000,
+    ]);
 
-// test('user can add a debt with different value shares', function() {
-//     $user_shares = selectRandomGroupUsers($this->group->groupUsers, 10000, false);
-    
-//     Event::fake();
+    $response = $this->patch(route('debt.update', $debt), [
+        'amount' => $debt->amount->plus(15)->getMinorAmount()->toInt(),
+        'name' => $debt->name,
+    ]);
 
-//     // save the debt 
-//     $response = $this->post(route('debt.store'), [
-//         'group_id' => $this->group->id,
-//         'group_user_id' => $this->group_user->id,
-//         'name' => 'test debt',
-//         'amount' => 10000,
-//         'split_even' => 0,
-//         'user_shares' => $user_shares,
-//         'currency' => 'GBP',
-//     ]);
+    $response->assertStatus(302)
+        ->assertSessionHasNoErrors()
+        ->assertSessionHas('status', 'Debt updated successfully.')
+        ->assertRedirect('/debts');
 
-//     Event::assertDispatched(DebtCreated::class);
-   
-//     $response->assertStatus(302)
-//         ->assertSessionHasNoErrors()
-//         ->assertSessionHas('status', 'Debt created successfully.')
-//         ->assertRedirect('/debts');
+    $this->assertDatabaseHas('debts', [
+        'id' => $debt->id,
+        'group_id' => $this->group->id,
+        'group_user_id' => $this->group_user->id,
+        'name' => $debt->name,
+        'split_even' => 0,
+        'amount' => $debt->amount->plus(15)->getMinorAmount()->toInt(),
+    ]);
 
-//     // assert it exists
-//     $this->assertDatabaseHas('debts', [
-//         'group_id' => $this->group->id,
-//         'name' => 'test debt',
-//         'amount' => 10000,
-//         'split_even' => 0,
-//         'cleared' => 0,
-//         'currency' => 'GBP',
-//     ]);
+    $splits = $debt->amount->plus(15)->split($debt->shares->count());
 
-//     $debt = Debt::where('name', 'test debt')->first();
+    foreach ($debt->shares as $key => $share) {
+        $this->assertDatabaseHas('shares', [
+            'id' => $share->id,
+            'group_user_id' => $share->group_user_id,
+            'debt_id' => $debt->id,
+            'amount' => $share->amount->getMinorAmount()->toInt(),
+        ]);
+    }
+});
 
-//     // loop over the values that were posted to check the splits are correct on each share
-//     foreach ($user_shares as $share) {
-//         $this->assertDatabaseHas('shares', [
-//             'group_user_id' => $share['group_user_id'],
-//             'debt_id' => $debt->id,
-//             'amount' => $share['amount'],
-//             'name' => 'share for user ' . $share['group_user_id'],
-//         ]);
-//     }
-// });
-
-// test('updating the amount on a split even debt updates the shares', function() {
-//     Event::fake();
-
-//     $debt = Debt::factory()->withShares()->create([
-//         'group_user_id' => $this->group_user->id,
-//         'group_id' => $this->group->id,
-//         'split_even' => 1,
-//     ]);
-
-//     $shares = $debt->shares;
-  
-//     $new_amount = $debt->amount->plus(10);
-
-//     $split = $new_amount->split($shares->count());
-  
-//     $response = $this->patch(route('debt.update', $debt), [
-//         'name' => $debt->name,
-//         'amount' => $new_amount->getMinorAmount()->toInt(),
-//     ]);
-
-//     $response->assertStatus(302)
-//         ->assertSessionHasNoErrors()
-//         ->assertSessionHas('status', 'Debt & shares updated successfully.')
-//         ->assertRedirect('/debts');
-    
-//     $this->assertDatabaseHas('debts', [
-//         'id' => $debt->id,
-//         'group_id' => $this->group->id,
-//         'group_user_id' => $this->group_user->id,
-//         'name' => $debt->name,
-//         'amount' => $new_amount->getMinorAmount()->toInt(),
-//     ]);
-
-//     foreach ($shares as $key => $share) {
-//         $this->assertDatabaseHas('shares', [
-//             'id' => $share->id,
-//             'group_user_id' => $share->group_user_id,
-//             'debt_id' => $debt->id,
-//             'amount' => $split[$key]->getMinorAmount()->toInt(),
-//         ]);
-//     }
-// });
-
-
-
-// test('user can not change the amount of a debt they do not own', function() {
-//     $this->actingAs($this->users->last());
-
-//     $debt = Debt::factory()->withShares()->create([
-//         'group_user_id' => $this->group_user->id,
-//         'group_id' => $this->group->id,
-//     ]);
-
-//     $response = $this->patch(route('debt.update', $debt), [
-//         'amount' => $debt->amount->getMinorAmount()->toInt(),
-//         'name' => 'change me',
-//     ]);
-    
-//     $response->assertSessionHasErrors([
-//         'id' => 'You do not have permission to edit this debt.',
-//     ]);
-
-//     $this->assertDatabaseHas('debts', [
-//         'id' => $debt->id,
-//         'group_id' => $debt->group_id,
-//         'group_user_id' => $debt->groupUser->id,
-//         'name' => $debt->name,
-//         'amount' => $debt->amount->getMinorAmount()->toInt(),
-//     ]);
-// });
 
 
 

--- a/tests/Feature/Http/Controllers/DebtControllerTest.php
+++ b/tests/Feature/Http/Controllers/DebtControllerTest.php
@@ -8,6 +8,7 @@ use Inertia\Testing\AssertableInertia as Assert;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Event;
 use App\Events\DebtCreated;
+use App\Events\DebtUpdated;
 use Illuminate\Support\Arr;
 use Brick\Money\Money;
 
@@ -26,6 +27,13 @@ beforeEach(function () {
     $this->actingAs($this->group_user->user);
 });
 
+/**
+ * Tests for shared behaviours:
+ * - Index and pagination
+ * - Update name for owned/not owned
+ * - Delete for owned/not owned
+ * - Deleting deletes shares & comments
+ */
 test('debts, shares and comments all appear with permissions paginated', function() {
     Debt::factory(10)->withShares()->withComments()->create([
         'group_user_id' => $this->group_user->id,
@@ -55,303 +63,7 @@ test('debts, shares and comments all appear with permissions paginated', functio
     );
 });
 
-test('user can add a debt with different value shares', function() {
-    $user_shares = selectRandomGroupUsers($this->group->groupUsers, 10000, false);
-    
-    Event::fake();
-
-    // save the debt 
-    $response = $this->post(route('debt.store'), [
-        'group_id' => $this->group->id,
-        'group_user_id' => $this->group_user->id,
-        'name' => 'test debt',
-        'amount' => 10000,
-        'split_even' => 0,
-        'user_shares' => $user_shares,
-        'currency' => 'GBP',
-    ]);
-
-    Event::assertDispatched(DebtCreated::class);
-   
-    $response->assertStatus(302)
-        ->assertSessionHasNoErrors()
-        ->assertSessionHas('status', 'Debt created successfully.')
-        ->assertRedirect('/debts');
-
-    // assert it exists
-    $this->assertDatabaseHas('debts', [
-        'group_id' => $this->group->id,
-        'name' => 'test debt',
-        'amount' => 10000,
-        'split_even' => 0,
-        'cleared' => 0,
-        'currency' => 'GBP',
-    ]);
-
-    $debt = Debt::where('name', 'test debt')->first();
-
-    // loop over the values that were posted to check the splits are correct on each share
-    foreach ($user_shares as $share) {
-        $this->assertDatabaseHas('shares', [
-            'group_user_id' => $share['group_user_id'],
-            'debt_id' => $debt->id,
-            'amount' => $share['amount'],
-            'name' => 'share for user ' . $share['group_user_id'],
-        ]);
-    }
-});
-
-/**
- * Bit of context for split even as it acts a bit differently to random amount debts
- * as they use selectRandomGroupUsers()
- * 
- * Just got kinda sick of having to write annoying separate conditions in the user
- * selection function, so it was easier to just take the hit and have separate <groups>
- * and users for the setup of this one.
- */
-test('user can add a debt that is split even', function() {
-    $users = User::factory(5)->create();
-    $this->actingAs($users[0]);
-
-    $group = Group::factory(1)
-        ->create([
-            'user_id' => $users->first()->id,
-        ]);
-    
-    foreach ($users as $user) {
-        GroupUser::factory()->create([
-            'user_id' => $user->id,
-            'group_id' => $group[0]->id,
-        ]);
-    }
-
-    $group_users = GroupUser::where('group_id', $group[0]->id)->get();
-    $shares = Money::ofMinor(10000, 'GBP')->split($group_users->count());
-    
-    $user_shares = $group_users->map(function ($group_user, $key) use ($shares) {
-        return $group_user_shares[] = [
-            'group_user_id' => $group_user->id,
-            'share_name' => 'share for user ' . $group_user->id,
-            'amount' => $shares[$key]->getMinorAmount(),
-            'user_name' => $group_user->user->name,
-        ];
-    })->toArray();
-
-    Event::fake();
-
-    $response = $this->post(route('debt.store'), [
-        'group_id' => $group[0]->id,
-        'group_user_id' => $group_users[0]->id,
-        'name' => 'test debt 2',
-        'amount' => 10000,
-        'split_even' => 1,
-        'user_shares' => $user_shares,
-        'currency' => 'GBP',
-    ]);
-
-    $response->assertStatus(302)
-        ->assertSessionHasNoErrors()
-        ->assertSessionHas('status', 'Debt created successfully.')
-        ->assertRedirect('/debts');
-
-    $this->assertDatabaseHas('debts', [
-        'group_id' => $group[0]->id,
-        'group_user_id' => $group_users[0]->id,
-        'name' => 'test debt 2',
-        'amount' => 10000,
-        'split_even' => 1,
-        'cleared' => 0,
-        'currency' => 'GBP',
-    ]);
-
-    $debt = Debt::where('group_id', $group[0]->id)->first();
-
-    foreach ($user_shares as $share) {
-        $this->assertDatabaseHas('shares', [
-            'group_user_id' => $share['group_user_id'],
-            'debt_id' => $debt->id,
-            'amount' => $share['amount'],
-            'name' => 'share for user ' . $share['group_user_id'],
-        ]);
-    }
-});
-
-test('user can not add a debt with no group users selected', function() {
-    $response = $this->post(route('debt.store'), [
-        'group_id' => $this->group->id,
-        'group_user_id' => $this->group_user->id,
-        'name' => 'test debt',
-        'amount' => 100,
-        'split_even' => 0,
-        'user_shares' => [],
-        'currency' => 'GBP',
-    ]);
-
-    $response->assertStatus(302);
-    $response->assertSessionHasErrors('user_shares');
-});
-
-test('user can not add a debt with no name', function() {
-    $user_shares = selectRandomGroupUsers($this->group->groupUsers, 15000, false);
-
-    $response = $this->post(route('debt.store'), [
-        'group_id' => $this->group->id,
-        'group_user_id' => $this->group_user->id,
-        'name' => null,
-        'amount' => 150,
-        'split_even' => 0,
-        'user_shares' => $user_shares,
-        'currency' => 'GBP',
-    ]);
-
-    $response->assertStatus(302);
-    $response->assertSessionHasErrors('name');
-
-    $this->assertDatabaseMissing('debts', [
-        'group_id' => $this->group->id,
-        'group_user_id' => $this->group_user->id,
-        'amount' => 150,
-        'name' => null,
-    ]);
-});
-
-test('user can not add a debt without a selected currency', function() {
-    $user_shares = selectRandomGroupUsers($this->group->groupUsers, 20000, false);
-
-    $response = $this->post(route('debt.store'), [
-        'group_id' => $this->group->id,
-        'group_user_id' => $this->group_user->id,
-        'name' => 'i should not exist',
-        'amount' => 151,
-        'split_even' => 0,
-        'user_shares' => $user_shares,
-        'currency' => '',
-    ]);
-
-    $response->assertStatus(302);
-    $response->assertSessionHasErrors('currency');
-
-    $this->assertDatabaseMissing('debts', [
-        'group_id' => $this->group->id,
-        'group_user_id' => $this->group_user->id,
-        'name' => 'i should not exist',
-    ]);
-});
-
-test('user can not add a debt without a selected user', function() {
-    $user_shares = selectRandomGroupUsers($this->group->groupUsers, 25000, false);
-
-    $response = $this->post(route('debt.store'), [
-        'group_id' => $this->group->id,
-        'group_user_id' => '',
-        'name' => 'i should not exist',
-        'amount' => 170,
-        'split_even' => 0,
-        'user_shares' => $user_shares,
-        'currency' => 'GBP',
-    ]);
-
-    $response->assertStatus(302);
-    $response->assertSessionHasErrors('group_user_id');
-
-    $this->assertDatabaseMissing('debts', [
-        'group_user_id' => $this->group_user->id,
-        'group_id' => $this->group->id,
-        'name' => 'i should not exist',
-    ]);
- 
-});
-
-test('user can delete a debt they own', function() {
-    $debt = Debt::factory()->withShares()->create([
-        'group_user_id' => $this->group_user->id,
-        'group_id' => $this->group->id,
-    ]);
-
-    $response = $this->delete(route('debt.destroy', $debt));
-
-    $response->assertStatus(302)
-        ->assertSessionHasNoErrors()
-        ->assertSessionHas('status', 'Debt deleted successfully.')
-        ->assertRedirect('/debts');
-
-    $this->assertDatabaseHas('debts', [
-        'id' => $debt->id,
-        'group_id' => $this->group->id,
-        'group_user_id' => $this->group_user->id,
-        'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
-    ]);
-});
-
-test('deleting a debt deletes the relevant shares', function() {
-    $debt = Debt::factory()->withShares()->create([
-        'group_user_id' => $this->group_user->id,
-        'group_id' => $this->group->id,
-    ]);
-
-    $shares = $debt->shares;
-
-    $response = $this->delete(route('debt.destroy', $debt));
-
-    $response->assertStatus(302)
-        ->assertSessionHasNoErrors()
-        ->assertSessionHas('status', 'Debt deleted successfully.')
-        ->assertRedirect('/debts');
-
-    foreach ($shares as $share) {
-        $this->assertDatabaseHas('shares', [
-            'id' => $share->id,
-            'group_user_id' => $share->group_user_id,
-            'debt_id' => $debt->id,
-            'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
-        ]);
-    }
-});
-
-test('updating the amount on a split even debt updates the shares', function() {
-    Event::fake();
-
-    $debt = Debt::factory()->withShares()->create([
-        'group_user_id' => $this->group_user->id,
-        'group_id' => $this->group->id,
-        'split_even' => 1,
-    ]);
-
-    $shares = $debt->shares;
-  
-    $new_amount = $debt->amount->plus(10);
-
-    $split = $new_amount->split($shares->count());
-  
-    $response = $this->patch(route('debt.update', $debt), [
-        'name' => $debt->name,
-        'amount' => $new_amount->getMinorAmount()->toInt(),
-    ]);
-
-    $response->assertStatus(302)
-        ->assertSessionHasNoErrors()
-        ->assertSessionHas('status', 'Debt & shares updated successfully.')
-        ->assertRedirect('/debts');
-    
-    $this->assertDatabaseHas('debts', [
-        'id' => $debt->id,
-        'group_id' => $this->group->id,
-        'group_user_id' => $this->group_user->id,
-        'name' => $debt->name,
-        'amount' => $new_amount->getMinorAmount()->toInt(),
-    ]);
-
-    foreach ($shares as $key => $share) {
-        $this->assertDatabaseHas('shares', [
-            'id' => $share->id,
-            'group_user_id' => $share->group_user_id,
-            'debt_id' => $debt->id,
-            'amount' => $split[$key]->getMinorAmount()->toInt(),
-        ]);
-    }
-});
-
-test('user can update the name of a debt', function() {
+test('user can update the name of a debt they own', function() {
     Event::fake();
 
     $debt = Debt::factory()->withShares()->create([
@@ -364,6 +76,8 @@ test('user can update the name of a debt', function() {
         'name' => 'i have been changed',
         'amount' => $debt->amount->getMinorAmount()->toInt(),
     ]);
+
+    Event::assertDispatched(DebtUpdated::class);
 
     $response->assertStatus(302)
         ->assertSessionHasNoErrors()
@@ -379,114 +93,476 @@ test('user can update the name of a debt', function() {
     ]);
 });
 
-test('user can not change the name of a debt they do not own', function() {
-    $this->actingAs($this->users->last());
+test('user can not update the name on a debt they do not own', function() {
+    Event::fake();
+
+    $other_group_user = $this->group->groupUsers->reject(fn($group_user) 
+        => $group_user->id === $this->group_user->id)->first();
+
+    $this->actingAs($other_group_user->user);
 
     $debt = Debt::factory()->withShares()->create([
         'group_user_id' => $this->group_user->id,
         'group_id' => $this->group->id,
-    ]);
-
-    $response = $this->patch(route('debt.update', $debt), [
-        'amount' => $debt->amount->getMinorAmount()->toInt(),
-        'name' => 'i have been changed',
-    ]);
-
-    $response->assertSessionHasErrors([
-        'id' => 'You do not have permission to edit this debt.',
-    ]);
-
-    $this->assertDatabaseHas('debts', [
-        'id' => $debt->id,
-        'group_id' => $debt->group_id,
-        'group_user_id' => $debt->groupUser->id,
-        'name' => $debt->name,
-        'amount' => $debt->amount->getMinorAmount()->toInt(),
-    ]);
-});
-
-test('user can not change the amount of a debt they do not own', function() {
-    $this->actingAs($this->users->last());
-
-    $debt = Debt::factory()->withShares()->create([
-        'group_user_id' => $this->group_user->id,
-        'group_id' => $this->group->id,
-    ]);
-
-    $response = $this->patch(route('debt.update', $debt), [
-        'amount' => $debt->amount->getMinorAmount()->toInt(),
-        'name' => 'change me',
-    ]);
-    
-    $response->assertSessionHasErrors([
-        'id' => 'You do not have permission to edit this debt.',
-    ]);
-
-    $this->assertDatabaseHas('debts', [
-        'id' => $debt->id,
-        'group_id' => $debt->group_id,
-        'group_user_id' => $debt->groupUser->id,
-        'name' => $debt->name,
-        'amount' => $debt->amount->getMinorAmount()->toInt(),
-    ]);
-});
-
-test('user can not delete a debt they do not own', function() {
-    $this->actingAs($this->users->last());
-
-    $debt = Debt::factory()->withShares()->create([
-        'group_user_id' => $this->group_user->id,
-        'group_id' => $this->group->id,
-    ]);
-    
-    $response = $this->delete(route('debt.destroy', $debt));
-
-    $response->assertStatus(302);
-    $response->assertSessionHasErrors([
-        'id' => 'You do not have permission to delete this debt.',
-    ]);
-
-    $this->assertDatabaseHas('debts', [
-        'id' => $debt->id,
-        'group_id' => $debt->group_id,
-        'group_user_id' => $debt->groupUser->id,
-        'amount' => $debt->amount->getMinorAmount()->toInt(),
-    ]);
-});
-
-test("user can not add a debt for a group they're not in", function() {
-    // at this point in the test suite, the ids are in the 70s
-    // so as all requets as still acting as myself, this should suffice
-    $group = Group::factory()->create([
-        'user_id' => $this->users[1]->id,
-    ]);
-
-    $user_shares = selectRandomGroupUsers($this->group->groupUsers, 10000, false);
-
-    // save the debt 
-    $response = $this->post(route('debt.store'), [
-        'group_id' => $group->id,
-        'group_user_id' => $this->group_user->id,
-        'name' => 'unauthorized debt',
-        'amount' => 100,
         'split_even' => 0,
-        'user_shares' => $user_shares,
-        'currency' => 'GBP',
+        'name' => 'original name',
     ]);
-   
+
+    $response = $this->patch(route('debt.update', $debt), [
+        'name' => 'i have been changed',
+        'amount' => $debt->amount->getMinorAmount()->toInt(),
+    ]);
+
+    Event::assertNotDispatched(DebtUpdated::class);
+
     $response->assertStatus(302)
-        ->assertSessionHasErrors(['id' => "You do not have permission to create this debt."])
+        ->assertSessionHasErrors([
+            'id' => "You do not have permission to edit this debt."
+        ])
         ->assertRedirect('/debts');
 
-    // assert it does not exist
-    $this->assertDatabaseMissing('debts', [
-        'group_id' => $group->id,
-        'name' => 'unauthorized debt',
-        'amount' => 10000,
-        'split_even' => 0,
-        'cleared' => 0,
-        'currency' => 'GBP',
+    $this->assertDatabaseHas('debts', [
+        'id' => $debt->id,
+        'group_id' => $this->group->id,
+        'group_user_id' => $this->group_user->id,
+        'name' => 'original name',
+        'amount' => $debt->amount->getMinorAmount()->toInt(),
     ]);
 });
+
+
+// test('user can add a debt with different value shares', function() {
+//     $user_shares = selectRandomGroupUsers($this->group->groupUsers, 10000, false);
+    
+//     Event::fake();
+
+//     // save the debt 
+//     $response = $this->post(route('debt.store'), [
+//         'group_id' => $this->group->id,
+//         'group_user_id' => $this->group_user->id,
+//         'name' => 'test debt',
+//         'amount' => 10000,
+//         'split_even' => 0,
+//         'user_shares' => $user_shares,
+//         'currency' => 'GBP',
+//     ]);
+
+//     Event::assertDispatched(DebtCreated::class);
+   
+//     $response->assertStatus(302)
+//         ->assertSessionHasNoErrors()
+//         ->assertSessionHas('status', 'Debt created successfully.')
+//         ->assertRedirect('/debts');
+
+//     // assert it exists
+//     $this->assertDatabaseHas('debts', [
+//         'group_id' => $this->group->id,
+//         'name' => 'test debt',
+//         'amount' => 10000,
+//         'split_even' => 0,
+//         'cleared' => 0,
+//         'currency' => 'GBP',
+//     ]);
+
+//     $debt = Debt::where('name', 'test debt')->first();
+
+//     // loop over the values that were posted to check the splits are correct on each share
+//     foreach ($user_shares as $share) {
+//         $this->assertDatabaseHas('shares', [
+//             'group_user_id' => $share['group_user_id'],
+//             'debt_id' => $debt->id,
+//             'amount' => $share['amount'],
+//             'name' => 'share for user ' . $share['group_user_id'],
+//         ]);
+//     }
+// });
+
+// /**
+//  * Bit of context for split even as it acts a bit differently to random amount debts
+//  * as they use selectRandomGroupUsers()
+//  * 
+//  * Just got kinda sick of having to write annoying separate conditions in the user
+//  * selection function, so it was easier to just take the hit and have separate <groups>
+//  * and users for the setup of this one.
+//  */
+// test('user can add a debt that is split even', function() {
+//     $users = User::factory(5)->create();
+//     $this->actingAs($users[0]);
+
+//     $group = Group::factory(1)
+//         ->create([
+//             'user_id' => $users->first()->id,
+//         ]);
+    
+//     foreach ($users as $user) {
+//         GroupUser::factory()->create([
+//             'user_id' => $user->id,
+//             'group_id' => $group[0]->id,
+//         ]);
+//     }
+
+//     $group_users = GroupUser::where('group_id', $group[0]->id)->get();
+//     $shares = Money::ofMinor(10000, 'GBP')->split($group_users->count());
+    
+//     $user_shares = $group_users->map(function ($group_user, $key) use ($shares) {
+//         return $group_user_shares[] = [
+//             'group_user_id' => $group_user->id,
+//             'share_name' => 'share for user ' . $group_user->id,
+//             'amount' => $shares[$key]->getMinorAmount(),
+//             'user_name' => $group_user->user->name,
+//         ];
+//     })->toArray();
+
+//     Event::fake();
+
+//     $response = $this->post(route('debt.store'), [
+//         'group_id' => $group[0]->id,
+//         'group_user_id' => $group_users[0]->id,
+//         'name' => 'test debt 2',
+//         'amount' => 10000,
+//         'split_even' => 1,
+//         'user_shares' => $user_shares,
+//         'currency' => 'GBP',
+//     ]);
+
+//     $response->assertStatus(302)
+//         ->assertSessionHasNoErrors()
+//         ->assertSessionHas('status', 'Debt created successfully.')
+//         ->assertRedirect('/debts');
+
+//     $this->assertDatabaseHas('debts', [
+//         'group_id' => $group[0]->id,
+//         'group_user_id' => $group_users[0]->id,
+//         'name' => 'test debt 2',
+//         'amount' => 10000,
+//         'split_even' => 1,
+//         'cleared' => 0,
+//         'currency' => 'GBP',
+//     ]);
+
+//     $debt = Debt::where('group_id', $group[0]->id)->first();
+
+//     foreach ($user_shares as $share) {
+//         $this->assertDatabaseHas('shares', [
+//             'group_user_id' => $share['group_user_id'],
+//             'debt_id' => $debt->id,
+//             'amount' => $share['amount'],
+//             'name' => 'share for user ' . $share['group_user_id'],
+//         ]);
+//     }
+// });
+
+// test('user can not add a debt with no group users selected', function() {
+//     $response = $this->post(route('debt.store'), [
+//         'group_id' => $this->group->id,
+//         'group_user_id' => $this->group_user->id,
+//         'name' => 'test debt',
+//         'amount' => 100,
+//         'split_even' => 0,
+//         'user_shares' => [],
+//         'currency' => 'GBP',
+//     ]);
+
+//     $response->assertStatus(302);
+//     $response->assertSessionHasErrors('user_shares');
+// });
+
+// test('user can not add a debt with no name', function() {
+//     $user_shares = selectRandomGroupUsers($this->group->groupUsers, 15000, false);
+
+//     $response = $this->post(route('debt.store'), [
+//         'group_id' => $this->group->id,
+//         'group_user_id' => $this->group_user->id,
+//         'name' => null,
+//         'amount' => 150,
+//         'split_even' => 0,
+//         'user_shares' => $user_shares,
+//         'currency' => 'GBP',
+//     ]);
+
+//     $response->assertStatus(302);
+//     $response->assertSessionHasErrors('name');
+
+//     $this->assertDatabaseMissing('debts', [
+//         'group_id' => $this->group->id,
+//         'group_user_id' => $this->group_user->id,
+//         'amount' => 150,
+//         'name' => null,
+//     ]);
+// });
+
+// test('user can not add a debt without a selected currency', function() {
+//     $user_shares = selectRandomGroupUsers($this->group->groupUsers, 20000, false);
+
+//     $response = $this->post(route('debt.store'), [
+//         'group_id' => $this->group->id,
+//         'group_user_id' => $this->group_user->id,
+//         'name' => 'i should not exist',
+//         'amount' => 151,
+//         'split_even' => 0,
+//         'user_shares' => $user_shares,
+//         'currency' => '',
+//     ]);
+
+//     $response->assertStatus(302);
+//     $response->assertSessionHasErrors('currency');
+
+//     $this->assertDatabaseMissing('debts', [
+//         'group_id' => $this->group->id,
+//         'group_user_id' => $this->group_user->id,
+//         'name' => 'i should not exist',
+//     ]);
+// });
+
+// test('user can not add a debt without a selected user', function() {
+//     $user_shares = selectRandomGroupUsers($this->group->groupUsers, 25000, false);
+
+//     $response = $this->post(route('debt.store'), [
+//         'group_id' => $this->group->id,
+//         'group_user_id' => '',
+//         'name' => 'i should not exist',
+//         'amount' => 170,
+//         'split_even' => 0,
+//         'user_shares' => $user_shares,
+//         'currency' => 'GBP',
+//     ]);
+
+//     $response->assertStatus(302);
+//     $response->assertSessionHasErrors('group_user_id');
+
+//     $this->assertDatabaseMissing('debts', [
+//         'group_user_id' => $this->group_user->id,
+//         'group_id' => $this->group->id,
+//         'name' => 'i should not exist',
+//     ]);
+ 
+// });
+
+// test('user can delete a debt they own', function() {
+//     $debt = Debt::factory()->withShares()->create([
+//         'group_user_id' => $this->group_user->id,
+//         'group_id' => $this->group->id,
+//     ]);
+
+//     $response = $this->delete(route('debt.destroy', $debt));
+
+//     $response->assertStatus(302)
+//         ->assertSessionHasNoErrors()
+//         ->assertSessionHas('status', 'Debt deleted successfully.')
+//         ->assertRedirect('/debts');
+
+//     $this->assertDatabaseHas('debts', [
+//         'id' => $debt->id,
+//         'group_id' => $this->group->id,
+//         'group_user_id' => $this->group_user->id,
+//         'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
+//     ]);
+// });
+
+// test('deleting a debt deletes the relevant shares', function() {
+//     $debt = Debt::factory()->withShares()->create([
+//         'group_user_id' => $this->group_user->id,
+//         'group_id' => $this->group->id,
+//     ]);
+
+//     $shares = $debt->shares;
+
+//     $response = $this->delete(route('debt.destroy', $debt));
+
+//     $response->assertStatus(302)
+//         ->assertSessionHasNoErrors()
+//         ->assertSessionHas('status', 'Debt deleted successfully.')
+//         ->assertRedirect('/debts');
+
+//     foreach ($shares as $share) {
+//         $this->assertDatabaseHas('shares', [
+//             'id' => $share->id,
+//             'group_user_id' => $share->group_user_id,
+//             'debt_id' => $debt->id,
+//             'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
+//         ]);
+//     }
+// });
+
+// test('updating the amount on a split even debt updates the shares', function() {
+//     Event::fake();
+
+//     $debt = Debt::factory()->withShares()->create([
+//         'group_user_id' => $this->group_user->id,
+//         'group_id' => $this->group->id,
+//         'split_even' => 1,
+//     ]);
+
+//     $shares = $debt->shares;
+  
+//     $new_amount = $debt->amount->plus(10);
+
+//     $split = $new_amount->split($shares->count());
+  
+//     $response = $this->patch(route('debt.update', $debt), [
+//         'name' => $debt->name,
+//         'amount' => $new_amount->getMinorAmount()->toInt(),
+//     ]);
+
+//     $response->assertStatus(302)
+//         ->assertSessionHasNoErrors()
+//         ->assertSessionHas('status', 'Debt & shares updated successfully.')
+//         ->assertRedirect('/debts');
+    
+//     $this->assertDatabaseHas('debts', [
+//         'id' => $debt->id,
+//         'group_id' => $this->group->id,
+//         'group_user_id' => $this->group_user->id,
+//         'name' => $debt->name,
+//         'amount' => $new_amount->getMinorAmount()->toInt(),
+//     ]);
+
+//     foreach ($shares as $key => $share) {
+//         $this->assertDatabaseHas('shares', [
+//             'id' => $share->id,
+//             'group_user_id' => $share->group_user_id,
+//             'debt_id' => $debt->id,
+//             'amount' => $split[$key]->getMinorAmount()->toInt(),
+//         ]);
+//     }
+// });
+
+// test('user can update the name of a debt', function() {
+//     Event::fake();
+
+//     $debt = Debt::factory()->withShares()->create([
+//         'group_user_id' => $this->group_user->id,
+//         'group_id' => $this->group->id,
+//         'split_even' => 0,
+//     ]);
+
+//     $response = $this->patch(route('debt.update', $debt), [
+//         'name' => 'i have been changed',
+//         'amount' => $debt->amount->getMinorAmount()->toInt(),
+//     ]);
+
+//     $response->assertStatus(302)
+//         ->assertSessionHasNoErrors()
+//         ->assertSessionHas('status', 'Debt updated successfully.')
+//         ->assertRedirect('/debts');
+
+//     $this->assertDatabaseHas('debts', [
+//         'id' => $debt->id,
+//         'group_id' => $this->group->id,
+//         'group_user_id' => $this->group_user->id,
+//         'name' => 'i have been changed',
+//         'amount' => $debt->amount->getMinorAmount()->toInt(),
+//     ]);
+// });
+
+// test('user can not change the name of a debt they do not own', function() {
+//     $this->actingAs($this->users->last());
+
+//     $debt = Debt::factory()->withShares()->create([
+//         'group_user_id' => $this->group_user->id,
+//         'group_id' => $this->group->id,
+//     ]);
+
+//     $response = $this->patch(route('debt.update', $debt), [
+//         'amount' => $debt->amount->getMinorAmount()->toInt(),
+//         'name' => 'i have been changed',
+//     ]);
+
+//     $response->assertSessionHasErrors([
+//         'id' => 'You do not have permission to edit this debt.',
+//     ]);
+
+//     $this->assertDatabaseHas('debts', [
+//         'id' => $debt->id,
+//         'group_id' => $debt->group_id,
+//         'group_user_id' => $debt->groupUser->id,
+//         'name' => $debt->name,
+//         'amount' => $debt->amount->getMinorAmount()->toInt(),
+//     ]);
+// });
+
+// test('user can not change the amount of a debt they do not own', function() {
+//     $this->actingAs($this->users->last());
+
+//     $debt = Debt::factory()->withShares()->create([
+//         'group_user_id' => $this->group_user->id,
+//         'group_id' => $this->group->id,
+//     ]);
+
+//     $response = $this->patch(route('debt.update', $debt), [
+//         'amount' => $debt->amount->getMinorAmount()->toInt(),
+//         'name' => 'change me',
+//     ]);
+    
+//     $response->assertSessionHasErrors([
+//         'id' => 'You do not have permission to edit this debt.',
+//     ]);
+
+//     $this->assertDatabaseHas('debts', [
+//         'id' => $debt->id,
+//         'group_id' => $debt->group_id,
+//         'group_user_id' => $debt->groupUser->id,
+//         'name' => $debt->name,
+//         'amount' => $debt->amount->getMinorAmount()->toInt(),
+//     ]);
+// });
+
+// test('user can not delete a debt they do not own', function() {
+//     $this->actingAs($this->users->last());
+
+//     $debt = Debt::factory()->withShares()->create([
+//         'group_user_id' => $this->group_user->id,
+//         'group_id' => $this->group->id,
+//     ]);
+    
+//     $response = $this->delete(route('debt.destroy', $debt));
+
+//     $response->assertStatus(302);
+//     $response->assertSessionHasErrors([
+//         'id' => 'You do not have permission to delete this debt.',
+//     ]);
+
+//     $this->assertDatabaseHas('debts', [
+//         'id' => $debt->id,
+//         'group_id' => $debt->group_id,
+//         'group_user_id' => $debt->groupUser->id,
+//         'amount' => $debt->amount->getMinorAmount()->toInt(),
+//     ]);
+// });
+
+// test("user can not add a debt for a group they're not in", function() {
+//     // at this point in the test suite, the ids are in the 70s
+//     // so as all requets as still acting as myself, this should suffice
+//     $group = Group::factory()->create([
+//         'user_id' => $this->users[1]->id,
+//     ]);
+
+//     $user_shares = selectRandomGroupUsers($this->group->groupUsers, 10000, false);
+
+//     // save the debt 
+//     $response = $this->post(route('debt.store'), [
+//         'group_id' => $group->id,
+//         'group_user_id' => $this->group_user->id,
+//         'name' => 'unauthorized debt',
+//         'amount' => 100,
+//         'split_even' => 0,
+//         'user_shares' => $user_shares,
+//         'currency' => 'GBP',
+//     ]);
+   
+//     $response->assertStatus(302)
+//         ->assertSessionHasErrors(['id' => "You do not have permission to create this debt."])
+//         ->assertRedirect('/debts');
+
+//     // assert it does not exist
+//     $this->assertDatabaseMissing('debts', [
+//         'group_id' => $group->id,
+//         'name' => 'unauthorized debt',
+//         'amount' => 10000,
+//         'split_even' => 0,
+//         'cleared' => 0,
+//         'currency' => 'GBP',
+//     ]);
+// });
 
 

--- a/tests/Feature/Http/Controllers/DebtControllerTest.php
+++ b/tests/Feature/Http/Controllers/DebtControllerTest.php
@@ -482,6 +482,45 @@ test('user can add a split even debt', function() {
     }
 });
 
+test('user can update the amount on a split even debt they own', function() {
+    Event::fake();
+
+    $debt = Debt::factory()->withShares()->create([
+        'group_user_id' => $this->group_user->id,
+        'group_id' => $this->group->id,
+        'split_even' => 1,
+        'amount' => 12000,
+    ]);
+
+    $response = $this->patch(route('debt.update', $debt), [
+        'amount' => $debt->amount->plus(15)->getMinorAmount()->toInt(),
+        'name' => $debt->name,
+    ]);
+
+    $response->assertStatus(302)
+        ->assertSessionHasNoErrors()
+        ->assertSessionHas('status', 'Debt updated successfully.')
+        ->assertRedirect('/debts');
+
+    $this->assertDatabaseHas('debts', [
+        'id' => $debt->id,
+        'group_id' => $this->group->id,
+        'group_user_id' => $this->group_user->id,
+        'name' => $debt->name,
+        'amount' => $debt->amount->plus(15)->getMinorAmount()->toInt(),
+    ]);
+
+    $splits = $debt->amount->plus(15)->split($debt->shares->count());
+
+    foreach ($debt->shares as $key => $share) {
+        $this->assertDatabaseHas('shares', [
+            'id' => $share->id,
+            'group_user_id' => $share->group_user_id,
+            'debt_id' => $debt->id,
+            'amount' => $splits[$key]->getMinorAmount()->toInt(),
+        ]);
+    }
+});
 
 // test('user can add a debt with different value shares', function() {
 //     $user_shares = selectRandomGroupUsers($this->group->groupUsers, 10000, false);

--- a/tests/Feature/Http/Controllers/DebtControllerTest.php
+++ b/tests/Feature/Http/Controllers/DebtControllerTest.php
@@ -130,6 +130,39 @@ test('user can not update the name on a debt they do not own', function() {
     ]);
 });
 
+test('user can delete a debt they own and along with all associated shares and comments', function() {
+    $debt = Debt::factory()->withShares()->withComments()->create([
+        'group_user_id' => $this->group_user->id,
+        'group_id' => $this->group->id,
+    ]);
+
+    $response = $this->delete(route('debt.destroy', $debt));
+
+    $response->assertStatus(302)
+        ->assertSessionHasNoErrors()
+        ->assertSessionHas('status', 'Debt deleted successfully.')
+        ->assertRedirect('/debts');
+
+    $this->assertDatabaseHas('debts', [
+        'id' => $debt->id,
+        'group_id' => $this->group->id,
+        'group_user_id' => $this->group_user->id,
+        'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
+    ]);
+
+    $this->assertDatabaseHas('shares', [
+        'debt_id' => $debt->id,
+        'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
+    ]);
+
+    $this->assertDatabaseHas('comments', [
+        'debt_id' => $debt->id,
+        'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
+    ]);
+});
+
+
+
 
 // test('user can add a debt with different value shares', function() {
 //     $user_shares = selectRandomGroupUsers($this->group->groupUsers, 10000, false);
@@ -338,51 +371,6 @@ test('user can not update the name on a debt they do not own', function() {
  
 // });
 
-// test('user can delete a debt they own', function() {
-//     $debt = Debt::factory()->withShares()->create([
-//         'group_user_id' => $this->group_user->id,
-//         'group_id' => $this->group->id,
-//     ]);
-
-//     $response = $this->delete(route('debt.destroy', $debt));
-
-//     $response->assertStatus(302)
-//         ->assertSessionHasNoErrors()
-//         ->assertSessionHas('status', 'Debt deleted successfully.')
-//         ->assertRedirect('/debts');
-
-//     $this->assertDatabaseHas('debts', [
-//         'id' => $debt->id,
-//         'group_id' => $this->group->id,
-//         'group_user_id' => $this->group_user->id,
-//         'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
-//     ]);
-// });
-
-// test('deleting a debt deletes the relevant shares', function() {
-//     $debt = Debt::factory()->withShares()->create([
-//         'group_user_id' => $this->group_user->id,
-//         'group_id' => $this->group->id,
-//     ]);
-
-//     $shares = $debt->shares;
-
-//     $response = $this->delete(route('debt.destroy', $debt));
-
-//     $response->assertStatus(302)
-//         ->assertSessionHasNoErrors()
-//         ->assertSessionHas('status', 'Debt deleted successfully.')
-//         ->assertRedirect('/debts');
-
-//     foreach ($shares as $share) {
-//         $this->assertDatabaseHas('shares', [
-//             'id' => $share->id,
-//             'group_user_id' => $share->group_user_id,
-//             'debt_id' => $debt->id,
-//             'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
-//         ]);
-//     }
-// });
 
 // test('updating the amount on a split even debt updates the shares', function() {
 //     Event::fake();

--- a/tests/Feature/Http/Controllers/DebtControllerTest.php
+++ b/tests/Feature/Http/Controllers/DebtControllerTest.php
@@ -191,6 +191,7 @@ test('user can not delete a debt they do not own', function() {
  * - Not able to add a debt with no currency
  * - Not able to add a debt with no owner (group user) selected
  * - Not able to add a debt with no shares
+ * - Not be able to add a debt that sums to zero
  * - Not able to add a debt with no amount
  */
 
@@ -240,6 +241,138 @@ test('user can not add a debt with no name', function() {
         'amount' => 101,
         'created_at' => Carbon::now()->format('Y-m-d H:i:s'),
     ]);
+});
+
+test('user can not add a debt with no currency selected', function() {
+    $user_shares = selectRandomGroupUsers($this->group->groupUsers, 10000, false);
+
+    $response = $this->post(route('debt.store'), [
+        'group_id' => $this->group_user->group->id,
+        'group_user_id' => $this->group_user->id,
+        'name' => 'test debt 56',
+        'amount' => 101,
+        'split_even' => 0,
+        'user_shares' => $user_shares,
+        'currency' => '',
+    ]);
+
+    $response->assertStatus(302);
+    $response->assertSessionHasErrors([
+        'currency' => 'Please select a currency.',
+    ]);
+
+    $this->assertDatabaseMissing('debts', [
+        'group_user_id' => $this->group_user->id,
+        'amount' => 101,
+        'name' => 'test debt 56',
+        'currency' => '',
+        'created_at' => Carbon::now()->format('Y-m-d H:i:s'),
+    ]);
+});
+
+test('user can not add a debt with no owner selected', function() {
+    $user_shares = selectRandomGroupUsers($this->group->groupUsers, 10000, false);
+
+    $response = $this->post(route('debt.store'), [
+        'group_id' => $this->group_user->group->id,
+        'group_user_id' => '',
+        'name' => 'test debt 51',
+        'amount' => 101,
+        'split_even' => 0,
+        'user_shares' => $user_shares,
+        'currency' => 'GBP',
+    ]);
+
+    $response->assertStatus(302)
+        ->assertSessionHasErrors([
+            'group_user_id' => 'Please select a user to own the debt.',
+        ]);
+
+    $this->assertDatabaseMissing('debts', [
+        'group_user_id' => '',
+        'amount' => 101,
+        'name' => 'test debt 51',
+        'currency' => 'GBP',
+        'created_at' => Carbon::now()->format('Y-m-d H:i:s'),
+    ]);
+});
+
+test('user can not add a debt with no shares', function() {
+    $response = $this->post(route('debt.store'), [
+        'group_id' => $this->group_user->group->id,
+        'group_user_id' => $this->group_user->id,
+        'name' => 'test debt 15',
+        'amount' => 101,
+        'split_even' => 0,
+        'user_shares' => [],
+        'currency' => 'GBP',
+    ]);
+
+    $response->assertStatus(302)
+        ->assertSessionHasErrors([
+            'user_shares' => 'Please select at least one user or enter a valid amount.',
+        ]);
+
+    $this->assertDatabaseMissing('debts', [
+        'group_user_id' => $this->group_user->id,
+        'amount' => 101,
+        'name' => 'test debt 15',
+        'currency' => 'GBP',
+        'created_at' => Carbon::now()->format('Y-m-d H:i:s'),
+    ]);
+});
+
+test('user can not add a debt that sums to zero', function() {
+    $user_shares = selectRandomGroupUsers($this->group->groupUsers, 10000, false);
+
+    $response = $this->post(route('debt.store', [
+        'group_id' => $this->group_user->group->id,
+        'group_user_id' => $this->group_user->id,
+        'name' => 'test debt 25',
+        'amount' => 0,
+        'split_even' => 0,
+        'user_shares' => $user_shares,
+        'currency' => 'GBP',
+    ]));
+
+    $response->assertStatus(302)
+        ->assertSessionHasErrors([
+            'amount' => 'The total amount must be at least 0.01.',
+        ]);
+
+    $this->assertDatabaseMissing('debts', [
+        'group_user_id' => $this->group_user->id,
+        'amount' => null,
+        'name' => 'test debt 25',
+        'currency' => 'GBP',
+        'created_at' => Carbon::now()->format('Y-m-d H:i:s'),
+    ]);
+});
+
+test('user can not add a debt with no amount', function() {
+    $user_shares = selectRandomGroupUsers($this->group->groupUsers, 10000, false);
+
+    $response = $this->post(route('debt.store', [
+        'group_id' => $this->group_user->group->id,
+        'group_user_id' => $this->group_user->id,
+        'name' => 'test debt 25',
+        'split_even' => 0,
+        'user_shares' => $user_shares,
+        'currency' => 'GBP',
+    ]));
+
+    $response->assertStatus(302)
+        ->assertSessionHasErrors([
+            'amount' => 'The amount field is required.',
+        ]);
+
+    $this->assertDatabaseMissing('debts', [
+        'group_user_id' => $this->group_user->id,
+        'amount' => null,
+        'name' => 'test debt 25',
+        'currency' => 'GBP',
+        'created_at' => Carbon::now()->format('Y-m-d H:i:s'),
+    ]);   
 });
 
 

--- a/tests/Feature/Http/Controllers/DebtControllerTest.php
+++ b/tests/Feature/Http/Controllers/DebtControllerTest.php
@@ -549,6 +549,52 @@ test('user can update the amount on a split even debt they own', function() {
     }
 });
 
+/**
+ * Tests for behaviours specific to standard debts:
+ * - Add a standard debt with different value shares
+ * - Updating the amount for a standard debt doesn't update shares
+ */
+
+test('user can add a standard debt with different value shares', function() {
+    Event::fake();
+
+    $user_shares = selectRandomGroupUsers($this->group->groupUsers, 10000, false);
+
+    $response = $this->post(route('debt.store', [
+        'group_id' => $this->group_user->group->id,
+        'group_user_id' => $this->group_user->id,
+        'name' => 'test debt 675',
+        'amount' => 10000,
+        'split_even' => 0,
+        'user_shares' => $user_shares,
+        'currency' => 'GBP',
+    ]));
+
+    Event::assertDispatched(DebtCreated::class);
+
+    $response->assertStatus(302)
+        ->assertSessionHasNoErrors()
+        ->assertSessionHas('status', 'Debt created successfully.')
+        ->assertRedirect('/debts');
+
+    $this->assertDatabaseHas('debts', [
+        'group_id' => $this->group_user->group->id,
+        'group_user_id' => $this->group_user->id,
+        'name' => 'test debt 675',
+        'amount' => 10000,
+        'split_even' => 0,
+        'currency' => 'GBP',
+    ]);
+
+    foreach ($user_shares as $share) {
+        $this->assertDatabaseHas('shares', [
+            'group_user_id' => $share['group_user_id'],
+            'amount' => $share['amount'],
+            'name' => 'share for user ' . $share['group_user_id'],
+        ]);
+    }
+});
+
 
 
 // test('user can add a debt with different value shares', function() {

--- a/tests/Feature/Http/Controllers/DebtControllerTest.php
+++ b/tests/Feature/Http/Controllers/DebtControllerTest.php
@@ -37,7 +37,7 @@ beforeEach(function () {
 });
 
 /**
- * Tests for shared behaviours:
+ * Tests for shared behaviours, not around adding debts:
  * - Index and pagination
  * - Update name for owned/not owned
  * - Delete for owned/not owned
@@ -184,7 +184,63 @@ test('user can not delete a debt they do not own', function() {
     }
 });
 
+/**
+ * Tests for behaviours to do with adding debts, but the type is irrelevant:
+ * - Not able to add a debt with no group selected
+ * - Not able to add a debt with no name
+ * - Not able to add a debt with no currency
+ * - Not able to add a debt with no owner (group user) selected
+ * - Not able to add a debt with no shares
+ * - Not able to add a debt with no amount
+ */
 
+test('user can not add a debt with no group selected', function() {
+    $user_shares = selectRandomGroupUsers($this->group->groupUsers, 10000, false);
+
+    $response = $this->post(route('debt.store'), [
+        'group_user_id' => $this->group_user->id,
+        'name' => 'test debt',
+        'amount' => 100,
+        'split_even' => 0,
+        'user_shares' => $user_shares,
+        'currency' => 'GBP',
+    ]);
+
+    $response->assertStatus(302);
+    $response->assertSessionHasErrors([
+        'group_id' => 'Please select a group.',
+    ]);
+
+    $this->assertDatabaseMissing('debts', [
+        'group_user_id' => $this->group_user->id,
+        'name' => 'test debt',
+        'amount' => 100,
+    ]);
+});
+
+test('user can not add a debt with no name', function() {
+    $user_shares = selectRandomGroupUsers($this->group->groupUsers, 10000, false);
+
+    $response = $this->post(route('debt.store'), [
+        'group_id' => $this->group_user->group->id,
+        'group_user_id' => $this->group_user->id,
+        'amount' => 101,
+        'split_even' => 0,
+        'user_shares' => $user_shares,
+        'currency' => 'GBP',
+    ]);
+
+    $response->assertStatus(302);
+    $response->assertSessionHasErrors([
+        'name' => 'The debt name is required.',
+    ]);
+
+    $this->assertDatabaseMissing('debts', [
+        'group_user_id' => $this->group_user->id,
+        'amount' => 101,
+        'created_at' => Carbon::now()->format('Y-m-d H:i:s'),
+    ]);
+});
 
 
 // test('user can add a debt with different value shares', function() {
@@ -518,28 +574,6 @@ test('user can not delete a debt they do not own', function() {
 //     ]);
 // });
 
-// test('user can not delete a debt they do not own', function() {
-//     $this->actingAs($this->users->last());
-
-//     $debt = Debt::factory()->withShares()->create([
-//         'group_user_id' => $this->group_user->id,
-//         'group_id' => $this->group->id,
-//     ]);
-    
-//     $response = $this->delete(route('debt.destroy', $debt));
-
-//     $response->assertStatus(302);
-//     $response->assertSessionHasErrors([
-//         'id' => 'You do not have permission to delete this debt.',
-//     ]);
-
-//     $this->assertDatabaseHas('debts', [
-//         'id' => $debt->id,
-//         'group_id' => $debt->group_id,
-//         'group_user_id' => $debt->groupUser->id,
-//         'amount' => $debt->amount->getMinorAmount()->toInt(),
-//     ]);
-// });
 
 // test("user can not add a debt for a group they're not in", function() {
 //     // at this point in the test suite, the ids are in the 70s

--- a/tests/Feature/Http/Controllers/DebtControllerTest.php
+++ b/tests/Feature/Http/Controllers/DebtControllerTest.php
@@ -40,6 +40,7 @@ beforeEach(function () {
  * Tests for shared behaviours, not around adding debts:
  * - Index and pagination
  * - Update name for owned/not owned
+ * - Update amount for owned/not owned
  * - Delete for owned/not owned
  * - Deleting debts deletes shares & comments
  */
@@ -97,6 +98,33 @@ test('user can update the name of a debt they own', function() {
 });
 
 test('user can not update the name on a debt they do not own', function() {
+    Event::fake();
+
+    $this->actingAs($this->other_group_user->user);
+
+    $response = $this->patch(route('debt.update', $this->debt), [
+        'name' => $this->debt->name,
+        'amount' => 20000,
+    ]);
+
+    Event::assertNotDispatched(DebtUpdated::class);
+
+    $response->assertStatus(302)
+        ->assertSessionHasErrors([
+            'id' => "You do not have permission to edit this debt."
+        ])
+        ->assertRedirect('/debts');
+
+    $this->assertDatabaseHas('debts', [
+        'id' => $this->debt->id,
+        'group_id' => $this->group->id,
+        'group_user_id' => $this->group_user->id,
+        'name' => $this->debt->name,
+        'amount' => $this->debt->amount->getMinorAmount()->toInt(),
+    ]);
+});
+
+test('user can not update the amount on a debt they do not own', function() {
     Event::fake();
 
     $this->actingAs($this->other_group_user->user);
@@ -439,7 +467,6 @@ test('user can not add a debt for a group they are not in', function() {
  * Tests for behaviours specific to to split even debts:
  * - Add a split even debt
  * - Updating the amount for a split even debt correctly updates shares
- * - Can not update the amount for a split even debt if not the owner
  */
 
 test('user can add a split even debt', function() {
@@ -521,6 +548,8 @@ test('user can update the amount on a split even debt they own', function() {
         ]);
     }
 });
+
+
 
 // test('user can add a debt with different value shares', function() {
 //     $user_shares = selectRandomGroupUsers($this->group->groupUsers, 10000, false);

--- a/tests/Feature/Http/Controllers/DebtControllerTest.php
+++ b/tests/Feature/Http/Controllers/DebtControllerTest.php
@@ -24,6 +24,17 @@ beforeEach(function () {
 
     $this->group_user = GroupUser::where('user_id', $this->user->id)->first();
 
+    $this->other_group_user = $this->group->groupUsers->reject(fn($group_user) 
+        => $group_user->id === $this->group_user->id)->first();
+
+    $this->debt = Debt::factory()->withShares()->withComments()->create([
+        'group_user_id' => $this->group_user->id,
+        'group_id' => $this->group->id,
+        'split_even' => 0,
+    ]);
+
+    Event::fake();
+
     $this->actingAs($this->group_user->user);
 });
 
@@ -32,7 +43,7 @@ beforeEach(function () {
  * - Index and pagination
  * - Update name for owned/not owned
  * - Delete for owned/not owned
- * - Deleting deletes shares & comments
+ * - Deleting debts deletes shares & comments
  */
 test('debts, shares and comments all appear with permissions paginated', function() {
     Debt::factory(10)->withShares()->withComments()->create([
@@ -64,17 +75,9 @@ test('debts, shares and comments all appear with permissions paginated', functio
 });
 
 test('user can update the name of a debt they own', function() {
-    Event::fake();
-
-    $debt = Debt::factory()->withShares()->create([
-        'group_user_id' => $this->group_user->id,
-        'group_id' => $this->group->id,
-        'split_even' => 0,
-    ]);
-
-    $response = $this->patch(route('debt.update', $debt), [
+    $response = $this->patch(route('debt.update', $this->debt), [
         'name' => 'i have been changed',
-        'amount' => $debt->amount->getMinorAmount()->toInt(),
+        'amount' => $this->debt->amount->getMinorAmount()->toInt(),
     ]);
 
     Event::assertDispatched(DebtUpdated::class);
@@ -85,32 +88,20 @@ test('user can update the name of a debt they own', function() {
         ->assertRedirect('/debts');
 
     $this->assertDatabaseHas('debts', [
-        'id' => $debt->id,
+        'id' => $this->debt->id,
         'group_id' => $this->group->id,
         'group_user_id' => $this->group_user->id,
         'name' => 'i have been changed',
-        'amount' => $debt->amount->getMinorAmount()->toInt(),
+        'amount' => $this->debt->amount->getMinorAmount()->toInt(),
     ]);
 });
 
 test('user can not update the name on a debt they do not own', function() {
-    Event::fake();
+    $this->actingAs($this->other_group_user->user);
 
-    $other_group_user = $this->group->groupUsers->reject(fn($group_user) 
-        => $group_user->id === $this->group_user->id)->first();
-
-    $this->actingAs($other_group_user->user);
-
-    $debt = Debt::factory()->withShares()->create([
-        'group_user_id' => $this->group_user->id,
-        'group_id' => $this->group->id,
-        'split_even' => 0,
-        'name' => 'original name',
-    ]);
-
-    $response = $this->patch(route('debt.update', $debt), [
+    $response = $this->patch(route('debt.update', $this->debt), [
         'name' => 'i have been changed',
-        'amount' => $debt->amount->getMinorAmount()->toInt(),
+        'amount' => $this->debt->amount->getMinorAmount()->toInt(),
     ]);
 
     Event::assertNotDispatched(DebtUpdated::class);
@@ -122,21 +113,17 @@ test('user can not update the name on a debt they do not own', function() {
         ->assertRedirect('/debts');
 
     $this->assertDatabaseHas('debts', [
-        'id' => $debt->id,
+        'id' => $this->debt->id,
         'group_id' => $this->group->id,
         'group_user_id' => $this->group_user->id,
-        'name' => 'original name',
-        'amount' => $debt->amount->getMinorAmount()->toInt(),
+        'name' => $this->debt->name,
+        'amount' => $this->debt->amount->getMinorAmount()->toInt(),
     ]);
 });
 
 test('user can delete a debt they own and along with all associated shares and comments', function() {
-    $debt = Debt::factory()->withShares()->withComments()->create([
-        'group_user_id' => $this->group_user->id,
-        'group_id' => $this->group->id,
-    ]);
-
-    $response = $this->delete(route('debt.destroy', $debt));
+    dump($this->debt->comments);    
+    $response = $this->delete(route('debt.destroy', $this->debt));
 
     $response->assertStatus(302)
         ->assertSessionHasNoErrors()
@@ -144,21 +131,25 @@ test('user can delete a debt they own and along with all associated shares and c
         ->assertRedirect('/debts');
 
     $this->assertDatabaseHas('debts', [
-        'id' => $debt->id,
+        'id' => $this->debt->id,
         'group_id' => $this->group->id,
         'group_user_id' => $this->group_user->id,
         'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
     ]);
-
+    
     $this->assertDatabaseHas('shares', [
-        'debt_id' => $debt->id,
+        'debt_id' => $this->debt->id,
         'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
     ]);
 
     $this->assertDatabaseHas('comments', [
-        'debt_id' => $debt->id,
+        'debt_id' => $this->debt->id,
         'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
     ]);
+});
+
+test('user can not delete a debt they do not own', function() {
+
 });
 
 

--- a/tests/Feature/Http/Controllers/DebtControllerTest.php
+++ b/tests/Feature/Http/Controllers/DebtControllerTest.php
@@ -35,7 +35,7 @@ test('debts, shares and comments all appear with permissions paginated', functio
     $this->get('debts')
         ->assertInertia(fn (Assert $page) => 
             $page->component('Debts')
-                ->has('debts.data', 5)
+                ->has('debts.data', 10)
                 ->has('groups')
                 ->has('debts.data.0.can', fn (Assert $can) => $can
                     ->has('update')

--- a/tests/Feature/Http/Controllers/DebtControllerTest.php
+++ b/tests/Feature/Http/Controllers/DebtControllerTest.php
@@ -435,6 +435,53 @@ test('user can not add a debt for a group they are not in', function() {
     ]);
 });
 
+/**
+ * Tests for behaviours specific to to split even debts:
+ * - Add a split even debt
+ * - Updating the amount for a split even debt correctly updates shares
+ * - Can not update the amount for a split even debt if not the owner
+ */
+
+test('user can add a split even debt', function() {
+    Event::fake();
+
+    $user_shares = selectRandomGroupUsers($this->group->groupUsers, 10000, true);
+
+    $response = $this->post(route('debt.store', [
+        'group_id' => $this->group_user->group->id,
+        'group_user_id' => $this->group_user->id,
+        'name' => 'test debt 25',
+        'amount' => 10000,
+        'split_even' => 1,
+        'user_shares' => $user_shares,
+        'currency' => 'GBP',
+    ]));
+
+    Event::assertDispatched(DebtCreated::class);
+
+    $response->assertStatus(302)
+        ->assertSessionHasNoErrors()
+        ->assertSessionHas('status', 'Debt created successfully.')
+        ->assertRedirect('/debts');
+
+    $this->assertDatabaseHas('debts', [
+        'group_id' => $this->group_user->group->id,
+        'group_user_id' => $this->group_user->id,
+        'name' => 'test debt 25',
+        'amount' => 10000,
+        'split_even' => 1,
+        'currency' => 'GBP',
+    ]);
+
+    foreach ($user_shares as $share) {
+        $this->assertDatabaseHas('shares', [
+            'group_user_id' => $share['group_user_id'],
+            'amount' => $share['amount'],
+            'name' => 'share for user ' . $share['group_user_id'],
+        ]);
+    }
+});
+
 
 // test('user can add a debt with different value shares', function() {
 //     $user_shares = selectRandomGroupUsers($this->group->groupUsers, 10000, false);
@@ -482,87 +529,6 @@ test('user can not add a debt for a group they are not in', function() {
 //     }
 // });
 
-// /**
-//  * Bit of context for split even as it acts a bit differently to random amount debts
-//  * as they use selectRandomGroupUsers()
-//  * 
-//  * Just got kinda sick of having to write annoying separate conditions in the user
-//  * selection function, so it was easier to just take the hit and have separate <groups>
-//  * and users for the setup of this one.
-//  */
-// test('user can add a debt that is split even', function() {
-//     $users = User::factory(5)->create();
-//     $this->actingAs($users[0]);
-
-//     $group = Group::factory(1)
-//         ->create([
-//             'user_id' => $users->first()->id,
-//         ]);
-    
-//     foreach ($users as $user) {
-//         GroupUser::factory()->create([
-//             'user_id' => $user->id,
-//             'group_id' => $group[0]->id,
-//         ]);
-//     }
-
-//     $group_users = GroupUser::where('group_id', $group[0]->id)->get();
-//     $shares = Money::ofMinor(10000, 'GBP')->split($group_users->count());
-    
-//     $user_shares = $group_users->map(function ($group_user, $key) use ($shares) {
-//         return $group_user_shares[] = [
-//             'group_user_id' => $group_user->id,
-//             'share_name' => 'share for user ' . $group_user->id,
-//             'amount' => $shares[$key]->getMinorAmount(),
-//             'user_name' => $group_user->user->name,
-//         ];
-//     })->toArray();
-
-//     Event::fake();
-
-//     $response = $this->post(route('debt.store'), [
-//         'group_id' => $group[0]->id,
-//         'group_user_id' => $group_users[0]->id,
-//         'name' => 'test debt 2',
-//         'amount' => 10000,
-//         'split_even' => 1,
-//         'user_shares' => $user_shares,
-//         'currency' => 'GBP',
-//     ]);
-
-//     $response->assertStatus(302)
-//         ->assertSessionHasNoErrors()
-//         ->assertSessionHas('status', 'Debt created successfully.')
-//         ->assertRedirect('/debts');
-
-//     $this->assertDatabaseHas('debts', [
-//         'group_id' => $group[0]->id,
-//         'group_user_id' => $group_users[0]->id,
-//         'name' => 'test debt 2',
-//         'amount' => 10000,
-//         'split_even' => 1,
-//         'cleared' => 0,
-//         'currency' => 'GBP',
-//     ]);
-
-//     $debt = Debt::where('group_id', $group[0]->id)->first();
-
-//     foreach ($user_shares as $share) {
-//         $this->assertDatabaseHas('shares', [
-//             'group_user_id' => $share['group_user_id'],
-//             'debt_id' => $debt->id,
-//             'amount' => $share['amount'],
-//             'name' => 'share for user ' . $share['group_user_id'],
-//         ]);
-//     }
-// });
-
-
-
-
-
-
-
 // test('updating the amount on a split even debt updates the shares', function() {
 //     Event::fake();
 
@@ -606,59 +572,7 @@ test('user can not add a debt for a group they are not in', function() {
 //     }
 // });
 
-// test('user can update the name of a debt', function() {
-//     Event::fake();
 
-//     $debt = Debt::factory()->withShares()->create([
-//         'group_user_id' => $this->group_user->id,
-//         'group_id' => $this->group->id,
-//         'split_even' => 0,
-//     ]);
-
-//     $response = $this->patch(route('debt.update', $debt), [
-//         'name' => 'i have been changed',
-//         'amount' => $debt->amount->getMinorAmount()->toInt(),
-//     ]);
-
-//     $response->assertStatus(302)
-//         ->assertSessionHasNoErrors()
-//         ->assertSessionHas('status', 'Debt updated successfully.')
-//         ->assertRedirect('/debts');
-
-//     $this->assertDatabaseHas('debts', [
-//         'id' => $debt->id,
-//         'group_id' => $this->group->id,
-//         'group_user_id' => $this->group_user->id,
-//         'name' => 'i have been changed',
-//         'amount' => $debt->amount->getMinorAmount()->toInt(),
-//     ]);
-// });
-
-// test('user can not change the name of a debt they do not own', function() {
-//     $this->actingAs($this->users->last());
-
-//     $debt = Debt::factory()->withShares()->create([
-//         'group_user_id' => $this->group_user->id,
-//         'group_id' => $this->group->id,
-//     ]);
-
-//     $response = $this->patch(route('debt.update', $debt), [
-//         'amount' => $debt->amount->getMinorAmount()->toInt(),
-//         'name' => 'i have been changed',
-//     ]);
-
-//     $response->assertSessionHasErrors([
-//         'id' => 'You do not have permission to edit this debt.',
-//     ]);
-
-//     $this->assertDatabaseHas('debts', [
-//         'id' => $debt->id,
-//         'group_id' => $debt->group_id,
-//         'group_user_id' => $debt->groupUser->id,
-//         'name' => $debt->name,
-//         'amount' => $debt->amount->getMinorAmount()->toInt(),
-//     ]);
-// });
 
 // test('user can not change the amount of a debt they do not own', function() {
 //     $this->actingAs($this->users->last());

--- a/tests/Feature/Http/Controllers/ShareControllerTest.php
+++ b/tests/Feature/Http/Controllers/ShareControllerTest.php
@@ -46,13 +46,16 @@ beforeEach(function () {
  * Tests for shared behaviours where the debt type is irrelevant
  * - Select 'sent' on own share
  * - Select 'seen' on own debt share that's not their share
- * - Can not select 'seen' on a share they own that has not been sent
  * - Can not select 'sent' on a share they don't own
  * - Can not select 'seen' on a share they don't own
+ * - Can not select 'seen' on a share they own, but has not been sent
+ * - Can not select 'seen' on a share they do own, for a debt they do not own
  * - Update name on own share
  * - Not update on name on share they don't own and a debt they don't own
  * - Update name on a share they don't own, but a debt they do own
  * - Can not add a share without an amount
+ * - Can not add a share to a debt they do not own
+ * - Can not delete a share for a debt they do not own
  */
 test('user can select sent on their own share', function() {
     $response = $this->patch(route('share.sent', $this->share), [
@@ -175,6 +178,132 @@ test('user can not select seen on a share they do own for a debt they do not own
     ]);
 });
 
+test('user can update the name of their own share', function() {
+    $response = $this->patch(route('share.update', $this->share), [
+        'id' => $this->share->id,
+        'name' => 'i have been updated successfully',
+        'amount' => $this->share->amount->getMinorAmount()->toInt(),
+    ]);
+
+    $response->assertStatus(302)
+        ->assertSessionHasNoErrors()
+        ->assertSessionHas('status', 'Share updated successfully.');
+
+    $this->assertDatabaseHas('shares', [
+        'id' => $this->share->id,
+        'name' => 'i have been updated successfully',
+    ]);
+});
+
+test('user can not update a name of a share they do not own in a debt they do not own', function() {
+    $debt = Debt::factory()->withShares()->create([
+        'group_user_id' => $this->group_users->last()->id,
+        'group_id' => $this->group->id,
+    ]);
+
+    $share = $debt->shares->reject(fn($share) => 
+        $share->group_user_id === $this->group_user->id)->first();
+
+    $response = $this->patch(route('share.update', $share), [
+        'id' => $share->id,
+        'name' => 'i have been updated successfully',
+        'amount' => $share->amount->getMinorAmount()->toInt(),
+    ]);
+
+    $response->assertStatus(302)
+        ->assertSessionHasErrors('share', 'You do not have permission to update this share.');
+
+    $this->assertDatabaseHas('shares', [
+        'id' => $share->id,
+        'name' => $share->name,
+    ]);
+});
+
+test('user can update the name of a share they do not own in a debt they do own', function() {
+    $share = $this->debt->shares->reject(fn($share) => 
+        $share->group_user_id === $this->group_user->id)->first();
+
+    $response = $this->patch(route('share.update', $share), [
+        'id' => $share->id,
+        'name' => 'i have been updated successfully',
+        'amount' => $share->amount->getMinorAmount()->toInt(),
+    ]);
+
+    $response->assertStatus(302)
+        ->assertSessionHasNoErrors()
+        ->assertSessionHas('status', 'Share updated successfully.');
+
+    $this->assertDatabaseHas('shares', [
+        'id' => $share->id,
+        'name' => 'i have been updated successfully',
+    ]);
+});
+
+test('user can not add a share without an amount', function() {
+    $response = $this->post(route('share.store'), [
+        'debt_id' => $this->debt->id,
+        'group_user_id' => $this->group_user->id,
+        'name' => 'new share',
+        'currency' => 'GBP',
+    ]);
+
+    $response->assertStatus(302)
+        ->assertSessionHasErrors('amount', 'The amount field is required.');
+
+    $this->assertDatabaseMissing('shares', [
+        'debt_id' => $this->debt->id,
+        'group_user_id' => $this->group_user->id,
+        'name' => 'new share',
+    ]);
+});
+
+test('user can not add a share to a debt they do not own', function() {
+    $debt = Debt::factory()->withShares()->create([
+        'group_user_id' => $this->group_users->last()->id,
+        'group_id' => $this->group->id,
+    ]);
+
+    $response = $this->post(route('share.store'), [
+        'debt_id' => $debt->id,
+        'group_user_id' => $this->group_user->id,
+        'amount' => 500,
+        'name' => 'new share',
+        'currency' => 'GBP',
+    ]);
+
+    $response->assertStatus(302)
+        ->assertSessionHasErrors('debt_id', 'You do not have permission to add a share to this debt.');
+
+    $this->assertDatabaseMissing('shares', [
+        'debt_id' => $debt->id,
+        'group_user_id' => $this->group_user->id,
+        'name' => 'new share',
+    ]);
+});
+
+test('user can not delete a share for a debt they do not own', function() {
+    $debt = Debt::factory()->withShares()->create([
+        'group_user_id' => $this->group_users->last()->id,
+        'group_id' => $this->group->id,
+    ]);
+
+    $share = $debt->shares->reject(fn($share) =>
+        $share->group_user_id === $this->group_user->id)->first();
+
+    $response = $this->delete(route('share.destroy', $share));
+
+    $response->assertStatus(302)
+        ->assertSessionHasErrors('id', 'You do not have permission to delete this share.');
+
+    $this->assertDatabaseHas('shares', [
+        'id' => $share->id,
+        'group_user_id' => $share->group_user_id,
+        'debt_id' => $share->debt_id,
+        'deleted_at' => null,
+    ]);
+});
+
+
 // test("user can delete a share for a debt they own", function() {
 //     $debt = Debt::factory()->withShares()->create([
 //         'group_user_id' => $this->group_user->id,
@@ -201,36 +330,6 @@ test('user can not select seen on a share they do own for a debt they do not own
 //     $this->assertDatabaseHas('debts', [
 //         'id' => $debt->id,
 //         'amount' => ($debt->amount->minus($share->amount))->getMinorAmount()->toInt(),
-//     ]);
-// });
-
-// test("user can update the name on a share for a debt they own", function() {
-//     $debt = Debt::factory()->withShares()->create([
-//         'group_user_id' => $this->group_user->id,
-//         'group_id' => $this->group->id,
-//     ]);
-    
-//     $share = Share::factory()->create([
-//         'group_user_id' => $this->group_user->id,
-//         'debt_id' => $debt->id,
-//         'amount' => 500,
-//     ]);
-
-//     $response = $this->patch(route('share.update', $share), [
-//         'id' => $share->id,
-//         'debt_id' => $debt->id,
-//         'name' => 'new name for this share',
-//         'amount' => $share->amount->getMinorAmount()->toInt(),
-//     ]);
-
-//     $response->assertStatus(302)
-//         ->assertSessionHas('status', 'Share updated successfully.')
-//         ->assertSessionHasNoErrors();
-
-//     $this->assertDatabaseHas('shares', [
-//         'id' => $share->id,
-//         'group_user_id' => $share->group_user_id,
-//         'name' => 'new name for this share'
 //     ]);
 // });
 
@@ -341,72 +440,4 @@ test('user can not select seen on a share they do own for a debt they do not own
 //  * are hidden from users behind js on the Controls component
 //  */
 
-// test("user can not add a share for a debt they do not own", function() {
-//     $debt = Debt::factory()->withShares()->create([
-//         'group_user_id' => $this->group_users->last()->id,
-//         'group_id' => $this->group->id,
-//     ]);
 
-//     $response = $this->post(route('share.store'), [
-//         'debt_id' => $debt->id,
-//         'group_user_id' => $this->group_user->id,
-//         'amount' => 500,
-//         'name' => 'new share',
-//         'currency' => 'GBP',
-//     ]);
-
-//     $response->assertStatus(302)
-//         ->assertSessionHasErrors('debt_id', 'You do not have permission to add a share to this debt.');
-
-//     $this->assertDatabaseMissing('shares', [
-//         'debt_id' => $debt->id,
-//         'group_user_id' => $this->group_user->id,
-//         'amount' => 500,
-//     ]);
-// });
-
-
-// test("user can not delete a share for a debt they do not own", function() {
-//     $debt = Debt::factory()->withShares()->create([
-//         'group_user_id' => $this->group_users->last()->id,
-//         'group_id' => $this->group->id,
-//     ]);
-
-//     $share = $debt->shares->first();
-
-//     $response = $this->delete(route('share.destroy', $share));
-
-//     // check is against debt id
-//     $response->assertSessionHasErrors('id', 'You do not have permission to delete this share.');
-
-//     $this->assertDatabaseHas('shares', [
-//         'id' => $share->id,
-//         'deleted_at' => null,
-//     ]);
-// });
-
-// test("user can not update the name or amount on a share for a debt they do not own", function() {
-//     $debt = Debt::factory()->withShares()->create([
-//         'group_user_id' => $this->group_users->last()->id,
-//         'group_id' => $this->group->id,
-//     ]);
-    
-//     $share = $debt->shares->reject(fn($share) => 
-//         $share->group_user_id === $this->group_user->id)->first();
- 
-//     $new = $share->amount->plus(Money::of(10, 'GBP'));
-
-//     $response = $this->patch(route('share.update', $share), [
-//         'id' => $share->id,
-//         'debt_id' => $debt->id,
-//         'amount' => $new->getMinorAmount()->toInt(),
-//         'name' => 'new share name'
-//     ]);
-    
-//     $response->assertSessionHasErrors('share', 'You do not have permission to update this share.');
-    
-//     $this->assertDatabaseHas('shares', [
-//         'id' => $share->id,
-//         'amount' => $share->amount->getMinorAmount()->toInt(),
-//     ]);
-// });

--- a/tests/Feature/Http/Controllers/ShareControllerTest.php
+++ b/tests/Feature/Http/Controllers/ShareControllerTest.php
@@ -87,35 +87,41 @@ test('user can select seen on a share they do not own for a debt they own', func
     ]);
 });
 
-// test("user can select 'seen' on a share they don't own for a debt they own", function () {
-//     $debt = Debt::factory()->withShares()->create([
-//         'group_user_id' => $this->group_user->id,
-//         'group_id' => $this->group->id,
-//     ]);
-    
-//     // get a share that's not mine
-//     $share = $debt->shares->reject(fn($share) => 
-//         $share->user_id === $this->user->id)->first();
+test('user can not select sent on a share they do not own', function() {
+    $share = $this->debt->shares->reject(fn($share) => 
+        $share->group_user_id === $this->group_user->id)->first();
 
-//     // set it to not sent
-//     $share->sent = 1;
-//     $share->save();
+    $response = $this->patch(route('share.sent', $share), [
+        'id' => $share->id,
+        'sent' => !$share->sent,
+    ]);
 
-//     // try to update it
-//     $response = $this->patch(route('share.seen', $share), [
-//         'id' => $share->id,
-//         'seen' => !$share->seen,
-//     ]);
+    $response->assertStatus(302)
+        ->assertSessionHasErrors(['sent' => "You do not have permission to update the 'sent' status of this share"]);
 
-//     // check correct response
-//     $response->assertStatus(302)->assertSessionHasNoErrors();
+    $this->assertDatabaseHas('shares', [
+        'id' => $share->id,
+        'sent' => $share->sent,
+    ]);
+});
 
-//     // confirm original status
-//     $this->assertDatabaseHas('shares', [
-//         'id' => $share->id,
-//         'seen' => !$share->seen,
-//     ]);
-// });
+test('user can not select seen on a share they do not own', function() {
+    $share = $this->debt->shares->reject(fn($share) => 
+        $share->group_user_id === $this->group_user->id)->first();
+
+    $response = $this->patch(route('share.seen', $share), [
+        'id' => $share->id,
+        'seen' => !$share->seen,
+    ]);
+
+    $response->assertStatus(302)
+        ->assertSessionHasErrors(['seen' => "You can not mark this share as seen becase it has not been sent yet"]);
+
+    $this->assertDatabaseHas('shares', [
+        'id' => $share->id,
+        'seen' => $share->seen,
+    ]);
+});
 
 // test("user can not select 'seen' on the share for a debt they do not own", function () {
 //     // a share i don't own, in a debt i don't own

--- a/tests/Feature/Http/Controllers/ShareControllerTest.php
+++ b/tests/Feature/Http/Controllers/ShareControllerTest.php
@@ -21,404 +21,414 @@ beforeEach(function () {
     $this->group_users = $this->group->groupUsers;
     $this->group_user = GroupUser::where('user_id', $this->user->id)->first();
 
+    $this->debt = Debt::factory()->withShares()->create([
+        'group_user_id' => $this->group_user->id,
+        'group_id' => $this->group->id,
+        'split_even' => 0,
+    ]);
+
+    $this->share = Share::factory()->create([
+        'group_user_id' => $this->group_user->id,
+        'debt_id' => $this->debt->id,
+        'name' => 'test share',
+        'amount' => 500,
+        'sent' => 0,
+        'seen' => 0,
+    ]);
+
+    $this->other_group_user = $this->group->groupUsers->reject(fn($group_user) 
+        => $group_user->id === $this->group_user->id)->first();
+
     $this->actingAs($this->user);
 });
 
-test("user can select 'sent' on their own share", function () {
-    $debt = Debt::factory()
-        ->withShares()
-        ->create([
-            'group_user_id' => $this->group_user->id,
-            'group_id' => $this->group->id,
-        ]);
-
-    $share = Share::factory()->create([
-        'group_user_id' => $this->group_user->id,
-        'debt_id' => $debt->id,
-        'amount' => 500,
-    ]);
-
-    $response = $this->patch(route('share.sent', $share), [
-        'id' => $share->id,
-        'sent' => !$share->sent,
+/**
+ * Tests for shared behaviours where the debt type is irrelevant
+ * - Select 'sent' on own share
+ * - Select 'seen' on own debt share that's not their share
+ * - Can not select 'sent' on a share they don't own
+ * - Can not select 'seen' on a share they don't own
+ * - Update name on own share
+ * - Not update on name on share they don't own and a debt they don't own
+ * - Update name on a share they don't own, but a debt they do own
+ * - Can not add a share without an amount
+ */
+test('user can select sent on their own share', function() {
+    $response = $this->patch(route('share.sent', $this->share), [
+        'id' => $this->share->id,
+        'sent' => !$this->share->sent,
     ]);
 
     $response->assertStatus(302)->assertSessionHasNoErrors();
 
     $this->assertDatabaseHas('shares', [
-        'id' => $share->id,
-        'sent' => !$share->sent,
+        'id' => $this->share->id,
+        'sent' => !$this->share->sent,
     ]);
 });
 
-test("user can not select 'sent' on a share they do not own", function () {
-    $debt = Debt::factory()->withShares()->create([
-        'group_user_id' => $this->group_user->id,
-        'group_id' => $this->group->id,
-    ]);
-
-    // get a share that's not mine
-    $share = $debt->shares->reject(fn($share) => 
+test('user can select seen on a share they do not own for a debt they own', function() {
+    $share = $this->debt->shares->reject(fn($share) => 
         $share->group_user_id === $this->group_user->id)->first();
 
-    // try to update it
-    $response = $this->patch(route('share.sent', $share), [
-        'id' => $share->id,
-        'sent' => !$share->sent,
-    ]);
-
-    $response->assertStatus(302)
-        ->assertSessionHasErrors(['sent' => "You do not have permission to update the 'sent' status of this share"]);
-
-    // confirm original status
-    $this->assertDatabaseHas('shares', [
-        'id' => $share->id,
-        'sent' => $share->sent,
-    ]);
-});
-
-test("user can select 'seen' on a share they don't own for a debt they own", function () {
-    $debt = Debt::factory()->withShares()->create([
-        'group_user_id' => $this->group_user->id,
-        'group_id' => $this->group->id,
-    ]);
-    
-    // get a share that's not mine
-    $share = $debt->shares->reject(fn($share) => 
-        $share->user_id === $this->user->id)->first();
-
-    // set it to not sent
     $share->sent = 1;
     $share->save();
 
-    // try to update it
     $response = $this->patch(route('share.seen', $share), [
         'id' => $share->id,
         'seen' => !$share->seen,
     ]);
 
-    // check correct response
     $response->assertStatus(302)->assertSessionHasNoErrors();
 
-    // confirm original status
     $this->assertDatabaseHas('shares', [
         'id' => $share->id,
         'seen' => !$share->seen,
     ]);
 });
 
-test("user can not select 'seen' on the share for a debt they do not own", function () {
-    // a share i don't own, in a debt i don't own
-    $debt = Debt::factory()->withShares()->create([
-        'group_user_id' => $this->group_users->last()->id,
-        'group_id' => $this->group->id,
-    ]);
-
-    $share = $debt->shares->reject(fn($share) => 
-        $share->user_id === $this->user->id)->first();
-
-   // try to update it
-    $response = $this->patch(route('share.seen', $share), [
-        'id' => $share->id,
-        'seen' => !$share->seen,
-    ]);
-
-    $response->assertStatus(302)
-        ->assertSessionHasErrors(['seen' => "You do not have permission to update the 'seen' status of this share"]);
-    // confirm original status
-    $this->assertDatabaseHas('shares', [
-        'id' => $share->id,
-        'sent' => $share->sent,
-    ]);
-});
-
-test("user can not select 'seen' on a share that has not yet been sent", function() {
-    $debt = Debt::factory()->withShares()->create([
-        'group_user_id' => $this->group_user->id,
-        'group_id' => $this->group->id,
-    ]);
+// test("user can select 'seen' on a share they don't own for a debt they own", function () {
+//     $debt = Debt::factory()->withShares()->create([
+//         'group_user_id' => $this->group_user->id,
+//         'group_id' => $this->group->id,
+//     ]);
     
-    // get a share that's not mine
-    $share = $debt->shares->reject(fn($share) => 
-        $share->user_id === $this->user->id)->first();
+//     // get a share that's not mine
+//     $share = $debt->shares->reject(fn($share) => 
+//         $share->user_id === $this->user->id)->first();
 
-    // set it to not sent
-    $share->sent = 0;
-    $share->save();
+//     // set it to not sent
+//     $share->sent = 1;
+//     $share->save();
 
-    // try to update it
-    $response = $this->patch(route('share.seen', $share), [
-        'id' => $share->id,
-        'seen' => !$share->seen,
-    ]);
+//     // try to update it
+//     $response = $this->patch(route('share.seen', $share), [
+//         'id' => $share->id,
+//         'seen' => !$share->seen,
+//     ]);
 
-    // check correct response
-    $response->assertStatus(302)
-        ->assertSessionHasErrors(['seen' => "You can not mark this share as seen becase it has not been sent yet"]);
+//     // check correct response
+//     $response->assertStatus(302)->assertSessionHasNoErrors();
 
-    // confirm original status
-    $this->assertDatabaseHas('shares', [
-        'id' => $share->id,
-        'seen' => $share->seen,
-    ]);
-});
+//     // confirm original status
+//     $this->assertDatabaseHas('shares', [
+//         'id' => $share->id,
+//         'seen' => !$share->seen,
+//     ]);
+// });
 
-test("user can not select 'seen' on a share they own", function() {
-    $debt = Debt::factory()->withShares()->create([
-        'group_user_id' => $this->group_users->last()->id,
-        'group_id' => $this->group->id,
-    ]);
+// test("user can not select 'seen' on the share for a debt they do not own", function () {
+//     // a share i don't own, in a debt i don't own
+//     $debt = Debt::factory()->withShares()->create([
+//         'group_user_id' => $this->group_users->last()->id,
+//         'group_id' => $this->group->id,
+//     ]);
 
-    $share = $debt->shares->first();
+//     $share = $debt->shares->reject(fn($share) => 
+//         $share->user_id === $this->user->id)->first();
 
-    $response = $this->patch(route('share.seen', $share), [
-        'id' => $share->id,
-        'seen' => !$share->seen,
-    ]);
+//    // try to update it
+//     $response = $this->patch(route('share.seen', $share), [
+//         'id' => $share->id,
+//         'seen' => !$share->seen,
+//     ]);
 
-    // check correct response
-    $response->assertStatus(302)
-        ->assertSessionHasErrors(['seen' => "You do not have permission to update the 'seen' status of this share"]);
+//     $response->assertStatus(302)
+//         ->assertSessionHasErrors(['seen' => "You do not have permission to update the 'seen' status of this share"]);
+//     // confirm original status
+//     $this->assertDatabaseHas('shares', [
+//         'id' => $share->id,
+//         'sent' => $share->sent,
+//     ]);
+// });
 
-    // confirm original status
-    $this->assertDatabaseHas('shares', [
-        'id' => $share->id,
-        'seen' => $share->seen,
-    ]);
-});
-
-test("user can delete a share for a debt they own", function() {
-    $debt = Debt::factory()->withShares()->create([
-        'group_user_id' => $this->group_user->id,
-        'group_id' => $this->group->id,
-    ]);
+// test("user can not select 'seen' on a share that has not yet been sent", function() {
+//     $debt = Debt::factory()->withShares()->create([
+//         'group_user_id' => $this->group_user->id,
+//         'group_id' => $this->group->id,
+//     ]);
     
-    // a share i don't own in a debt i do own
-    $share = $debt->shares->reject(fn($share) => 
-        $share->user_id === $this->user->id)->first();
+//     // get a share that's not mine
+//     $share = $debt->shares->reject(fn($share) => 
+//         $share->user_id === $this->user->id)->first();
+
+//     // set it to not sent
+//     $share->sent = 0;
+//     $share->save();
+
+//     // try to update it
+//     $response = $this->patch(route('share.seen', $share), [
+//         'id' => $share->id,
+//         'seen' => !$share->seen,
+//     ]);
+
+//     // check correct response
+//     $response->assertStatus(302)
+//         ->assertSessionHasErrors(['seen' => "You can not mark this share as seen becase it has not been sent yet"]);
+
+//     // confirm original status
+//     $this->assertDatabaseHas('shares', [
+//         'id' => $share->id,
+//         'seen' => $share->seen,
+//     ]);
+// });
+
+// test("user can not select 'seen' on a share they own", function() {
+//     $debt = Debt::factory()->withShares()->create([
+//         'group_user_id' => $this->group_users->last()->id,
+//         'group_id' => $this->group->id,
+//     ]);
+
+//     $share = $debt->shares->first();
+
+//     $response = $this->patch(route('share.seen', $share), [
+//         'id' => $share->id,
+//         'seen' => !$share->seen,
+//     ]);
+
+//     // check correct response
+//     $response->assertStatus(302)
+//         ->assertSessionHasErrors(['seen' => "You do not have permission to update the 'seen' status of this share"]);
+
+//     // confirm original status
+//     $this->assertDatabaseHas('shares', [
+//         'id' => $share->id,
+//         'seen' => $share->seen,
+//     ]);
+// });
+
+// test("user can delete a share for a debt they own", function() {
+//     $debt = Debt::factory()->withShares()->create([
+//         'group_user_id' => $this->group_user->id,
+//         'group_id' => $this->group->id,
+//     ]);
     
-    // delete it
-    $response = $this->delete(route('share.destroy', $share));
-
-    $response->assertStatus(302)
-        ->assertSessionHas('status', 'Share deleted successfully.')
-        ->assertSessionHasNoErrors();;
-
-    // confirm it's gone
-    $this->assertDatabaseHas('shares', [
-        'id' => $share->id,
-        'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
-    ]);
-
-    $this->assertDatabaseHas('debts', [
-        'id' => $debt->id,
-        'amount' => ($debt->amount->minus($share->amount))->getMinorAmount()->toInt(),
-    ]);
-});
-
-test("user can update the name on a share for a debt they own", function() {
-    $debt = Debt::factory()->withShares()->create([
-        'group_user_id' => $this->group_user->id,
-        'group_id' => $this->group->id,
-    ]);
+//     // a share i don't own in a debt i do own
+//     $share = $debt->shares->reject(fn($share) => 
+//         $share->user_id === $this->user->id)->first();
     
-    $share = Share::factory()->create([
-        'group_user_id' => $this->group_user->id,
-        'debt_id' => $debt->id,
-        'amount' => 500,
-    ]);
+//     // delete it
+//     $response = $this->delete(route('share.destroy', $share));
 
-    $response = $this->patch(route('share.update', $share), [
-        'id' => $share->id,
-        'debt_id' => $debt->id,
-        'name' => 'new name for this share',
-        'amount' => $share->amount->getMinorAmount()->toInt(),
-    ]);
+//     $response->assertStatus(302)
+//         ->assertSessionHas('status', 'Share deleted successfully.')
+//         ->assertSessionHasNoErrors();;
 
-    $response->assertStatus(302)
-        ->assertSessionHas('status', 'Share updated successfully.')
-        ->assertSessionHasNoErrors();
+//     // confirm it's gone
+//     $this->assertDatabaseHas('shares', [
+//         'id' => $share->id,
+//         'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
+//     ]);
 
-    $this->assertDatabaseHas('shares', [
-        'id' => $share->id,
-        'group_user_id' => $share->group_user_id,
-        'name' => 'new name for this share'
-    ]);
-});
+//     $this->assertDatabaseHas('debts', [
+//         'id' => $debt->id,
+//         'amount' => ($debt->amount->minus($share->amount))->getMinorAmount()->toInt(),
+//     ]);
+// });
 
-test("user can update the amount on a share for a debt they own", function() {
-    $debt = Debt::factory()->withShares()->create([
-        'group_user_id' => $this->group_user->id,
-        'group_id' => $this->group->id,
-        'split_even' => 0,
-    ]);
+// test("user can update the name on a share for a debt they own", function() {
+//     $debt = Debt::factory()->withShares()->create([
+//         'group_user_id' => $this->group_user->id,
+//         'group_id' => $this->group->id,
+//     ]);
     
-    $share = Share::factory()->create([
-        'group_user_id' => $this->group_user->id,
-        'debt_id' => $debt->id,
-        'amount' => 500,
-    ]);
+//     $share = Share::factory()->create([
+//         'group_user_id' => $this->group_user->id,
+//         'debt_id' => $debt->id,
+//         'amount' => 500,
+//     ]);
 
-    // the 'new' amount is basically what the user sees,
-    // e..g if they add a fiver it's just 5
-    $new = $share->amount->plus(Money::of(10, 'GBP'));
+//     $response = $this->patch(route('share.update', $share), [
+//         'id' => $share->id,
+//         'debt_id' => $debt->id,
+//         'name' => 'new name for this share',
+//         'amount' => $share->amount->getMinorAmount()->toInt(),
+//     ]);
 
-    $response = $this->patch(route('share.update', $share), [
-        'id' => $share->id,
-        'name' => $share->name,
-        'debt_id' => $debt->id,
-        // we have to do this weird thing as brick money deals in minor units
-        // and does not make ints into decimals, only decimals into ints
-        // so if new is 5.65, minorAmount gives us 565
-        // then /100 to simulate user input of 5.65
-        // as the casting is handled in Cash.php attribute cast
-        'amount' => $new->getMinorAmount()->toInt() / 100
-    ]);
+//     $response->assertStatus(302)
+//         ->assertSessionHas('status', 'Share updated successfully.')
+//         ->assertSessionHasNoErrors();
 
-    $response->assertStatus(302)
-        ->assertSessionHas('status', 'Share updated successfully.')
-        ->assertSessionHasNoErrors();
+//     $this->assertDatabaseHas('shares', [
+//         'id' => $share->id,
+//         'group_user_id' => $share->group_user_id,
+//         'name' => 'new name for this share'
+//     ]);
+// });
 
-
-    $this->assertDatabaseHas('shares', [
-        'id' => $share->id,
-        'group_user_id' => $share->group_user_id,
-        'amount' => $new->getMinorAmount()->toInt(),
-    ]);
-
-    $this->assertDatabaseHas('debts', [
-        'id' => $debt->id,
-        'amount' => $debt->amount->plus(Money::of(10, 'GBP'))->getMinorAmount()->toInt(),
-    ]);
-});
-
-test("user can add a share for themselves for a debt they own", function() {
-    $debt = Debt::factory()->withShares()->create([
-        'group_user_id' => $this->group_user->id,
-        'group_id' => $this->group->id,
-        'split_even' => 0,
-    ]);
-
-    $response = $this->post(route('share.store'), [
-        'debt_id' => $debt->id,
-        'group_user_id' => $this->group_user->id,
-        'amount' => 500,
-        'name' => 'new share',
-        'currency' => 'GBP',
-    ]);
-
-    $response->assertStatus(302)
-        ->assertSessionHas('status', 'Share created successfully.')
-        ->assertSessionHasNoErrors();
-
-    $this->assertDatabaseHas('shares', [
-        'debt_id' => $debt->id,
-        'group_user_id' => $this->group_user->id,
-        'amount' => 500 * 100,
-    ]);
-});
-
-test("user can add a share for another user for a debt they own", function() {
-    $debt = Debt::factory()->withShares()->create([
-        'group_user_id' => $this->group_user->id,
-        'group_id' => $this->group->id,
-        'split_even' => 0,
-    ]);
-
-    $other_group_user = $debt->groupUsers->reject(fn($group_user) => 
-        $group_user->id === $this->group_user->id)->first();
-
-    $response = $this->post(route('share.store'), [
-        'debt_id' => $debt->id,
-        'group_user_id' => $other_group_user->id,
-        'amount' => 750,
-        'name' => 'new share for other user',
-        'currency' => 'GBP',
-    ]);
-
-    $response->assertStatus(302)
-        ->assertSessionHas('status', 'Share created successfully.')
-        ->assertSessionHasNoErrors();
-
-    $this->assertDatabaseHas('shares', [
-        'debt_id' => $debt->id,
-        'group_user_id' => $other_group_user->id,
-        'amount' => 750 * 100,
-    ]);
-});
-
-
-/**
- * these are all tests for functionality that by default, 
- * are hidden from users behind js on the Controls component
- */
-
-test("user can not add a share for a debt they do not own", function() {
-    $debt = Debt::factory()->withShares()->create([
-        'group_user_id' => $this->group_users->last()->id,
-        'group_id' => $this->group->id,
-    ]);
-
-    $response = $this->post(route('share.store'), [
-        'debt_id' => $debt->id,
-        'group_user_id' => $this->group_user->id,
-        'amount' => 500,
-        'name' => 'new share',
-        'currency' => 'GBP',
-    ]);
-
-    $response->assertStatus(302)
-        ->assertSessionHasErrors('debt_id', 'You do not have permission to add a share to this debt.');
-
-    $this->assertDatabaseMissing('shares', [
-        'debt_id' => $debt->id,
-        'group_user_id' => $this->group_user->id,
-        'amount' => 500,
-    ]);
-});
-
-
-test("user can not delete a share for a debt they do not own", function() {
-    $debt = Debt::factory()->withShares()->create([
-        'group_user_id' => $this->group_users->last()->id,
-        'group_id' => $this->group->id,
-    ]);
-
-    $share = $debt->shares->first();
-
-    $response = $this->delete(route('share.destroy', $share));
-
-    // check is against debt id
-    $response->assertSessionHasErrors('id', 'You do not have permission to delete this share.');
-
-    $this->assertDatabaseHas('shares', [
-        'id' => $share->id,
-        'deleted_at' => null,
-    ]);
-});
-
-test("user can not update the name or amount on a share for a debt they do not own", function() {
-    $debt = Debt::factory()->withShares()->create([
-        'group_user_id' => $this->group_users->last()->id,
-        'group_id' => $this->group->id,
-    ]);
+// test("user can update the amount on a share for a debt they own", function() {
+//     $debt = Debt::factory()->withShares()->create([
+//         'group_user_id' => $this->group_user->id,
+//         'group_id' => $this->group->id,
+//         'split_even' => 0,
+//     ]);
     
-    $share = $debt->shares->reject(fn($share) => 
-        $share->group_user_id === $this->group_user->id)->first();
+//     $share = Share::factory()->create([
+//         'group_user_id' => $this->group_user->id,
+//         'debt_id' => $debt->id,
+//         'amount' => 500,
+//     ]);
+
+//     // the 'new' amount is basically what the user sees,
+//     // e..g if they add a fiver it's just 5
+//     $new = $share->amount->plus(Money::of(10, 'GBP'));
+
+//     $response = $this->patch(route('share.update', $share), [
+//         'id' => $share->id,
+//         'name' => $share->name,
+//         'debt_id' => $debt->id,
+//         // we have to do this weird thing as brick money deals in minor units
+//         // and does not make ints into decimals, only decimals into ints
+//         // so if new is 5.65, minorAmount gives us 565
+//         // then /100 to simulate user input of 5.65
+//         // as the casting is handled in Cash.php attribute cast
+//         'amount' => $new->getMinorAmount()->toInt() / 100
+//     ]);
+
+//     $response->assertStatus(302)
+//         ->assertSessionHas('status', 'Share updated successfully.')
+//         ->assertSessionHasNoErrors();
+
+
+//     $this->assertDatabaseHas('shares', [
+//         'id' => $share->id,
+//         'group_user_id' => $share->group_user_id,
+//         'amount' => $new->getMinorAmount()->toInt(),
+//     ]);
+
+//     $this->assertDatabaseHas('debts', [
+//         'id' => $debt->id,
+//         'amount' => $debt->amount->plus(Money::of(10, 'GBP'))->getMinorAmount()->toInt(),
+//     ]);
+// });
+
+// test("user can add a share for themselves for a debt they own", function() {
+//     $debt = Debt::factory()->withShares()->create([
+//         'group_user_id' => $this->group_user->id,
+//         'group_id' => $this->group->id,
+//         'split_even' => 0,
+//     ]);
+
+//     $response = $this->post(route('share.store'), [
+//         'debt_id' => $debt->id,
+//         'group_user_id' => $this->group_user->id,
+//         'amount' => 500,
+//         'name' => 'new share',
+//         'currency' => 'GBP',
+//     ]);
+
+//     $response->assertStatus(302)
+//         ->assertSessionHas('status', 'Share created successfully.')
+//         ->assertSessionHasNoErrors();
+
+//     $this->assertDatabaseHas('shares', [
+//         'debt_id' => $debt->id,
+//         'group_user_id' => $this->group_user->id,
+//         'amount' => 500 * 100,
+//     ]);
+// });
+
+// test("user can add a share for another user for a debt they own", function() {
+//     $debt = Debt::factory()->withShares()->create([
+//         'group_user_id' => $this->group_user->id,
+//         'group_id' => $this->group->id,
+//         'split_even' => 0,
+//     ]);
+
+//     $other_group_user = $debt->groupUsers->reject(fn($group_user) => 
+//         $group_user->id === $this->group_user->id)->first();
+
+//     $response = $this->post(route('share.store'), [
+//         'debt_id' => $debt->id,
+//         'group_user_id' => $other_group_user->id,
+//         'amount' => 750,
+//         'name' => 'new share for other user',
+//         'currency' => 'GBP',
+//     ]);
+
+//     $response->assertStatus(302)
+//         ->assertSessionHas('status', 'Share created successfully.')
+//         ->assertSessionHasNoErrors();
+
+//     $this->assertDatabaseHas('shares', [
+//         'debt_id' => $debt->id,
+//         'group_user_id' => $other_group_user->id,
+//         'amount' => 750 * 100,
+//     ]);
+// });
+
+
+// /**
+//  * these are all tests for functionality that by default, 
+//  * are hidden from users behind js on the Controls component
+//  */
+
+// test("user can not add a share for a debt they do not own", function() {
+//     $debt = Debt::factory()->withShares()->create([
+//         'group_user_id' => $this->group_users->last()->id,
+//         'group_id' => $this->group->id,
+//     ]);
+
+//     $response = $this->post(route('share.store'), [
+//         'debt_id' => $debt->id,
+//         'group_user_id' => $this->group_user->id,
+//         'amount' => 500,
+//         'name' => 'new share',
+//         'currency' => 'GBP',
+//     ]);
+
+//     $response->assertStatus(302)
+//         ->assertSessionHasErrors('debt_id', 'You do not have permission to add a share to this debt.');
+
+//     $this->assertDatabaseMissing('shares', [
+//         'debt_id' => $debt->id,
+//         'group_user_id' => $this->group_user->id,
+//         'amount' => 500,
+//     ]);
+// });
+
+
+// test("user can not delete a share for a debt they do not own", function() {
+//     $debt = Debt::factory()->withShares()->create([
+//         'group_user_id' => $this->group_users->last()->id,
+//         'group_id' => $this->group->id,
+//     ]);
+
+//     $share = $debt->shares->first();
+
+//     $response = $this->delete(route('share.destroy', $share));
+
+//     // check is against debt id
+//     $response->assertSessionHasErrors('id', 'You do not have permission to delete this share.');
+
+//     $this->assertDatabaseHas('shares', [
+//         'id' => $share->id,
+//         'deleted_at' => null,
+//     ]);
+// });
+
+// test("user can not update the name or amount on a share for a debt they do not own", function() {
+//     $debt = Debt::factory()->withShares()->create([
+//         'group_user_id' => $this->group_users->last()->id,
+//         'group_id' => $this->group->id,
+//     ]);
+    
+//     $share = $debt->shares->reject(fn($share) => 
+//         $share->group_user_id === $this->group_user->id)->first();
  
-    $new = $share->amount->plus(Money::of(10, 'GBP'));
+//     $new = $share->amount->plus(Money::of(10, 'GBP'));
 
-    $response = $this->patch(route('share.update', $share), [
-        'id' => $share->id,
-        'debt_id' => $debt->id,
-        'amount' => $new->getMinorAmount()->toInt(),
-        'name' => 'new share name'
-    ]);
+//     $response = $this->patch(route('share.update', $share), [
+//         'id' => $share->id,
+//         'debt_id' => $debt->id,
+//         'amount' => $new->getMinorAmount()->toInt(),
+//         'name' => 'new share name'
+//     ]);
     
-    $response->assertSessionHasErrors('share', 'You do not have permission to update this share.');
+//     $response->assertSessionHasErrors('share', 'You do not have permission to update this share.');
     
-    $this->assertDatabaseHas('shares', [
-        'id' => $share->id,
-        'amount' => $share->amount->getMinorAmount()->toInt(),
-    ]);
-});
+//     $this->assertDatabaseHas('shares', [
+//         'id' => $share->id,
+//         'amount' => $share->amount->getMinorAmount()->toInt(),
+//     ]);
+// });

--- a/tests/Feature/Http/Controllers/ShareControllerTest.php
+++ b/tests/Feature/Http/Controllers/ShareControllerTest.php
@@ -403,6 +403,88 @@ test('user can delete a share in a split even debt they own and the debt total i
     ]);
 });
 
+/**
+ * Tests for non-split (standard) debts
+ * - Can add a share to a standard debt they own, balance is recalculated
+ * - Can update a share of a standard debt they own, balance is recalculated
+ * - Can delete a share of a standard debt they own, balance is recalculated
+ */
+
+test('user can add a share to a standard debt they own and the balance is recalcuated', function() {
+    $response = $this->post(route('share.store'), [
+        'debt_id' => $this->debt->id,
+        'group_user_id' => $this->group_user->id,
+        'amount' => 700,
+        'currency' => 'GBP',
+        'name' => 'new share',
+    ]);
+
+    $response->assertStatus(302)
+        ->assertSessionHas('status', 'Share created successfully.')
+        ->assertSessionHasNoErrors();
+
+    
+    $this->assertDatabaseHas('debts', [
+        'id' => $this->debt->id,
+        'amount' => $this->debt->amount->plus(Money::of(7, 'GBP'))->getMinorAmount()->toInt(),
+        'group_user_id' => $this->group_user->id,
+    ]);
+
+    $this->assertDatabaseHas('shares', [
+        'debt_id' => $this->debt->id,
+        'group_user_id' => $this->group_user->id,
+        'amount' => 700,
+        'name' => 'new share',
+    ]);
+});
+
+test('user can update a share of a standard debt they own and the balance is recalculated', function() {
+    $response = $this->patch(route('share.update', $this->share), [
+        'id' => $this->share->id,
+        'name' => $this->share->name,
+        'amount' => 1000,
+    ]);
+
+    $response->assertStatus(302)
+        ->assertSessionHas('status', 'Share updated successfully.')
+        ->assertSessionHasNoErrors();
+
+    $this->assertDatabaseHas('debts', [
+        'id' => $this->debt->id,
+        'amount' => $this->debt->amount->plus(Money::of(5, 'GBP'))->getMinorAmount()->toInt(),
+        'group_user_id' => $this->group_user->id,
+    ]);
+
+    $this->assertDatabaseHas('shares', [
+        'debt_id' => $this->debt->id,
+        'group_user_id' => $this->group_user->id,
+        'amount' => 1000,
+        'name' => $this->share->name,
+    ]);
+});
+
+test('user can delete a share of a standard debt they own and the balance is recalculated', function() {
+    $response = $this->delete(route('share.destroy', $this->share));
+
+    $response->assertStatus(302)
+        ->assertSessionHas('status', 'Share deleted successfully.')
+        ->assertSessionHasNoErrors();
+
+    $this->assertDatabaseHas('debts', [
+        'id' => $this->debt->id,
+        'amount' => $this->debt->amount->minus(Money::of(5, 'GBP'))->getMinorAmount()->toInt(),
+        'group_user_id' => $this->group_user->id,
+    ]);
+
+    $this->assertDatabaseHas('shares', [
+        'id' => $this->share->id,
+        'group_user_id' => $this->share->group_user_id,
+        'debt_id' => $this->share->debt_id,
+        'amount' => 500,
+        'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
+    ]);
+});
+
 
 // test("user can delete a share for a debt they own", function() {
 //     $debt = Debt::factory()->withShares()->create([

--- a/tests/Feature/Http/Controllers/ShareControllerTest.php
+++ b/tests/Feature/Http/Controllers/ShareControllerTest.php
@@ -353,6 +353,30 @@ test('user can add a share to a split even debt they own, and the balance is rec
     }
 });
 
+test('user can not update the amount on a split even debt share', function() {
+    $debt = Debt::factory()->create([
+        'group_user_id' => $this->group_user->id,
+        'group_id' => $this->group->id,
+        'split_even' => 1,
+    ]);
+
+    $share = $debt->shares->where('group_user_id', $this->group_user->id)->first();
+
+    $response = $this->patch(route('share.update', $share), [
+        'id' => $share->id,
+        'name' => $share->name,
+        'amount' => $share->amount->getMinorAmount()->toInt() + 1000,
+    ]);
+
+    $response->assertStatus(302)
+        ->assertSessionHasErrors(['amount' => 'You do not have permission to update the amount of this share.']);
+    
+        $this->assertDatabaseHas('shares', [
+        'id' => $share->id,
+        'amount' => $share->amount->getMinorAmount()->toInt(),
+    ]);
+});
+
 
 // test("user can delete a share for a debt they own", function() {
 //     $debt = Debt::factory()->withShares()->create([

--- a/tests/Feature/Http/Controllers/ShareControllerTest.php
+++ b/tests/Feature/Http/Controllers/ShareControllerTest.php
@@ -377,6 +377,32 @@ test('user can not update the amount on a split even debt share', function() {
     ]);
 });
 
+test('user can delete a share in a split even debt they own and the debt total is unaffected', function() {
+    Share::factory()->create([
+        'debt_id' => $this->debt->id,
+        'group_user_id' => $this->group_user->id,
+        'amount' => 100,
+    ]);
+
+    $response = $this->delete(route('share.destroy', $this->debt->shares->last()));
+
+    $response->assertStatus(302)
+        ->assertSessionHas('status', 'Share deleted successfully.')
+        ->assertSessionHasNoErrors();
+
+    $this->assertDatabaseHas('debts', [
+        'id' => $this->debt->id,
+        'amount' => $this->debt->amount->getMinorAmount()->toInt() - 100,
+    ]);
+
+    $this->assertDatabaseHas('shares', [
+        'debt_id' => $this->debt->id,
+        'group_user_id' => $this->group_user->id,
+        'amount' => 100,
+        'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
+    ]);
+});
+
 
 // test("user can delete a share for a debt they own", function() {
 //     $debt = Debt::factory()->withShares()->create([

--- a/tests/Feature/Http/Controllers/ShareControllerTest.php
+++ b/tests/Feature/Http/Controllers/ShareControllerTest.php
@@ -406,7 +406,7 @@ test('user can delete a share in a split even debt they own and the debt total i
 /**
  * Tests for non-split (standard) debts
  * - Can add a share to a standard debt they own, balance is recalculated
- * - Can update a share of a standard debt they own, balance is recalculated
+ * - Can update the amount of a share of a standard debt they own, balance is recalculated
  * - Can delete a share of a standard debt they own, balance is recalculated
  */
 
@@ -438,7 +438,7 @@ test('user can add a share to a standard debt they own and the balance is recalc
     ]);
 });
 
-test('user can update a share of a standard debt they own and the balance is recalculated', function() {
+test('user can update the amount of a share of a standard debt they own and the balance is recalculated', function() {
     $response = $this->patch(route('share.update', $this->share), [
         'id' => $this->share->id,
         'name' => $this->share->name,
@@ -484,142 +484,5 @@ test('user can delete a share of a standard debt they own and the balance is rec
         'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
     ]);
 });
-
-
-// test("user can delete a share for a debt they own", function() {
-//     $debt = Debt::factory()->withShares()->create([
-//         'group_user_id' => $this->group_user->id,
-//         'group_id' => $this->group->id,
-//     ]);
-    
-//     // a share i don't own in a debt i do own
-//     $share = $debt->shares->reject(fn($share) => 
-//         $share->user_id === $this->user->id)->first();
-    
-//     // delete it
-//     $response = $this->delete(route('share.destroy', $share));
-
-//     $response->assertStatus(302)
-//         ->assertSessionHas('status', 'Share deleted successfully.')
-//         ->assertSessionHasNoErrors();;
-
-//     // confirm it's gone
-//     $this->assertDatabaseHas('shares', [
-//         'id' => $share->id,
-//         'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
-//     ]);
-
-//     $this->assertDatabaseHas('debts', [
-//         'id' => $debt->id,
-//         'amount' => ($debt->amount->minus($share->amount))->getMinorAmount()->toInt(),
-//     ]);
-// });
-
-// test("user can update the amount on a share for a debt they own", function() {
-//     $debt = Debt::factory()->withShares()->create([
-//         'group_user_id' => $this->group_user->id,
-//         'group_id' => $this->group->id,
-//         'split_even' => 0,
-//     ]);
-    
-//     $share = Share::factory()->create([
-//         'group_user_id' => $this->group_user->id,
-//         'debt_id' => $debt->id,
-//         'amount' => 500,
-//     ]);
-
-//     // the 'new' amount is basically what the user sees,
-//     // e..g if they add a fiver it's just 5
-//     $new = $share->amount->plus(Money::of(10, 'GBP'));
-
-//     $response = $this->patch(route('share.update', $share), [
-//         'id' => $share->id,
-//         'name' => $share->name,
-//         'debt_id' => $debt->id,
-//         // we have to do this weird thing as brick money deals in minor units
-//         // and does not make ints into decimals, only decimals into ints
-//         // so if new is 5.65, minorAmount gives us 565
-//         // then /100 to simulate user input of 5.65
-//         // as the casting is handled in Cash.php attribute cast
-//         'amount' => $new->getMinorAmount()->toInt() / 100
-//     ]);
-
-//     $response->assertStatus(302)
-//         ->assertSessionHas('status', 'Share updated successfully.')
-//         ->assertSessionHasNoErrors();
-
-
-//     $this->assertDatabaseHas('shares', [
-//         'id' => $share->id,
-//         'group_user_id' => $share->group_user_id,
-//         'amount' => $new->getMinorAmount()->toInt(),
-//     ]);
-
-//     $this->assertDatabaseHas('debts', [
-//         'id' => $debt->id,
-//         'amount' => $debt->amount->plus(Money::of(10, 'GBP'))->getMinorAmount()->toInt(),
-//     ]);
-// });
-
-// test("user can add a share for themselves for a debt they own", function() {
-//     $debt = Debt::factory()->withShares()->create([
-//         'group_user_id' => $this->group_user->id,
-//         'group_id' => $this->group->id,
-//         'split_even' => 0,
-//     ]);
-
-//     $response = $this->post(route('share.store'), [
-//         'debt_id' => $debt->id,
-//         'group_user_id' => $this->group_user->id,
-//         'amount' => 500,
-//         'name' => 'new share',
-//         'currency' => 'GBP',
-//     ]);
-
-//     $response->assertStatus(302)
-//         ->assertSessionHas('status', 'Share created successfully.')
-//         ->assertSessionHasNoErrors();
-
-//     $this->assertDatabaseHas('shares', [
-//         'debt_id' => $debt->id,
-//         'group_user_id' => $this->group_user->id,
-//         'amount' => 500 * 100,
-//     ]);
-// });
-
-// test("user can add a share for another user for a debt they own", function() {
-//     $debt = Debt::factory()->withShares()->create([
-//         'group_user_id' => $this->group_user->id,
-//         'group_id' => $this->group->id,
-//         'split_even' => 0,
-//     ]);
-
-//     $other_group_user = $debt->groupUsers->reject(fn($group_user) => 
-//         $group_user->id === $this->group_user->id)->first();
-
-//     $response = $this->post(route('share.store'), [
-//         'debt_id' => $debt->id,
-//         'group_user_id' => $other_group_user->id,
-//         'amount' => 750,
-//         'name' => 'new share for other user',
-//         'currency' => 'GBP',
-//     ]);
-
-//     $response->assertStatus(302)
-//         ->assertSessionHas('status', 'Share created successfully.')
-//         ->assertSessionHasNoErrors();
-
-//     $this->assertDatabaseHas('shares', [
-//         'debt_id' => $debt->id,
-//         'group_user_id' => $other_group_user->id,
-//         'amount' => 750 * 100,
-//     ]);
-// });
-
-
-// /**
-//  * these are all tests for functionality that by default, 
-//  * are hidden from users behind js on the Controls component
-//  */
 
 

--- a/tests/Feature/Http/Controllers/ShareControllerTest.php
+++ b/tests/Feature/Http/Controllers/ShareControllerTest.php
@@ -46,6 +46,7 @@ beforeEach(function () {
  * Tests for shared behaviours where the debt type is irrelevant
  * - Select 'sent' on own share
  * - Select 'seen' on own debt share that's not their share
+ * - Can not select 'seen' on a share they own that has not been sent
  * - Can not select 'sent' on a share they don't own
  * - Can not select 'seen' on a share they don't own
  * - Update name on own share
@@ -123,85 +124,56 @@ test('user can not select seen on a share they do not own', function() {
     ]);
 });
 
-// test("user can not select 'seen' on the share for a debt they do not own", function () {
-//     // a share i don't own, in a debt i don't own
-//     $debt = Debt::factory()->withShares()->create([
-//         'group_user_id' => $this->group_users->last()->id,
-//         'group_id' => $this->group->id,
-//     ]);
+test('user can not select seen on a share for a debt they own, but has not been sent', function() {
+    $share = $this->debt->shares->reject(fn($share) => 
+        $share->group_user_id === $this->group_user->id)->first();
 
-//     $share = $debt->shares->reject(fn($share) => 
-//         $share->user_id === $this->user->id)->first();
+    $share->sent = 0;
+    $share->save();
 
-//    // try to update it
-//     $response = $this->patch(route('share.seen', $share), [
-//         'id' => $share->id,
-//         'seen' => !$share->seen,
-//     ]);
+    $response = $this->patch(route('share.seen', $share), [
+        'id' => $share->id,
+        'seen' => !$share->seen,
+    ]);
 
-//     $response->assertStatus(302)
-//         ->assertSessionHasErrors(['seen' => "You do not have permission to update the 'seen' status of this share"]);
-//     // confirm original status
-//     $this->assertDatabaseHas('shares', [
-//         'id' => $share->id,
-//         'sent' => $share->sent,
-//     ]);
-// });
+    $response->assertStatus(302)
+        ->assertSessionHasErrors(['seen' => "You can not mark this share as seen becase it has not been sent yet"]);
 
-// test("user can not select 'seen' on a share that has not yet been sent", function() {
-//     $debt = Debt::factory()->withShares()->create([
-//         'group_user_id' => $this->group_user->id,
-//         'group_id' => $this->group->id,
-//     ]);
-    
-//     // get a share that's not mine
-//     $share = $debt->shares->reject(fn($share) => 
-//         $share->user_id === $this->user->id)->first();
+    $this->assertDatabaseHas('shares', [
+        'id' => $share->id,
+        'seen' => $share->seen,
+    ]);
+});
 
-//     // set it to not sent
-//     $share->sent = 0;
-//     $share->save();
+test('user can not select seen on a share they do own for a debt they do not own', function() {
+    $debt = Debt::factory()->withShares()->create([
+        'group_user_id' => $this->group_users->last()->id,
+        'group_id' => $this->group->id,
+    ]);
 
-//     // try to update it
-//     $response = $this->patch(route('share.seen', $share), [
-//         'id' => $share->id,
-//         'seen' => !$share->seen,
-//     ]);
+    $share = Share::factory()->create([
+        'group_user_id' => $this->group_user->id,
+        'debt_id' => $debt->id,
+        'amount' => 500,
+        'sent' => 1,
+    ]);
 
-//     // check correct response
-//     $response->assertStatus(302)
-//         ->assertSessionHasErrors(['seen' => "You can not mark this share as seen becase it has not been sent yet"]);
+    $response = $this->patch(route('share.seen', $share), [
+        'id' => $share->id,
+        'seen' => !$share->seen,
+    ]);
 
-//     // confirm original status
-//     $this->assertDatabaseHas('shares', [
-//         'id' => $share->id,
-//         'seen' => $share->seen,
-//     ]);
-// });
+    $response->assertStatus(302)
+        ->assertSessionHasErrors(['seen' => "You do not have permission to update the 'seen' status of this share"]);
 
-// test("user can not select 'seen' on a share they own", function() {
-//     $debt = Debt::factory()->withShares()->create([
-//         'group_user_id' => $this->group_users->last()->id,
-//         'group_id' => $this->group->id,
-//     ]);
-
-//     $share = $debt->shares->first();
-
-//     $response = $this->patch(route('share.seen', $share), [
-//         'id' => $share->id,
-//         'seen' => !$share->seen,
-//     ]);
-
-//     // check correct response
-//     $response->assertStatus(302)
-//         ->assertSessionHasErrors(['seen' => "You do not have permission to update the 'seen' status of this share"]);
-
-//     // confirm original status
-//     $this->assertDatabaseHas('shares', [
-//         'id' => $share->id,
-//         'seen' => $share->seen,
-//     ]);
-// });
+    $this->assertDatabaseHas('shares', [
+        'group_user_id' => $this->group_user->id,
+        'debt_id' => $debt->id,
+        'amount' => 500,
+        'sent' => 1,
+        'seen' => 0,
+    ]);
+});
 
 // test("user can delete a share for a debt they own", function() {
 //     $debt = Debt::factory()->withShares()->create([

--- a/tests/Feature/Http/Controllers/ShareControllerTest.php
+++ b/tests/Feature/Http/Controllers/ShareControllerTest.php
@@ -7,6 +7,7 @@ use App\Models\GroupUser;
 use App\Models\Share;
 use Carbon\Carbon;
 use Brick\Money\Money;
+use Illuminate\Database\Eloquent\Factories\Sequence;
 
 beforeEach(function () {
     $this->users = User::factory(10)->create();
@@ -50,12 +51,6 @@ beforeEach(function () {
  * - Can not select 'seen' on a share they don't own
  * - Can not select 'seen' on a share they own, but has not been sent
  * - Can not select 'seen' on a share they do own, for a debt they do not own
- * - Update name on own share
- * - Not update on name on share they don't own and a debt they don't own
- * - Update name on a share they don't own, but a debt they do own
- * - Can not add a share without an amount
- * - Can not add a share to a debt they do not own
- * - Can not delete a share for a debt they do not own
  */
 test('user can select sent on their own share', function() {
     $response = $this->patch(route('share.sent', $this->share), [
@@ -177,6 +172,16 @@ test('user can not select seen on a share they do own for a debt they do not own
         'seen' => 0,
     ]);
 });
+
+/**
+ * Tests for create/update/delete behaviours that are not sent/seen, type irrelevant:
+ * - Update name on own share
+ * - Not update on name on share they don't own and a debt they don't own
+ * - Update name on a share they don't own, but a debt they do own
+ * - Can not add a share without an amount
+ * - Can not add a share to a debt they do not own
+ * - Can not delete a share for a debt they do not own
+ */
 
 test('user can update the name of their own share', function() {
     $response = $this->patch(route('share.update', $this->share), [
@@ -301,6 +306,51 @@ test('user can not delete a share for a debt they do not own', function() {
         'debt_id' => $share->debt_id,
         'deleted_at' => null,
     ]);
+});
+
+/**
+ * Tests for split even
+ * - Can add split even debt share, does not recalc debt total
+ * - Can not update a split even debt share amount at all
+ * - Can delete split even debt share, does not recalc debt total
+ */
+
+test('user can add a share to a split even debt they own, and the balance is recalculated', function() {
+    $debt = Debt::factory()->create([
+        'group_user_id' => $this->group_user->id,
+        'group_id' => $this->group->id,
+        'split_even' => 1,
+    ]);
+
+    $response = $this->post(route('share.store'), [
+        'debt_id' => $debt->id,
+        'group_user_id' => $this->group_user->id,
+        'amount' => $debt->shares->first()->amount->getMinorAmount()->toInt(),
+        'name' => 'new split even share',
+        'currency' => 'GBP',
+    ]);
+
+    $response->assertStatus(302)
+        ->assertSessionHas('status', 'Share created successfully.')
+        ->assertSessionHasNoErrors();
+
+    $splits = Debt::findOrFail($debt->id)->amount
+        ->split($debt->fresh()->shares->count());
+
+    $this->assertDatabaseHas('debts', [
+        'id' => $debt->id,
+        'group_user_id' => $this->group_user->id,
+        'group_id' => $this->group->id,
+        'split_even' => 1,
+    ]);
+
+    foreach ($splits as $key => $split) {
+        $this->assertDatabaseHas('shares', [
+            'debt_id' => $debt->id,
+            'group_user_id' => $this->group_user->id,
+            'amount' => $split->getMinorAmount()->toInt(),
+        ]);
+    }
 });
 
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -49,7 +49,6 @@ function something()
 }
 
 /**
- * Used in all non-split even debt tests.
  * Pick some random users.
  * Create 'cuts' (milestones) of which value to cut the debt at,
  * e.g. on the way to 10000, you may cut at 2932, 4893, 4934 and 8752.
@@ -65,30 +64,40 @@ function something()
  * 
  * @param \Illuminate\Database\Eloquent\Collection $group_users
  * @param int $debt_total
+ * @param bool $split_even
+ * @return array
  */
-function selectRandomGroupUsers($group_users, $debt_total) {
+function selectRandomGroupUsers($group_users, $debt_total, $split_even) {
     
     $group_users = $group_users->random(rand(2, $group_users->count()));
-    $cuts = [];
-
-    for ($i = 0; $i < $group_users->count() - 1; $i++) {
-        $cuts[] = rand(1, $debt_total - 1); 
-    }
-
-    sort($cuts);
-    $points = array_merge([0], $cuts, [$debt_total]);
     $shares = [];
 
-    for ($i = 0; $i < $group_users->count(); $i++) {
-        $minor_units = $points[$i + 1] - $points[$i];
-        $shares[] = Money::of($minor_units, 'GBP');
+    if ($split_even) {
+        $shares = Money::of($debt_total, 'GBP')->split($group_users->count());
+    } else {
+        $cuts = [];
+
+        for ($i = 0; $i < $group_users->count() - 1; $i++) {
+            $cuts[] = rand(1, $debt_total - 1); 
+        }
+
+        sort($cuts);
+        $points = array_merge([0], $cuts, [$debt_total]);
+
+
+        for ($i = 0; $i < $group_users->count(); $i++) {
+            $minor_units = $points[$i + 1] - $points[$i];
+            $shares[] = Money::of($minor_units, 'GBP');
+        }
     }
 
-    $group_user_shares = $group_users->map(function ($group_user, $key) use ($shares) {
-        return [
+    $group_user_shares = $group_users->map(function ($group_user, $key) use ($shares, $split_even) {
+
+    // for some reason, using a money object here strips it in the share service
+    return [
             'group_user_id' => $group_user->id,
             'name'    => 'share for user ' . $group_user->id,
-            'amount'        => $shares[$key]->getAmount(),
+            'amount'        => $split_even ? $shares[$key]->getAmount()->toInt() : $shares[$key]->getAmount(),
             'user_name'     => $group_user->user->name,
         ];
     });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -97,7 +97,7 @@ function selectRandomGroupUsers($group_users, $debt_total, $split_even) {
     return [
             'group_user_id' => $group_user->id,
             'name'    => 'share for user ' . $group_user->id,
-            'amount'        => $split_even ? $shares[$key]->getAmount()->toInt() : $shares[$key]->getAmount(),
+            'amount'        => $split_even ? $shares[$key]->getMinorAmount()->toInt() : $shares[$key]->getMinorAmount(),
             'user_name'     => $group_user->user->name,
         ];
     });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -87,7 +87,7 @@ function selectRandomGroupUsers($group_users, $debt_total) {
     $group_user_shares = $group_users->map(function ($group_user, $key) use ($shares) {
         return [
             'group_user_id' => $group_user->id,
-            'share_name'    => 'share for user ' . $group_user->id,
+            'name'    => 'share for user ' . $group_user->id,
             'amount'        => $shares[$key]->getAmount(),
             'user_name'     => $group_user->user->name,
         ];

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -92,14 +92,13 @@ function selectRandomGroupUsers($group_users, $debt_total, $split_even) {
     }
 
     $group_user_shares = $group_users->map(function ($group_user, $key) use ($shares, $split_even) {
-
-    // for some reason, using a money object here strips it in the share service
-    return [
-            'group_user_id' => $group_user->id,
-            'name'    => 'share for user ' . $group_user->id,
-            'amount'        => $split_even ? $shares[$key]->getMinorAmount()->toInt() : $shares[$key]->getMinorAmount(),
-            'user_name'     => $group_user->user->name,
-        ];
+        // for some reason, using a money object here strips it in the share service
+        return [
+                'group_user_id' => $group_user->id,
+                'name'    => 'share for user ' . $group_user->id,
+                'amount'        => $shares[$key]->getMinorAmount()->toInt(),
+                'user_name'     => $group_user->user->name,
+            ];
     });
 
     return $group_user_shares->toArray();


### PR DESCRIPTION
Following the changes from #53, #54 and #55, it's time to rewrite the test suite for debts/shares/user balance. Tests will now be grouped by debt type (standard/split even):

### Debts:

#### Shared behaviour: - done
- index & pagination
- update name (owned)
- update name (not owned)
- delete (owned)
- delete (not owned)

#### Behaviours to do with adding, but the type is irrelevant: - done
- adding debt with no group
- adding debt with no name
- adding a debt with a name longer than 25 characters
- adding debt with no currency
- adding debt with no owner
- adding debt with no shares
- adding a debt that sums to zero
- adding a debt that with no amount
- add a debt for a group they don't belong to

#### Split even - done
- add split
- update amount (owned)

#### Standard - done
- add standard
- update amount (owned)

So in short, the only difference in behaviour lies in whether or not an updated debt is split or standard. As these are the only operations that are for debts, things like "debt amount updates when adding a split even share" will be in the share tests, same for total balance tests.

Tests around ledger entries will be in another PR as there's more work to do around improving them. mostly adding some variance to the types of ledger entry. 

### Shares:

#### Shared sent/seen behaviour, type irrelevant: 
- select 'sent' on own share
- select 'seen' on own debt share
- can not select 'seen' on a debt share they own, that has not been sent
- not select 'sent' on a share they don't own
- not select 'seen' on a share they don't own
- not select 'seen' on a share they do own, for a debt they do

#### Shared behaviours around create/update/delete, type irrelevant:
- update name on own share
- not update name on a share they don't own
- can update name on a share they don't own, but a debt they do
- not add a share without an amount
- not add a share for a debt they do not own
- delete a share for a debt they do not own
- can update amount on own share for an owned debt
- can update amount on not owned share for an owned debt
- can not update amount on not owned share for not owned debt

#### Split even
- adding split debt share does not recalc debt amount, but recalcs share amounts
- updating split share is not allowed at all
- deleting split debt share does not recalc debt amount, but recalcs share amounts

#### Standard
- adding a standard debt share recalcs debt amount
- updating standard debt share reclacs debt amount
- deleting a standard debt share recalcs debt amount

### Extras:
- Ledger entry relationships, though this was added prematurely.
- Changed randomness in `withComments()` to 1,5 from 0,5 as 'with comments' should apply at least one comment.
- `selectRandomGroupUsers()` can now be used for split debts rather than just standard ones.
- Generic `update` method added to `SharePolicy` for readability.
- Reworked logic in `SharePolicy` `updateAmount` method.
- `afterCreating()` method added to debt factory so at least one share is always added. 
- Small frontend cleanups. 

### Bugfixes:
- Added a forgotten `.amount` onto a prop when updating debt amounts.
- Added a forgotten `.amount` onto a prop when updating share amounts.
- Added a ternary operator in the update share form to fix share amount not being populated into the form as the v-if on split event stops it rendering.
- Changed a forgotten `user_id` to `group_user_id` on the picker, and added margin for the error message.