### PR TITLE
Adding DB::transaction() to service layer db interactions

### DIFF
--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -28,9 +28,9 @@ class GroupController extends Controller
                         })
                         ->latest()
                         ->with([
-                            'groupUsers.user',
-                            'groupUsers.aliases',
-                        ])
+                            'groupUsers' => fn($query)
+                                => $query->with(['user', 'aliases'])
+                            ])
                         ->paginate(10)
                     )
                 ),

--- a/app/Http/Controllers/ShareController.php
+++ b/app/Http/Controllers/ShareController.php
@@ -45,9 +45,7 @@ class ShareController extends Controller
             return redirect()->route('debt.index')->withErrors(['debt_id' => 'You do not have permission to add a share to this debt.']);
         }
 
-        DB::transaction( function () use ($validated, $debt, $shareService) {
-            return $shareService->createSingleShare($debt, $validated);
-        });
+        $shareService->createSingleShare($debt, $validated);
 
         // eventually dispatch event, notif etc
         
@@ -98,9 +96,7 @@ class ShareController extends Controller
             default:
                 $validated = $request->validated();
 
-                DB::transaction( function () use ($validated, $share, $shareService) { 
-                    $shareService->updateSingleShare($share, $validated);
-                });
+                $shareService->updateSingleShare($share, $validated);
 
                 return redirect()
                     ->route('debt.index')
@@ -123,9 +119,7 @@ class ShareController extends Controller
 
         $validated = $request->validated();
 
-        DB::transaction( function () use ($share, $shareService, $validated) {
-            $shareService->updateSentStatus($share, $validated['sent']);
-        });
+        $shareService->updateSentStatus($share, $validated['sent']);
 
         return redirect()->route('debt.index');
     }
@@ -155,9 +149,7 @@ class ShareController extends Controller
         
         $validated = $request->validated();
 
-        DB::transaction( function () use ($share, $shareService, $validated) {
-            $shareService->updateSeenStatus($share, $validated['seen']);
-        });
+        $shareService->updateSeenStatus($share, $validated['seen']);
 
         return redirect()->route('debt.index');
     }
@@ -174,9 +166,7 @@ class ShareController extends Controller
                 ]);
         }
 
-        DB::transaction( function () use ($share, $shareService) {
-            $shareService->deleteShare($share);
-        });
+        $shareService->deleteShare($share);
 
         return redirect()
             ->route('debt.index')

--- a/app/Services/DebtService.php
+++ b/app/Services/DebtService.php
@@ -119,8 +119,9 @@ class DebtService
      */
     public function deleteDebt($debt): mixed
     {
+        $this->shareService->deleteShares($debt);
+
         return DB::transaction(function () use ($debt) {
-            $this->shareService->deleteShares($debt);
             $debt->delete();
         });
     }

--- a/app/Services/DebtService.php
+++ b/app/Services/DebtService.php
@@ -22,6 +22,7 @@ class DebtService
 
     /**
      * For the purpose of creating a single debt with shares, the more complex logic of share creation during debt creation is handled in the service layer to avoid bloating the controller. The same applies for updating a debt with shares.
+     * 
      * @param Group $group
      * @param array $data
      * @return Debt
@@ -48,6 +49,7 @@ class DebtService
     /**
      * For the purpose of updating a debt,
      * only called when the debt itself is being directly updated,
+     * 
      * not when a share being updated then updates a debt.
      * @param Debt $debt
      * @param array $data
@@ -70,38 +72,44 @@ class DebtService
 
     /**
      * For just updating the debt name.
+     * 
      * @param Debt $debt
      * @param string $name
      * @return Debt
      */
     public function updateDebtName($debt, $name): Debt
     {
-        $debt->update([
-            'name' => $name,
-        ]);
+        return DB::transaction(function () use ($debt, $name) {
+            $debt->update([
+                'name' => $name,
+            ]);
 
-        return $debt;
+            return $debt;
+        });
     }
 
     /**
      * For updating the debt amount.
      * If it's a split debt, shares are recalculated after the amount has been set.
      * Otherwise, the amont just gets updated and the frontend shows a discrepancy.
+     * 
      * @param Debt $debt
      * @param int $amount
      * @return Debt
      */
     public function updateDebtAmount($debt, $amount): Debt
     {
-        $debt->update([
-            'amount' => $amount,
-        ]);
+        return DB::transaction(function () use ($debt, $amount) {
+            $debt->update([
+                'amount' => $amount,
+            ]);
 
-        if ($debt->split_even->value) {
-            $this->shareService->updateShares($debt);
-        }
+            if ($debt->split_even->value) {
+                $this->shareService->updateShares($debt);
+            }
 
-        return $debt;
+            return $debt;
+        });
     }
 
     /**

--- a/app/Services/LedgerService.php
+++ b/app/Services/LedgerService.php
@@ -19,21 +19,25 @@ class LedgerService
      */
     public function createShareLedgerEntry(Share $share): void
     {
-        LedgerEntry::create([
-            'share_id' => $share->id,
-            'user_id' => $share->debt->groupUser->user->id,
-            'amount' => $share->amount,
-            'type' => LedgerEntryType::DEBT_OWNERSHIP_CREATED,
-        ]);
+        DB::transaction( function () use ($share) {
+            LedgerEntry::create([
+                'share_id' => $share->id,
+                'user_id' => $share->debt->groupUser->user->id,
+                'amount' => $share->amount,
+                'type' => LedgerEntryType::DEBT_OWNERSHIP_CREATED,
+            ]);
+        });
 
         $this->updateUserBalance($share->debt->groupUser->user->id, $share->amount);
 
-        LedgerEntry::create([
-            'share_id' => $share->id,
-            'user_id' => $share->groupUser->user->id,
-            'amount' => $share->amount->negated(),
-            'type' => LedgerEntryType::SHARE_CREATED,
-        ]);
+        DB::transaction( function () use ($share) {
+            LedgerEntry::create([
+                'share_id' => $share->id,
+                'user_id' => $share->groupUser->user->id,
+                'amount' => $share->amount->negated(),
+                'type' => LedgerEntryType::SHARE_CREATED,
+            ]);
+        });
 
         $this->updateUserBalance($share->groupUser->user->id, $share->amount->negated());
     }
@@ -54,21 +58,25 @@ class LedgerService
             $difference = $share->amount;
         }
 
-        LedgerEntry::create([
-            'share_id' => $share->id,
-            'user_id' => $share->debt->groupUser->user->id,
-            'amount'  => $difference,
-            'type'    => LedgerEntryType::DEBT_OWNERSHIP_UPDATED,
-        ]);
+        DB::transaction( function () use ($share, $difference) {
+            LedgerEntry::create([
+                'share_id' => $share->id,
+                'user_id' => $share->debt->groupUser->user->id,
+                'amount'  => $difference,
+                'type'    => LedgerEntryType::DEBT_OWNERSHIP_UPDATED,
+            ]);
+        });
 
         $this->updateUserBalance($share->debt->groupUser->user->id, $difference);
 
-        LedgerEntry::create([
-            'share_id' => $share->id,
-            'user_id' => $share->groupUser->user->id,
-            'amount'  => $difference->negated(),
-            'type'    => LedgerEntryType::SHARE_UPDATED,
-        ]);
+        DB::transaction( function () use ($share, $difference) {
+            LedgerEntry::create([
+                'share_id' => $share->id,
+                'user_id' => $share->groupUser->user->id,
+                'amount'  => $difference->negated(),
+                'type'    => LedgerEntryType::SHARE_UPDATED,
+            ]);
+        });
 
         $this->updateUserBalance($share->groupUser->user->id, $difference->negated());
     }
@@ -81,21 +89,25 @@ class LedgerService
      */
     public function deleteShareLedgerEntry(Share $share): void
     {
-        LedgerEntry::create([
-            'share_id' => $share->id,
-            'user_id' => $share->debt->groupUser->user->id,
-            'amount' => $share->amount->negated(),
-            'type' => LedgerEntryType::DEBT_OWNERSHIP_DELETED,
-        ]);
+        DB::transaction( function () use ($share) {
+            LedgerEntry::create([
+                'share_id' => $share->id,
+                'user_id' => $share->debt->groupUser->user->id,
+                'amount' => $share->amount->negated(),
+                'type' => LedgerEntryType::DEBT_OWNERSHIP_DELETED,
+            ]);
+        });
 
         $this->updateUserBalance($share->debt->groupUser->user->id, $share->amount->negated());
 
-        LedgerEntry::create([
-            'share_id' => $share->id,
-            'user_id' => $share->groupUser->user->id,
-            'amount' => $share->amount,
-            'type' => LedgerEntryType::SHARE_DELETED,
-        ]);
+        DB::transaction( function () use ($share) {
+            LedgerEntry::create([
+                'share_id' => $share->id,
+                'user_id' => $share->groupUser->user->id,
+                'amount' => $share->amount,
+                'type' => LedgerEntryType::SHARE_DELETED,
+            ]);
+        });
 
         $this->updateUserBalance($share->groupUser->user->id, $share->amount);
     }
@@ -109,8 +121,10 @@ class LedgerService
      */
     private function updateUserBalance(int $user_id, Money $amount): void
     {
-        DB::table('users')
-            ->where('id', $user_id)
-            ->increment('balance', $amount->getMinorAmount()->toInt());
+        DB::transaction( function () use ($user_id, $amount) {
+            DB::table('users')
+                ->where('id', $user_id)
+                ->increment('balance', $amount->getMinorAmount()->toInt());
+        });
     }
 }

--- a/app/Services/ShareService.php
+++ b/app/Services/ShareService.php
@@ -7,6 +7,7 @@ use App\Models\Debt;
 use App\Models\GroupUser;
 use App\Services\LedgerService;
 use Brick\Money\Money;
+use Illuminate\Support\Facades\DB;
 
 class ShareService
 {
@@ -51,9 +52,11 @@ class ShareService
         if ($debt->split_even->value) {
             $this->updateShares($debt);
         } else {
-            $debt->update([
-                'amount' => $debt->amount->plus($share->amount),
-            ]);
+            DB::transaction( function () use ($debt, $share) {
+                $debt->update([
+                    'amount' => $debt->amount->plus($share->amount),
+                ]);
+            });
         }
 
         return $share;
@@ -69,17 +72,16 @@ class ShareService
      */
     private function createShare($debt, $share_data): Share
     {
-        // todo: see if there's a better way to do this without query
-        $share_user_id = GroupUser::findOrFail($share_data['group_user_id'])->user_id;
-
-        $share = Share::create([
-            'debt_id' => $debt->id,
-            'group_user_id' => $share_data['group_user_id'],
-            'name' => $share_data['name'],
-            'amount' => $share_data['amount'],
-            'sent' => $debt->groupUser->user->id === $share_user_id ? 1 : 0,
-            'seen' => $debt->groupUser->user->id === $share_user_id ? 1 : 0,
-        ]);
+        $share = DB::transaction( function () use ($debt, $share_data) {
+            return Share::create([
+                'debt_id' => $debt->id,
+                'group_user_id' => $share_data['group_user_id'],
+                'name' => $share_data['name'],
+                'amount' => $share_data['amount'],
+                'sent' => $debt->groupUser->id === $share_data['group_user_id'] ? 1 : 0,
+                'seen' => $debt->groupUser->id === $share_data['group_user_id'] ? 1 : 0,
+            ]);
+        });
 
         $this->ledgerService->createShareLedgerEntry($share);
 
@@ -125,9 +127,11 @@ class ShareService
         $original_amount = $share->amount;
         $difference = Money::ofMinor($data['amount'], $share->debt->currency)->minus($original_amount);
 
-        $share->debt->update([
+        DB::transaction( function () use ($share, $difference) {
+            $share->debt->update([
                 'amount' => $share->debt->amount->plus($difference),
             ]);
+        });
 
         $share = $this->updateShare($share, $data);
 
@@ -147,7 +151,7 @@ class ShareService
         if ($share->name !== $data['name']) {
             $share = $this->updateShareName($share, $data['name']);
         };
-  
+
         if ($share->amount->getMinorAmount()->toInt() !== $data['amount']) {
             $share = $this->updateShareAmount($share, $data['amount']);
         };
@@ -164,10 +168,12 @@ class ShareService
      */
     private function updateShareName(Share $share, string $name): Share
     {
-        $share->update([
-            'name' => $name,
-        ]);
-
+        DB::transaction( function () use ($share, $name) {
+            $share->update([
+                'name' => $name,
+            ]);
+        });
+ 
         return $share;
     }
 
@@ -187,9 +193,11 @@ class ShareService
 
         $this->ledgerService->updateShareLedgerEntry($share, $amount);
 
-        $share->update([
-            'amount' => $amount,
-        ]);
+        DB::transaction( function () use ($share, $amount) {
+            $share->update([
+                'amount' => $amount,
+            ]);
+        });
 
         return $share;
     }
@@ -217,9 +225,11 @@ class ShareService
             $this->ledgerService->createShareLedgerEntry($share);
         }
 
-        $share->update([
-            'sent' => $sent,
-        ]);
+        DB::transaction( function () use ($share, $sent) {
+            $share->update([
+                'sent' => $sent,
+            ]);
+        });
 
         return $share;
     }
@@ -234,9 +244,11 @@ class ShareService
      */
     public function updateSeenStatus(Share $share, $seen): Share
     {
-        $share->update([
-            'seen' => $seen,
-        ]);
+        DB::transaction( function () use ($share, $seen) {
+            $share->update([
+                'seen' => $seen,
+            ]);
+        });
 
         return $share;
     }
@@ -258,7 +270,10 @@ class ShareService
     {
         foreach ($debt->shares as $share) {
             $this->ledgerService->deleteShareLedgerEntry($share);
-            $share->delete();
+
+            DB::transaction( function () use ($share) {
+                $share->delete();
+            });
         }
     }
 
@@ -279,13 +294,21 @@ class ShareService
         $this->ledgerService->deleteShareLedgerEntry($share);
 
         if ($share->debt->split_even->value) {
-            $share->delete();
+            DB::transaction( function () use ($share) {
+                $share->delete();
+            });
+
             $this->updateShares($share->debt);
         } else {
-            $share->debt->update([
-                'amount' => $share->debt->amount->minus($share->amount),
-            ]);
-            $share->delete();
+            DB::transaction( function () use ($share) {
+                $share->debt->update([
+                    'amount' => $share->debt->amount->minus($share->amount),
+                ]);
+            });
+
+            DB::transaction( function () use ($share) {
+                $share->delete();
+            });
         }
     }
 }


### PR DESCRIPTION
PR raised to wrap debt/share/ledger services in `DB::transaction()` as it supposedly does cascade down (previously everything was wrapped in 1 transaction at a controller level) though this is meant to be safer. 

Also added a minor refactor of the group controller index method. Tested it with over 1000 groups in query and reduced time from ~250ms to ~210ms, real world scenario is stil unlikely that someone would make 1000 groups. Would also archive groups over 1yr old. 