### PR TITLE
Containerise laravel horizon and reverb

### DIFF
--- a/app/Events/UserBalanceUpdated.php
+++ b/app/Events/UserBalanceUpdated.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 use Brick\Money\Money;
+use App\Models\User;
 
 class UserBalanceUpdated implements ShouldBroadcast
 {
@@ -19,8 +20,7 @@ class UserBalanceUpdated implements ShouldBroadcast
      * Create a new event instance.
      */
     public function __construct(
-        public int $userId, 
-        public Money $amount
+        public User $user,
     ) {}
 
     /**
@@ -31,7 +31,7 @@ class UserBalanceUpdated implements ShouldBroadcast
     public function broadcastOn(): array
     {
         return [
-            new PrivateChannel("App.Models.User.Balance.{$this->userId}"),
+            new PrivateChannel("App.Models.User.Balance.{$this->user->id}"),
         ];
     }
 }

--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -121,7 +121,9 @@ class DebtController extends Controller
     public function destroy(Request $request, Debt $debt, DebtService $debtService): RedirectResponse
     {
         if ($request->user()->cannot('delete', $debt)) {
-            return redirect()->route('debt.index')->withErrors(['id' => "You do not have permission to delete this debt."]);
+            return redirect()->route('debt.index')->withErrors([
+                'id' => "You do not have permission to delete this debt."
+            ]);
         } 
 
         $debtService->deleteDebt($debt);

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -83,7 +83,9 @@ class GroupController extends Controller
     public function update(UpdateGroupRequest $request, Group $group): RedirectResponse
     {
         if ($request->user()->cannot('update', $group)) {
-            return redirect()->route('group.index')->withErrors(['name' => "You do not have permission to edit this group."]);
+            return redirect()->route('group.index')->withErrors([
+                'name' => "You do not have permission to edit this group."
+            ]);
         }
 
         $validated = $request->validated();
@@ -105,7 +107,9 @@ class GroupController extends Controller
     public function destroy(Request $request, Group $group)
     {
         if ($request->user()->cannot('delete', $group)) {
-            return redirect()->route('group.index')->withErrors(['id' => "You do not have permission to delete this group."]);
+            return redirect()->route('group.index')->withErrors([
+                'id' => "You do not have permission to delete this group."
+            ]);
         } 
 
         $debts_count = Debt::where('group_id', $group->id)->count();

--- a/app/Jobs/UpdateUserBalance.php
+++ b/app/Jobs/UpdateUserBalance.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\DB;
 use Brick\Money\Money;
 use App\Events\UserBalanceUpdated;
+use App\Models\User;
 
 class UpdateUserBalance implements ShouldQueue
 {
@@ -28,10 +29,14 @@ class UpdateUserBalance implements ShouldQueue
      */
     public function handle(): void
     {
-        DB::table('users')
-            ->where('id', $this->userId)
-            ->increment('balance', $this->amount->getMinorAmount()->toInt());
+        DB::transaction( function () {
+            DB::table('users')
+                ->where('id', $this->userId)
+                ->increment('balance', $this->amount->getMinorAmount()->toInt());
 
-        UserBalanceUpdated::dispatch($this->userId, $this->amount);
+            $user = User::findOrFail($this->userId);
+
+            UserBalanceUpdated::dispatch($user);
+        });
     }
 }

--- a/app/Providers/HorizonServiceProvider.php
+++ b/app/Providers/HorizonServiceProvider.php
@@ -29,7 +29,8 @@ class HorizonServiceProvider extends HorizonApplicationServiceProvider
     {
         Gate::define('viewHorizon', function ($user = null) {
             return in_array(optional($user)->email, [
-                'dom_elves@hotmail.co.uk'
+                'dom_elves@hotmail.co.uk',
+                'dom@example.com',
             ]);
         });
     }

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -210,6 +210,32 @@ return [
             'timeout' => 60,
             'nice' => 0,
         ],
+        'local-supervisor-1' => [
+            'connection' => 'redis',
+            'queue' => ['default'],
+            'balance' => 'auto',
+            'autoScalingStrategy' => 'time',
+            'maxProcesses' => 1,
+            'maxTime' => 0,
+            'maxJobs' => 0,
+            'memory' => 128,
+            'tries' => 1,
+            'timeout' => 60,
+            'nice' => 0,
+        ],
+        'local-supervisor-2' => [
+            'connection' => 'redis',
+            'queue' => ['default'],
+            'balance' => 'auto',
+            'autoScalingStrategy' => 'time',
+            'maxProcesses' => 1,
+            'maxTime' => 0,
+            'maxJobs' => 0,
+            'memory' => 128,
+            'tries' => 1,
+            'timeout' => 60,
+            'nice' => 0,
+        ],
     ],
 
     'environments' => [
@@ -222,8 +248,11 @@ return [
         ],
 
         'local' => [
-            'supervisor-1' => [
-                'maxProcesses' => 3,
+            'local-supervisor-1' => [
+                'maxProcesses' => 10,
+            ],
+            'local-supervisor-2' => [
+                'maxProcesses' => 10,
             ],
         ],
     ],

--- a/database/factories/GroupFactory.php
+++ b/database/factories/GroupFactory.php
@@ -40,6 +40,7 @@ class GroupFactory extends Factory
     }
 
     /**
+     * First create a group user for the group owner, subtract that from the desired count.
      * Takes a param of an int, but without one sets it to randon between 2 and 10.
      * $count determines number of group users created,
      * so pick a random $count of a users and make a group user for each.
@@ -49,7 +50,13 @@ class GroupFactory extends Factory
     public function withGroupUsers(?int $count = 0): static
     {
         return $this->afterCreating(function (Group $group) use ($count) {
-            $count = $count === 0 ? rand(2, 10) : $count;
+
+            GroupUser::factory()->create([
+                'group_id' => $group->id,
+                'user_id' => $group->user_id,
+            ]);
+
+            $count = ($count === 0 ? rand(2, 10) : $count) - 1;
 
             $user_ids = User::whereNot('id', $group->user_id)
                 ->get()

--- a/database/seeders/TestSeeder.php
+++ b/database/seeders/TestSeeder.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Seeder;
 use App\Models\User;
 use App\Models\Group;
 use App\Models\GroupUser;
+use App\Models\Debt;
 
 class TestSeeder extends Seeder
 {
@@ -16,7 +17,7 @@ class TestSeeder extends Seeder
      */
     public function run(): void
     {
-        $users = ['dom', 'alex', 'gman', 'remi'];
+        $users = ['dom', 'alex', 'gman', 'remi', 'louis'];
      
         foreach ($users as $user) {
             User::factory()->create([
@@ -39,5 +40,12 @@ class TestSeeder extends Seeder
                 'user_id' => $user->id,
             ]);
         }
+
+        Debt::factory()
+            ->withShares()
+            ->create([
+                'group_id' => $group->id,
+                'group_user_id' => GroupUser::where('user_id', User::where('name', 'dom')->first()->id)->first()->id,
+            ]);
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
             - '${APP_PORT:-80}:80'
             - '${VITE_PORT:-5173}:${VITE_PORT:-5173}'
             - '8000:8000'
-            - '8080:8080'
+            # - '8080:8080'
         environment:
             WWWUSER: '${WWWUSER}'
             LARAVEL_SAIL: 1
@@ -68,40 +68,46 @@ services:
                 - ping
             retries: 3
             timeout: 5s
-    # meilisearch:
-    #     image: 'getmeili/meilisearch:latest'
-    #     ports:
-    #         - '${FORWARD_MEILISEARCH_PORT:-7700}:7700'
-    #     environment:
-    #         MEILI_NO_ANALYTICS: '${MEILISEARCH_NO_ANALYTICS:-false}'
-    #     volumes:
-    #         - 'sail-meilisearch:/meili_data'
-    #     networks:
-    #         - sail
-    #     healthcheck:
-    #         test:
-    #             - CMD
-    #             - wget
-    #             - '--no-verbose'
-    #             - '--spider'
-    #             - 'http://127.0.0.1:7700/health'
-    #         retries: 3
-    #         timeout: 5s
-    # mailpit:
-    #     image: 'axllent/mailpit:latest'
-    #     ports:
-    #         - '${FORWARD_MAILPIT_PORT:-1025}:1025'
-    #         - '${FORWARD_MAILPIT_DASHBOARD_PORT:-8025}:8025'
-    #     networks:
-    #         - sail
-    # selenium:
-    #     image: selenium/standalone-chromium
-    #     extra_hosts:
-    #         - 'host.docker.internal:host-gateway'
-    #     volumes:
-    #         - '/dev/shm:/dev/shm'
-    #     networks:
-    #         - sail
+    horizon:
+        image: sail-8.4/app
+        command: ["php", "/var/www/html/artisan", "horizon:listen"]
+        restart: unless-stopped
+        stop_signal: SIGTERM
+        depends_on:
+            - redis
+            - mysql
+        environment:
+            WWWUSER: '${WWWUSER}'
+            LARAVEL_SAIL: 1
+            DB_HOST: mysql
+            REDIS_HOST: redis
+        env_file:
+            - .env
+        volumes:
+            - '.:/var/www/html'
+        networks:
+            - sail
+    reverb:
+        image: sail-8.4/app
+        command: ["php", "/var/www/html/artisan", "reverb:start"]
+        restart: unless-stopped
+        stop_signal: SIGTERM
+        ports:
+            - '8080:8080'
+        depends_on:
+            - redis
+            - mysql
+        environment:
+            WWWUSER: '${WWWUSER}'
+            LARAVEL_SAIL: 1
+            DB_HOST: mysql
+            REDIS_HOST: redis
+        env_file:
+            - .env
+        volumes:
+            - '.:/var/www/html'
+        networks:
+            - sail
     buggregator:
         image: ghcr.io/buggregator/server:latest
         ports:

--- a/resources/js/Components/Shares/Share.vue
+++ b/resources/js/Components/Shares/Share.vue
@@ -58,7 +58,7 @@ function setSentSeenMessage(message) {
 }
 
 onMounted(() => {
-    console.log(props.share);
+
 })
 
 </script>

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -22,7 +22,6 @@ import { useNotificationStore } from '@/Stores/NotificationStore.js';
 useEchoNotification(
     `App.Models.User.${usePage().props.auth.user.id}`,
     (notification) => {
-        console.log('new', notification);
         useNotificationStore().notifications.unshift({
             id: notification.id,
             type: notification.type,
@@ -41,7 +40,7 @@ useEcho(
     `App.Models.User.Balance.${usePage().props.auth.user.id}`,
     'UserBalanceUpdated',
     (notification) => {
-        console.log(notification);
+        user_balance.value = notification.user.balance.amount;
     },
 );
 
@@ -58,11 +57,11 @@ const user_balance = ref(usePage().props.auth.user.balance.amount);
 
 // alternative to using pusher for polling user balance
 // as jobs are async on redis, request always beats the job so balance doesn't update
-// onMounted(() => {
-//     setInterval(() => {
-//         router.reload({ only: ['auth'] })
-//     }, 5000);
-// });
+onMounted(() => {
+    // setInterval(() => {
+    //     router.reload({ only: ['auth'] })
+    // }, 5000);
+});
 
 watch( () => usePage().props.auth.user.balance.amount, (newBalance) => {
     user_balance.value = newBalance;

--- a/vite.config.js
+++ b/vite.config.js
@@ -31,7 +31,6 @@ export default defineConfig({
 
             // current?
             host: process.env.VITE_HOST ?? '127.0.0.1',
-            // host: '192.168.0.20',
             protocol: 'ws',
             port: 5173,
         },


### PR DESCRIPTION
Aim of this PR is to containerise laravel horizon & reverb for two reasons:

1. Learn more about docker.
2. So I no longer have to have 4 terminals open and running a separate command in each.

Got a bit carried away, so some extras that probably should have been it's own PR:

- Extra supervisors created when playing around with horizon settings
- Bought prod server up to speed;
    - `CACHE_STORE` and `SESSION_DRIVER` now on redis
    - Added domain for wss and updated that on the `env` too, seemed to be falling over a lot but removing and reinstalling reverb seems to have fixed it 
- Fixed issue with `GroupUserFactory` where if the user that owns the group was not randomly selected when passing an amount of group users in, it would bug and you could own a group that you are not a user of. Rectified this by including the user.
- User model w/updated balance now gets passed to the frontend rather than the balance amount, as it makes more sense.  

Up next:

Fix balance changes on group user deletion as it is just wrong somehow, look into job batching.
