### PR TITLE
Balancing issues on group user deletion

### DIFF
--- a/app/Events/UserBalanceUpdated.php
+++ b/app/Events/UserBalanceUpdated.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Brick\Money\Money;
+
+class UserBalanceUpdated implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public int $userId, 
+        public Money $amount
+    ) {}
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, \Illuminate\Broadcasting\Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel("App.Models.User.Balance.{$this->userId}"),
+        ];
+    }
+}

--- a/app/Http/Controllers/GroupUserController.php
+++ b/app/Http/Controllers/GroupUserController.php
@@ -97,9 +97,9 @@ class GroupUserController extends Controller
             foreach ($groupUser->shares as $share) {
                 $shareService->deleteShare($share);
             }
-
-            $groupUser->delete();
         });
+
+        $groupUser->delete();
 
         return redirect()->route('group.index')->with('status', 'Group User deleted successfully.');
     }

--- a/app/Http/Controllers/GroupUserController.php
+++ b/app/Http/Controllers/GroupUserController.php
@@ -7,6 +7,8 @@ use App\Models\GroupUser;
 use App\Models\Group;
 use Dotenv\Validator;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\DB;
+use App\Services\ShareService;
 
 class GroupUserController extends Controller
 {
@@ -70,13 +72,15 @@ class GroupUserController extends Controller
      * If the user is removing themselves from a group & owns the group, allocate the selected
      * user id as group owner.
      */
-    public function destroy(Request $request, GroupUser $group_user): RedirectResponse
+    public function destroy(Request $request, GroupUser $groupUser, ShareService $shareService): RedirectResponse
     {
-        if ($request->user()->cannot('delete', $group_user)) {
-            return redirect()->route('group.index')->withErrors(['id' => 'You do not have permission to delete this group user.']);
+        if ($request->user()->cannot('delete', $groupUser)) {
+            return redirect()->route('group.index')->withErrors([
+                'id' => 'You do not have permission to delete this group user.'
+            ]);
         }
         
-        if ($group_user->user->id === $group_user->group->user_id && $request->user()->can('delete', $group_user->group)) {
+        if ($groupUser->user->id === $groupUser->group->user_id && $request->user()->can('delete', $groupUser->group)) {
             $validated = $request->validate(
                 ['new_owner_group_user_id' => 'required|exists:group_users,id'],
                 ['new_owner_group_user_id.required' => 'Please select a new group owner before leaving the group'],
@@ -84,12 +88,18 @@ class GroupUserController extends Controller
 
             $new_user = GroupUser::findOrFail($validated['new_owner_group_user_id']);
 
-            Group::findOrFail($group_user->group_id)->update([
+            Group::findOrFail($groupUser->group_id)->update([
                 'user_id' => $new_user->user_id,
             ]);
         }
 
-        $group_user->delete();
+        DB::transaction(function () use ($groupUser, $shareService) {
+            foreach ($groupUser->shares as $share) {
+                $shareService->deleteShare($share);
+            }
+
+            $groupUser->delete();
+        });
 
         return redirect()->route('group.index')->with('status', 'Group User deleted successfully.');
     }

--- a/app/Jobs/DeleteShare.php
+++ b/app/Jobs/DeleteShare.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use App\Models\Share;
+use Carbon\Carbon;
+
+class DeleteShare implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(public Share $share)
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $this->share->delete();
+    }
+}

--- a/app/Jobs/DeleteShare.php
+++ b/app/Jobs/DeleteShare.php
@@ -9,6 +9,8 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use App\Models\Share;
 use Carbon\Carbon;
+use App\Services\ShareService;
+use App\Services\LedgerService;
 
 class DeleteShare implements ShouldQueue
 {
@@ -17,7 +19,9 @@ class DeleteShare implements ShouldQueue
     /**
      * Create a new job instance.
      */
-    public function __construct(public Share $share)
+    public function __construct(
+        public Share $share,
+    )
     {
         //
     }
@@ -25,7 +29,7 @@ class DeleteShare implements ShouldQueue
     /**
      * Execute the job.
      */
-    public function handle(): void
+    public function handle(LedgerService $ledgerService): void
     {
         $this->share->delete();
     }

--- a/app/Jobs/UpdateUserBalance.php
+++ b/app/Jobs/UpdateUserBalance.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\DB;
 use Brick\Money\Money;
+use App\Events\UserBalanceUpdated;
 
 class UpdateUserBalance implements ShouldQueue
 {
@@ -23,11 +24,14 @@ class UpdateUserBalance implements ShouldQueue
      * Execute the job.
      * increment() does += for the user.
      * DB::table() is just quicker than User::where() etc.
+     * Fire event to broadcast balance update to the user.
      */
     public function handle(): void
     {
         DB::table('users')
             ->where('id', $this->userId)
             ->increment('balance', $this->amount->getMinorAmount()->toInt());
+
+        UserBalanceUpdated::dispatch($this->userId, $this->amount);
     }
 }

--- a/app/Jobs/UpdateUserBalance.php
+++ b/app/Jobs/UpdateUserBalance.php
@@ -21,6 +21,8 @@ class UpdateUserBalance implements ShouldQueue
 
     /**
      * Execute the job.
+     * increment() does += for the user.
+     * DB::table() is just quicker than User::where() etc.
      */
     public function handle(): void
     {

--- a/app/Jobs/UpdateUserBalance.php
+++ b/app/Jobs/UpdateUserBalance.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\DB;
+use Brick\Money\Money;
+
+class UpdateUserBalance implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        protected int $userId, 
+        protected Money $amount
+    ) {}
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        DB::table('users')
+            ->where('id', $this->userId)
+            ->increment('balance', $this->amount->getMinorAmount()->toInt());
+    }
+}

--- a/app/Observers/GroupUserObserver.php
+++ b/app/Observers/GroupUserObserver.php
@@ -4,9 +4,18 @@ namespace App\Observers;
 
 use App\Models\GroupUser;
 use App\Notifications\GroupUserCreatedNotification;
+use App\Services\DebtService;
+use App\Services\ShareService;
 
 class GroupUserObserver
 {
+    protected ShareService $shareService;
+
+    public function __construct(ShareService $shareService)
+    {
+        $this->shareService = $shareService;
+    }
+
     /**
      * Handle the GroupUser "created" event.
      */
@@ -36,9 +45,9 @@ class GroupUserObserver
             $debt->delete();
         }
 
-        foreach ($groupUser->shares as $share) {
-            $share->delete();
-        }
+        // foreach ($groupUser->shares as $share) {
+        //     $this->shareService->deleteShare($share);
+        // }
 
         foreach ($groupUser->comments as $comment) {
             $comment->delete();

--- a/app/Services/LedgerService.php
+++ b/app/Services/LedgerService.php
@@ -88,6 +88,7 @@ class LedgerService
      */
     public function deleteShareLedgerEntry(Share $share): void
     {
+        dump($share);
         DB::transaction( function () use ($share) {
             LedgerEntry::create([
                 'share_id' => $share->id,

--- a/app/Services/LedgerService.php
+++ b/app/Services/LedgerService.php
@@ -7,6 +7,7 @@ use App\Models\Share;
 use Illuminate\Support\Facades\DB;
 use Brick\Money\Money;
 use App\Enums\LedgerEntryType;
+use App\Jobs\UpdateUserBalance;
 
 class LedgerService
 {
@@ -88,7 +89,6 @@ class LedgerService
      */
     public function deleteShareLedgerEntry(Share $share): void
     {
-        dump($share);
         DB::transaction( function () use ($share) {
             LedgerEntry::create([
                 'share_id' => $share->id,
@@ -113,18 +113,14 @@ class LedgerService
     }
 
     /**
-     * increment() does += for the user. DB::table() is just quicker than User::where() etc.
+     * Fire ledger updates in a job as this is the most used process.
      *
-     * @param int $user_id
+     * @param int $userId
      * @param Money $amount
      * @return void
      */
-    private function updateUserBalance(int $user_id, Money $amount): void
+    private function updateUserBalance(int $userId, Money $amount): void
     {
-        DB::transaction( function () use ($user_id, $amount) {
-            DB::table('users')
-                ->where('id', $user_id)
-                ->increment('balance', $amount->getMinorAmount()->toInt());
-        });
+        UpdateUserBalance::dispatch($userId, $amount);
     }
 }

--- a/app/Services/ShareService.php
+++ b/app/Services/ShareService.php
@@ -8,6 +8,7 @@ use App\Models\GroupUser;
 use App\Services\LedgerService;
 use Brick\Money\Money;
 use Illuminate\Support\Facades\DB;
+use App\Jobs\DeleteShare;
 
 class ShareService
 {
@@ -278,7 +279,7 @@ class ShareService
                     'amount' => $share->debt->amount->minus($share->amount),
                 ]);
 
-                $share->delete();
+                DeleteShare::dispatch($share);
             }
         });
     }

--- a/app/Services/ShareService.php
+++ b/app/Services/ShareService.php
@@ -273,13 +273,16 @@ class ShareService
             $this->ledgerService->deleteShareLedgerEntry($share);
 
             if ($share->debt->split_even->value) {
+                DB::transaction( function () use ($share) {
+                    $share->delete();
+                });
                 $this->updateShares($share->debt);
             } else {
                 $share->debt->update([
                     'amount' => $share->debt->amount->minus($share->amount),
                 ]);
 
-                DeleteShare::dispatch($share);
+                $share->delete();
             }
         });
     }

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -6,7 +6,7 @@ import DropdownLink from '@/Components/Forms/DropdownLink.vue';
 import NavLink from '@/Components/NavLink.vue';
 import ResponsiveNavLink from '@/Components/ResponsiveNavLink.vue';
 import Toast from '@/Components/Misc/Toast.vue';
-import { Link, usePage } from '@inertiajs/vue3';
+import { Link, usePage, router } from '@inertiajs/vue3';
 import { currencies } from '@/currencies.js';
 import Notifications from '@/Components/Notifications/Notifications.vue';
 import MobileNotifications from '@/Components/Notifications/MobileNotifications.vue';
@@ -44,9 +44,13 @@ const props = defineProps({
 // const currency = currencies.find((currency) => currency.code == usePage().props.auth.user.user_balance.currency);
 const user_balance = ref(usePage().props.auth.user.balance.amount);
 
-onMounted(() => {
-
-});
+// alternative to using pusher for polling user balance
+// as jobs are async on redis, request always beats the job so balance doesn't update
+// onMounted(() => {
+//     setInterval(() => {
+//         router.reload({ only: ['auth'] })
+//     }, 5000);
+// });
 
 watch( () => usePage().props.auth.user.balance.amount, (newBalance) => {
     user_balance.value = newBalance;

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -10,7 +10,7 @@ import { Link, usePage, router } from '@inertiajs/vue3';
 import { currencies } from '@/currencies.js';
 import Notifications from '@/Components/Notifications/Notifications.vue';
 import MobileNotifications from '@/Components/Notifications/MobileNotifications.vue';
-import { useEchoNotification } from "@laravel/echo-vue";
+import { useEchoNotification, useEcho } from "@laravel/echo-vue";
 import { useNotificationStore } from '@/Stores/NotificationStore.js';
 
 /*
@@ -22,6 +22,7 @@ import { useNotificationStore } from '@/Stores/NotificationStore.js';
 useEchoNotification(
     `App.Models.User.${usePage().props.auth.user.id}`,
     (notification) => {
+        console.log('new', notification);
         useNotificationStore().notifications.unshift({
             id: notification.id,
             type: notification.type,
@@ -30,6 +31,17 @@ useEchoNotification(
             data: notification,
             read_at: null,
         });
+    },
+);
+
+/**
+ * Listen for balance updates.
+ */
+useEcho(
+    `App.Models.User.Balance.${usePage().props.auth.user.id}`,
+    'UserBalanceUpdated',
+    (notification) => {
+        console.log(notification);
     },
 );
 

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -8,6 +8,10 @@ Broadcast::channel('App.Models.User.{id}', function ($user, $id) {
     return (int) $user->id === (int) $id;
 });
 
+Broadcast::channel('App.Models.User.Balance.{id}', function ($user, $id) {
+    return (int) $user->id === (int) $id;
+});
+
 // Broadcast::channel('debts.{id}', function (User $user, int $debt_id) {
 //     return $user->id === Debt::findOrFail($debt_id)->user_id;
 // });

--- a/tests/Feature/LedgerEntryTest.php
+++ b/tests/Feature/LedgerEntryTest.php
@@ -508,6 +508,14 @@ test('deleting a split share creates the correct ledger entries', function() {
 });
 
 /**
+ * Tests around deleting group users
+ */
+
+test('deleting a group user deletes all their shares and creates the correct ledger entries', function() {
+
+});
+
+/**
  * Test for toggling 'sent' status. Same concept as updating a share, 
  * agnostic to standard/split debts.
  */


### PR DESCRIPTION
#### Preamble

So with the last few PRs based around reworking the debt/share/ledger services & the tests, bugs (I think) finally ironed out, I'd managed to overlook balancing following deleting debts/shares by way of group/group user deletion. Currently, these are based off model events and therefore live in observers. Now that balancing is done by the ledger system, which is tied into the service layer, deleting groups/group users no longer affects a user balance, but the models do delete. 

Currently, I'm looking into solutions. I've tested the idea of simply calling the debt & share services in the group user controller. This works fine, though as a sort of future-proofing idea I'd like to look at making model deletions into queued jobs. 


#### Body
So, this PR spiralled a bit. What started as just "I need to update group user deletion" morphed into actually utilising redis properly and after making some awful calls, I _think_ I've settled on what to do going forward - having balance updates in queues. 

**this PR has kinda got out of hand, so closing it off here and taking a step back to plan changes to make as this is too much to just do on the fly** 

changelog:

- Basic pattern of moving user balance update to an event, that then broadcasts to the frontend. This may end up being really stupid and reworked slightly as it'll broadcast to the frontend every time a balance is updated


