### PR TITLE
Small Tune Ups

### DIFF
--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -34,7 +34,6 @@ class DebtController extends Controller
                         $query->where('user_id', $user->id);
                     })
                     ->distinct()
-                    ->orderBy('id', 'DESC')
                     ->latest()
                     ->with([
                         'shares.groupUser.user:id,name',

--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -34,6 +34,7 @@ class DebtController extends Controller
                         $query->where('user_id', $user->id);
                     })
                     ->distinct()
+                    ->orderBy('id', 'DESC')
                     ->latest()
                     ->with([
                         'shares.groupUser.user:id,name',

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -18,23 +18,22 @@ class GroupController extends Controller
      */
     public function index(Request $request)
     {
-        $groups = Inertia::scroll(fn () =>
-            GroupResource::collection(
-                Group::where('user_id', $request->user()->id)
-                    ->orWhereHas('groupUsers', function ($query) use ($request) {
-                        $query->where('user_id', $request->user()->id);
-                    })
-                    ->with([
-                        'groupUsers.user',
-                        'groupUsers.aliases',
-                    ])
-                    ->paginate(10)
-                )
-            );
-
         return Inertia::render('Groups', [
-            'groups' => $groups,
             'status' => $request->session()->get('status') ?? null,
+            'groups' => Inertia::scroll(fn () =>
+                GroupResource::collection(
+                    Group::where('user_id', $request->user()->id)
+                        ->orWhereHas('groupUsers', function ($query) use ($request) {
+                            $query->where('user_id', $request->user()->id);
+                        })
+                        ->latest()
+                        ->with([
+                            'groupUsers.user',
+                            'groupUsers.aliases',
+                        ])
+                        ->paginate(10)
+                    )
+                ),
         ]);
     }
 

--- a/app/Services/ShareService.php
+++ b/app/Services/ShareService.php
@@ -46,7 +46,6 @@ class ShareService
      */
     public function createSingleShare($debt, $share_data): Share
     {
-        dump($debt->shares);
         $share = $this->createShare($debt, $share_data);
         
         if ($debt->split_even->value) {

--- a/resources/js/Components/Comments/Comment.vue
+++ b/resources/js/Components/Comments/Comment.vue
@@ -37,7 +37,7 @@ onMounted(() => {
 
 </script>
 <template>
-    <div class="flex flex-col my-2 bg-gray-100" style="border-radius:15px;padding:10px">
+    <div class="flex flex-col m-2 bg-gray-100" style="border-radius:15px;padding:10px">
         <!-- picture, name, controls-->
         <div class="flex flex-row w-full justify-between">
             <div class="flex flex-row">

--- a/resources/js/Components/Debts/Debt.vue
+++ b/resources/js/Components/Debts/Debt.vue
@@ -39,12 +39,13 @@ const debtCurrency = computed(() => {
  * then edits the value of the debt, rather than adding a share.
  */
 const debtDiscrepancy = computed(() => {
-    const total = props.debt.shares.reduce((total, share) => total + Number(share.amount.amount), 0);
-    const amountString = Math.round((props.debt.amount.amount - total) * 100).toString();
-    const pounds = amountString.slice(0, -2);
-    const pence = amountString.slice(-2);
+    const total = Math.round(props.debt.shares.reduce((total, share) => total + Number(share.amount.amount), 0) * 100, 2);
+    const discrepancy = (total - Math.round((props.debt.amount.amount * 100))).toString();
+    
+    const pounds = discrepancy.slice(0, -2);
+    const pence = discrepancy.slice(-2);
 
-    return `${pounds}.${pence}`;
+    return discrepancy == 0 ? '' : `${pounds}.${pence}`;
 });
 
 /**

--- a/resources/js/Components/Debts/Debt.vue
+++ b/resources/js/Components/Debts/Debt.vue
@@ -40,7 +40,11 @@ const debtCurrency = computed(() => {
  */
 const debtDiscrepancy = computed(() => {
     const total = props.debt.shares.reduce((total, share) => total + Number(share.amount.amount), 0);
-    return Math.round((props.debt.amount.amount - total) * 100);
+    const amountString = Math.round((props.debt.amount.amount - total) * 100).toString();
+    const pounds = amountString.slice(0, -2);
+    const pence = amountString.slice(-2);
+
+    return `${pounds}.${pence}`;
 });
 
 /**
@@ -50,10 +54,6 @@ const debtDiscrepancy = computed(() => {
 const debtOwnerHasNoShare = computed(() => {
     return !props.debt.shares.map((share) => share.group_user_id).includes(props.debt.group_user_id);
 });
-
-onMounted(() => {
-
-})
 
 </script>
 

--- a/resources/js/Components/Invites/InviteToGroup.vue
+++ b/resources/js/Components/Invites/InviteToGroup.vue
@@ -92,7 +92,7 @@ function removeRecipient(emailAddress) {
                     :action="route('invite.send')" 
                     method="post" 
                     #default="{ errors }"
-                    @success="openModal = false;"
+                    @success="recipients = []; openModal = false;"
                     resetOnSuccess
                     :transform="data => ({ 
                         ...data, 

--- a/resources/js/invite.js
+++ b/resources/js/invite.js
@@ -1,6 +1,0 @@
-// import { reactive } from 'vue';
-
-// export const invite = reactive({
-//     recipients: [],
-//     body: '',
-// });


### PR DESCRIPTION
Raising a PR to cover a few minor tune-ups before presentation.

- Added `latest()` to the group index query so new groups appear at the top, also removed the setting of $groups as a variable.
- Removed pointless setting of `$groups` in group controller
- (finally) Fixed discrepancies so they actually appear as pounds & pence, though they need a rework. Issues with adding & removing shares, noted.
- Margin adjustment on comments.
- Reset recipients array in invite modal after successful invite send.
- Remove defunct invite store