### PR TITLE
Refactor debts index query

### DIFF
--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -29,11 +29,7 @@ class DebtController extends Controller
             DebtResource::collection(
                 // query builder to get the debts where the user is the owner
                 // or has a share in the debt via group_user
-                Debt::whereIn('group_user_id', $user->groupUsers->pluck('id')->toArray())
-                    ->orWhereHas('shares.groupUser', function ($query) use ($user) {
-                        $query->where('user_id', $user->id);
-                    })
-                    ->distinct()
+                Debt::involved($user)
                     ->latest()
                     ->with([
                         'shares.groupUser.user:id,name',

--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -25,21 +25,6 @@ class DebtController extends Controller
     {
         $user = $request->user();
 
-        Inertia::scroll(fn() =>
-            DebtResource::collection(
-                // query builder to get the debts where the user is the owner
-                // or has a share in the debt via group_user
-                Debt::involved($user)
-                    ->latest()
-                    ->with([
-                        'shares.groupUser.user:id,name',
-                        'comments.groupUser.user:id,name',
-                        'group.groupUsers.user',
-                    ])
-                    ->paginate(10)
-            )
-        );
-
         return Inertia::render('Debts', [
             'status' => $request->session()->get('status') ?? null,
             'groups' => GroupResource::collection(

--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -25,7 +25,7 @@ class DebtController extends Controller
     {
         $user = $request->user();
 
-        $debts = Inertia::scroll(fn() => 
+        Inertia::scroll(fn() =>
             DebtResource::collection(
                 // query builder to get the debts where the user is the owner
                 // or has a share in the debt via group_user
@@ -40,17 +40,26 @@ class DebtController extends Controller
             )
         );
 
-        $groups = GroupResource::collection(
-            $request->user()
-                ->groups()
-                ->with('groupUsers.user')
-                ->get()
-        );
-            
         return Inertia::render('Debts', [
-            'groups' => $groups,
-            'debts' => $debts,
             'status' => $request->session()->get('status') ?? null,
+            'groups' => GroupResource::collection(
+                $request->user()
+                    ->groups()
+                    ->with('groupUsers.user')
+                    ->get()
+            ),
+            'debts' => Inertia::scroll(fn() =>
+                DebtResource::collection(
+                    Debt::involved($user)
+                        ->latest()
+                        ->with([
+                            'shares.groupUser.user:id,name',
+                            'comments.groupUser.user:id,name',
+                            'group.groupUsers.user',
+                        ])
+                        ->paginate(10)
+                )
+            ),
         ]);
     }
 

--- a/app/Models/Debt.php
+++ b/app/Models/Debt.php
@@ -112,7 +112,7 @@ class Debt extends Model
     }
 
     /**
-     * Scope to inclue all the debts a user is involed in:
+     * Scope to include all the debts a user is involed in:
      * - Debts they are the owner of, with or without a share.
      * - Debts they have a share in.
      */

--- a/app/Models/Debt.php
+++ b/app/Models/Debt.php
@@ -12,6 +12,8 @@ use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use App\Casts\Cash;
 use App\Enums\DebtType;
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
 
 class Debt extends Model
 {
@@ -107,5 +109,18 @@ class Debt extends Model
             Share::class,
             'debt_id',  
         );
+    }
+
+    /**
+     * Scope to inclue all the debts a user is involed in:
+     * - Debts they are the owner of, with or without a share.
+     * - Debts they have a share in.
+     */
+    #[Scope]
+    protected function involved(Builder $query, User $user): void
+    {
+        $query->whereIn('group_user_id', $user->groupUsers->pluck('id'))
+            ->orWhereHas('shares', fn($q) => $q->whereIn('group_user_id', $user->groupUsers->pluck('id')))
+            ->distinct();
     }
 }

--- a/resources/js/Components/Debts/Debt.vue
+++ b/resources/js/Components/Debts/Debt.vue
@@ -50,7 +50,7 @@ const debtDiscrepancy = computed(() => {
 
 /**
  * If the debt owner doesn't have a share but recorded the debt, they are owed all of it.
- * Using this computer property, we can show a plate that does nothing, for clarity.
+ * Using this computed property, we can show a plate that does nothing, for clarity.
  */
 const debtOwnerHasNoShare = computed(() => {
     return !props.debt.shares.map((share) => share.group_user_id).includes(props.debt.group_user_id);


### PR DESCRIPTION
The aim of this PR is to refactor the debts controller index query, as when querying larger datasets (1k+ debts & groups), it was taking several seconds. 

After learning about scoped queries, I've moved the bulk of the query into a scoped query on the debts model, called `involved`. This is where, with a `$user` parameter, we'll find all the group users of the logged in user and retrieve the debts they own, as well as the debts where they have a share. As a while ago I changed uses of `user_id` to `group_user_id` for debts, shares etc the query has been refactored to only query the shares of debts, rather than the, previously necessary, shares.groupUser relationship. When trying this with larger datasets, the debts page load times have gone from ~2000ms to <200ms, similar to the groups page.