### PR TITLE
Further changes with group user deletion

### DIFF
--- a/app/Http/Controllers/GroupUserController.php
+++ b/app/Http/Controllers/GroupUserController.php
@@ -71,11 +71,6 @@ class GroupUserController extends Controller
      */
     public function destroy(Request $request, GroupUser $groupUser): RedirectResponse
     {
-        $validated = $request->validate(
-            ['new_owner_group_user_id' => 'required|exists:group_users,id'],
-            ['new_owner_group_user_id.required' => 'Please select a new group owner before leaving the group'],
-        );
-
         if ($request->user()->cannot('delete', $groupUser)) {
             return redirect()->route('group.index')->withErrors([
                 'id' => 'You do not have permission to delete this group user.'
@@ -83,14 +78,15 @@ class GroupUserController extends Controller
         }
         
         if ($groupUser->user->id === $groupUser->group->user_id && $request->user()->can('delete', $groupUser->group)) {
-            $new_user = GroupUser::findOrFail($validated['new_owner_group_user_id']);
+            $validated = $request->validate(
+                ['new_owner_group_user_id' => 'required|exists:group_users,id'],
+                ['new_owner_group_user_id.required' => 'Please select a new group owner before leaving the group'],
+            );
 
-            Group::findOrFail($groupUser->group_id)->update([
-                'user_id' => $new_user->user_id,
-            ]);
+            DeleteGroupUserAndData::dispatch($groupUser->id, $validated['new_owner_group_user_id']);
+        } else {
+            DeleteGroupUserAndData::dispatch($groupUser->id);
         }
-
-        DeleteGroupUserAndData::dispatch($groupUser->id);
 
         return redirect()->route('group.index')->with('status', 'Group User deleted successfully. Your balance may take a moment to update.');
     }

--- a/app/Jobs/DeleteDebtAndShares.php
+++ b/app/Jobs/DeleteDebtAndShares.php
@@ -19,7 +19,7 @@ use Illuminate\Support\Facades\DB;
 use App\Events\UserBalanceUpdated;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
 
-class DeleteDebt implements ShouldQueue
+class DeleteDebtAndShares implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels, Batchable;
 

--- a/app/Jobs/DeleteGroupUserAndData.php
+++ b/app/Jobs/DeleteGroupUserAndData.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use App\Models\Group;
 use App\Models\GroupUser;
 use App\Models\Debt;
 use Carbon\Carbon;
@@ -25,7 +26,8 @@ class DeleteGroupUserAndData implements ShouldQueue
      * Create a new job instance.
      */
     public function __construct(
-        public int $groupUserId
+        public int $groupUserId,
+        public ?int $newOwnerGroupUserId = null,
     ) {}
 
     /**
@@ -45,7 +47,9 @@ class DeleteGroupUserAndData implements ShouldQueue
      * 1. Batch of debt jobs
      * 2. Instantiate new DeleteGroupUser job, fires as it is in chain
      * 3. A callback to fire the UserBalanceUpdated event, which then fires the notif etc
-     */
+     * 
+     * If a group user id to transfer ownership was passed in, add that job to the queue too.
+    */
     public function handle(): void
     {
         $groupUser = GroupUser::find($this->groupUserId);
@@ -56,15 +60,22 @@ class DeleteGroupUserAndData implements ShouldQueue
             fn ($debt) => new DeleteDebt($debt)
         )->all();
 
-        Bus::chain([
+        $jobs = [
             Bus::batch($deleteDebtJobs)
                 ->name('Delete ' . count($deleteDebtJobs) . ' debts for group user ' . $groupUser->id),
             new DeleteGroupUser($groupUser),
             function () use ($groupUser) {
                 UserBalanceUpdated::dispatch($groupUser->user);
-            }
-        ])->catch(function (Throwable $e) {
-            // do something here one day
-        })->dispatch();
+            },
+        ];
+
+        if ($this->newOwnerGroupUserId) {
+            $jobs[] = new TransferGroupOwnership($groupUser->group_id, $this->newOwnerGroupUserId);
+        }
+
+        Bus::chain($jobs)
+            ->catch(function (Throwable $e) {
+                dump($e);
+            })->dispatch();
     }
 }

--- a/app/Jobs/DeleteGroupUserAndData.php
+++ b/app/Jobs/DeleteGroupUserAndData.php
@@ -10,8 +10,10 @@ use Illuminate\Queue\SerializesModels;
 use App\Models\Group;
 use App\Models\GroupUser;
 use App\Models\Debt;
+use App\Models\Share;
 use Carbon\Carbon;
-use App\Jobs\DeleteDebt;
+use App\Jobs\DeleteDebtAndShares;
+use App\Jobs\DeleteShare;
 use App\Jobs\DeleteGroupUser;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Bus\Batchable;
@@ -35,39 +37,62 @@ class DeleteGroupUserAndData implements ShouldQueue
      * which is debts, shares, comments and aliases. 
      * 
      * Comments & aliases are covered in the GroupUserOberserver, 
-     * though debts and shares require extra bits afterwards (ledgers).
+     * though debts and shares require extra bits afterwards (ledgers).]
      * 
-     * So, to explain:
+     * Explaination of building the chain:
      * 
-     * Query group user w/id
-     * Leverage involved() on Debt
-     * Map each involved debt to a collection of DeleteDebt jobs
-     * Build the chain:
-     * 
-     * 1. Batch of debt jobs
-     * 2. Instantiate new DeleteGroupUser job, fires as it is in chain
-     * 3. A callback to fire the UserBalanceUpdated event, which then fires the notif etc
-     * 
-     * If a group user id to transfer ownership was passed in, add that job to the queue too.
+     * 1. Start with an empty $jobs array
+     * 2. Query user owned debts, create batch if they exist
+     * 3. Same with shares but exclude the ones that would have been included as debt shares
+     * 4. Delete the group user
+     * 5. Update the delete group user's user balance
+     * 6. If ownership is being transferred, add that job to the queue
+     * 7. Finally, dispatch the chain
     */
     public function handle(): void
     {
+        $jobs = [];
+
+        $debtsAndShares = Debt::where('group_user_id', $this->groupUserId)
+            ->with('shares.groupUser.user:id')
+            ->get();
+
+        if ($debtsAndShares) {
+            $deleteDebtJobs = $debtsAndShares->map(
+                fn ($debt) => new DeleteDebtAndShares($debt)
+            )->all();
+
+            $jobs[] = Bus::batch($deleteDebtJobs)
+                ->name('Delete ' . count($deleteDebtJobs) . ' debts for group user ' . $this->groupUser->id);
+        }
+
+        $shares = Share::where('group_user_id', $this->groupUserId)
+            ->whereHas('debt', function ($query) {
+                $query->whereColumn('group_user_id', '!=', 'shares.group_user_id');
+            })
+            ->with([
+                'debt.groupUser.user:id',
+                'groupUser.user:id'
+            ])
+            ->get();
+
+        if ($shares) {
+            $deleteShareJobs = $shares->map(
+                fn ($share) => new DeleteShare($share)
+            )->all();
+
+            $jobs[] = Bus::batch($deleteShareJobs)
+                ->name('Delete ' . count($deleteShareJobs) . ' shares for group user ' . $this->groupUser->id);
+        }
+
         $groupUser = GroupUser::find($this->groupUserId);
-        // todo: fetch this from cache when looking into cache
-        $debtsAndShares = Debt::involved($groupUser->user)->with('shares.groupUser.user:id')->get();
+        $user = $groupUser->user;
 
-        $deleteDebtJobs = $debtsAndShares->map(
-            fn ($debt) => new DeleteDebt($debt)
-        )->all();
+        $jobs[] = new DeleteGroupUser($groupUser);
 
-        $jobs = [
-            Bus::batch($deleteDebtJobs)
-                ->name('Delete ' . count($deleteDebtJobs) . ' debts for group user ' . $groupUser->id),
-            new DeleteGroupUser($groupUser),
-            function () use ($groupUser) {
-                UserBalanceUpdated::dispatch($groupUser->user);
-            },
-        ];
+        $jobs[] = function () use ($user) {
+                UserBalanceUpdated::dispatch($user);
+            };
 
         if ($this->newOwnerGroupUserId) {
             $jobs[] = new TransferGroupOwnership($groupUser->group_id, $this->newOwnerGroupUserId);

--- a/app/Jobs/DeleteGroupUserAndData.php
+++ b/app/Jobs/DeleteGroupUserAndData.php
@@ -57,13 +57,13 @@ class DeleteGroupUserAndData implements ShouldQueue
             ->with('shares.groupUser.user:id')
             ->get();
 
-        if ($debtsAndShares) {
+        if ($debtsAndShares->isNotEmpty()) {
             $deleteDebtJobs = $debtsAndShares->map(
                 fn ($debt) => new DeleteDebtAndShares($debt)
             )->all();
 
             $jobs[] = Bus::batch($deleteDebtJobs)
-                ->name('Delete ' . count($deleteDebtJobs) . ' debts for group user ' . $this->groupUser->id);
+                ->name('Delete ' . count($deleteDebtJobs) . ' debts for group user ' . $this->groupUserId);
         }
 
         $shares = Share::where('group_user_id', $this->groupUserId)
@@ -76,13 +76,13 @@ class DeleteGroupUserAndData implements ShouldQueue
             ])
             ->get();
 
-        if ($shares) {
+        if ($shares->isNotEmpty()) {
             $deleteShareJobs = $shares->map(
                 fn ($share) => new DeleteShare($share)
             )->all();
 
             $jobs[] = Bus::batch($deleteShareJobs)
-                ->name('Delete ' . count($deleteShareJobs) . ' shares for group user ' . $this->groupUser->id);
+                ->name('Delete ' . count($deleteShareJobs) . ' shares for group user ' . $this->groupUserId);
         }
 
         $groupUser = GroupUser::find($this->groupUserId);

--- a/app/Jobs/DeleteGroupUserAndData.php
+++ b/app/Jobs/DeleteGroupUserAndData.php
@@ -19,6 +19,7 @@ use Illuminate\Support\Facades\Bus;
 use Illuminate\Bus\Batchable;
 use Throwable;
 use App\Events\UserBalanceUpdated;
+use App\Jobs\DeleteGroupUserAndData;
 
 class DeleteGroupUserAndData implements ShouldQueue
 {
@@ -45,7 +46,7 @@ class DeleteGroupUserAndData implements ShouldQueue
      * 2. Query user owned debts, create batch if they exist
      * 3. Same with shares but exclude the ones that would have been included as debt shares
      * 4. Delete the group user
-     * 5. Update the delete group user's user balance
+     * 5. Notify (visually update balance) of the user doing the deleting
      * 6. If ownership is being transferred, add that job to the queue
      * 7. Finally, dispatch the chain
     */

--- a/app/Jobs/DeleteShare.php
+++ b/app/Jobs/DeleteShare.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Bus\Batchable;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
+use App\Services\ShareService;
 
 class DeleteShare implements ShouldQueue
 {
@@ -29,35 +30,41 @@ class DeleteShare implements ShouldQueue
     public function handle(): void
     {
         $share = $this->share;
+        $debt = $this->share->debt;
         $debtor = $this->share->debt->groupUser->user;
 
         DB::transaction( function() use ($debtor, $share) {
             LedgerEntry::create([
-                    'share_id' => $share->id,
-                    'user_id' => $debtor->id,
-                    'amount' => $share->amount->negated(),
-                    'type' => LedgerEntryType::DEBT_OWNERSHIP_DELETED,
-                ]);
+                'share_id' => $share->id,
+                'user_id' => $debtor->id,
+                'amount' => $share->amount->negated(),
+                'type' => LedgerEntryType::DEBT_OWNERSHIP_DELETED,
+            ]);
 
-                DB::table('users')
-                    ->where('id', $debtor->id)
-                    ->increment('balance', $share->amount->negated()->getMinorAmount()->toInt());
+            DB::table('users')
+                ->where('id', $debtor->id)
+                ->increment('balance', $share->amount->negated()->getMinorAmount()->toInt());
 
-                $indebted = $share->groupUser->user;
+            $indebted = $share->groupUser->user;
 
-                LedgerEntry::create([
-                    'share_id' => $share->id,
-                    'user_id' => $indebted->id,
-                    'amount' => $share->amount,
-                    'type' => LedgerEntryType::SHARE_DELETED,
-                ]);
+            LedgerEntry::create([
+                'share_id' => $share->id,
+                'user_id' => $indebted->id,
+                'amount' => $share->amount,
+                'type' => LedgerEntryType::SHARE_DELETED,
+            ]);
 
-                DB::table('users')
-                    ->where('id', $indebted->id)
-                    ->increment('balance', $share->amount->getMinorAmount()->toInt());
+            DB::table('users')
+                ->where('id', $indebted->id)
+                ->increment('balance', $share->amount->getMinorAmount()->toInt());
 
-                $share->delete();
+            $share->delete();
         });
+
+        if ($debt->split_even && $debt->shares->count() === 1) {
+            $shareService = new ShareService();
+            $shareService->updateShares($debt);
+        }
     }
 
     /**

--- a/app/Jobs/DeleteShare.php
+++ b/app/Jobs/DeleteShare.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use App\Models\LedgerEntry;
+use App\Models\Share;
+use App\Enums\LedgerEntryType;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Bus\Batchable;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
+
+class DeleteShare implements ShouldQueue
+{
+    use Queueable, Batchable, Dispatchable;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        public Share $share,
+    ) {}
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $share = $this->share;
+        $debtor = $this->share->debt->groupUser->user;
+
+        DB::transaction( function() use ($debtor, $share) {
+            LedgerEntry::create([
+                    'share_id' => $share->id,
+                    'user_id' => $debtor->id,
+                    'amount' => $share->amount->negated(),
+                    'type' => LedgerEntryType::DEBT_OWNERSHIP_DELETED,
+                ]);
+
+                DB::table('users')
+                    ->where('id', $debtor->id)
+                    ->increment('balance', $share->amount->negated()->getMinorAmount()->toInt());
+
+                $indebted = $share->groupUser->user;
+
+                LedgerEntry::create([
+                    'share_id' => $share->id,
+                    'user_id' => $indebted->id,
+                    'amount' => $share->amount,
+                    'type' => LedgerEntryType::SHARE_DELETED,
+                ]);
+
+                DB::table('users')
+                    ->where('id', $indebted->id)
+                    ->increment('balance', $share->amount->getMinorAmount()->toInt());
+
+                $share->delete();
+        });
+    }
+
+    /**
+     * Get the middleware the job should pass through.
+     *
+     * @return array<int, object>
+     */
+    public function middleware(): array
+    {
+        return [new WithoutOverlapping($this->share->id)];
+    }
+}

--- a/app/Jobs/TransferGroupOwnership.php
+++ b/app/Jobs/TransferGroupOwnership.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use App\Models\Group;
+use App\Models\GroupUser;
+
+
+class TransferGroupOwnership implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        public int $groupId,
+        public int $newOwnerGroupUserId,
+    ) {}
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $newUser = GroupUser::findOrFail($this->newOwnerGroupUserId);
+
+        Group::findOrFail($this->groupId)->update([
+            'user_id' => $this->newOwnerGroupUserId,
+        ]);
+    }
+}

--- a/app/Jobs/TransferGroupOwnership.php
+++ b/app/Jobs/TransferGroupOwnership.php
@@ -25,10 +25,10 @@ class TransferGroupOwnership implements ShouldQueue
      */
     public function handle(): void
     {
-        $newUser = GroupUser::findOrFail($this->newOwnerGroupUserId);
+        $newGroupUser = GroupUser::findOrFail($this->newOwnerGroupUserId);
 
         Group::findOrFail($this->groupId)->update([
-            'user_id' => $this->newOwnerGroupUserId,
+            'user_id' => $newGroupUser->user->id,
         ]);
     }
 }

--- a/app/Services/ShareService.php
+++ b/app/Services/ShareService.php
@@ -106,12 +106,18 @@ class ShareService
      */
     public function updateShares($debt): void
     {
-        $updated_splits = $debt->amount->split($debt->shares->count());
-    
-        foreach ($debt->shares as $key => $share) {
-            $share->amount = $updated_splits[$key];
+        if ($debt->shares->count() === 1) {
+            $debt->shares->first()->update([
+                'amount' => $debt->amount,
+            ]);
+        } else {
+            $updated_splits = $debt->amount->split($debt->shares->count());
 
-            $this->updateShareAmount($share);
+            foreach ($debt->shares as $key => $share) {
+                $share->amount = $updated_splits[$key];
+
+                $this->updateShareAmount($share);
+            }
         }
     }
     /**

--- a/app/Services/ShareService.php
+++ b/app/Services/ShareService.php
@@ -12,11 +12,9 @@ use App\Jobs\DeleteShare;
 
 class ShareService
 {
-    protected LedgerService $ledgerService;
-
-    public function __construct(LedgerService $ledgerService)
+    public function __construct()
     {
-        $this->ledgerService = $ledgerService;
+        $this->ledgerService = new LedgerService();
     }
 
     /**

--- a/database/factories/DebtFactory.php
+++ b/database/factories/DebtFactory.php
@@ -101,11 +101,11 @@ class DebtFactory extends Factory
     /**
      * Add between 0 and 5 comments to a debt on creation.
      */
-    public function withComments(): static
+    public function withComments($count = 0): static
     {
-        return $this->afterCreating(function (Debt $debt) {
+        return $this->afterCreating(function (Debt $debt) use ($count) {
             Comment::factory()
-                ->count(rand(0, 5))
+                ->count($count === 0 ? rand(0, 5): $count)
                 ->create([
                     'debt_id' => $debt->id,
             ]);

--- a/tests/Feature/Http/Controllers/GroupUserControllerTest.php
+++ b/tests/Feature/Http/Controllers/GroupUserControllerTest.php
@@ -6,6 +6,7 @@ use App\Models\Debt;
 use App\Models\Alias;
 use App\Models\Comment;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Bus;
 
 beforeEach(function () {
     $this->users = User::factory(10)->create();
@@ -56,6 +57,8 @@ test('user can not remove group users from a group they do not own', function() 
 });
 
 test('deleting a group user also deletes their comments', function() {
+    Bus::fake();
+    
     $this->actingAs($this->user);
 
     $debt = Debt::factory()->create([
@@ -82,6 +85,28 @@ test('deleting a group user also deletes their comments', function() {
     ]);
 });
 
+test('deleting a group user also deletes their aliases', function() {
+    Bus::fake();
+    
+    $this->actingAs($this->user);
+
+    $alias = Alias::factory()->create([
+        'user_id' => $this->user->id,
+        'group_user_id' => $this->group->groupUsers[2]->id,
+    ]);
+
+    $response = $this->delete(route('group-users.destroy', $this->group->groupUsers[2]));
+
+    $response->assertStatus(302)
+        ->assertSessionHas('status', 'Group User deleted successfully. Your balance may take a moment to update.');
+
+    $this->assertDatabaseHas('aliases', [
+        'id' => $alias->id,
+        'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
+        'group_user_id' => $this->group->groupUsers[2]->id,
+    ]);
+});
+
 test('deleting a group user also deletes their shares', function() {
     $this->actingAs($this->user);
 
@@ -101,26 +126,6 @@ test('deleting a group user also deletes their shares', function() {
         'id' => $share->id,
         'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
         'group_user_id' => $share->group_user_id,
-    ]);
-});
-
-test('deleting a group user also deletes their aliases', function() {
-    $this->actingAs($this->user);
-
-    $alias = Alias::factory()->create([
-        'user_id' => $this->user->id,
-        'group_user_id' => $this->group->groupUsers[2]->id,
-    ]);
-
-    $response = $this->delete(route('group-users.destroy', $this->group->groupUsers[2]));
-
-    $response->assertStatus(302)
-        ->assertSessionHas('status', 'Group User deleted successfully. Your balance may take a moment to update.');
-
-    $this->assertDatabaseHas('aliases', [
-        'id' => $alias->id,
-        'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
-        'group_user_id' => $this->group->groupUsers[2]->id,
     ]);
 });
 

--- a/tests/Feature/Http/Controllers/GroupUserControllerTest.php
+++ b/tests/Feature/Http/Controllers/GroupUserControllerTest.php
@@ -2,11 +2,7 @@
 
 use App\Models\User;
 Use App\Models\Group;
-use App\Models\Debt;
-use App\Models\Alias;
-use App\Models\Comment;
 use Carbon\Carbon;
-use Illuminate\Support\Facades\Bus;
 
 beforeEach(function () {
     $this->users = User::factory(10)->create();
@@ -21,7 +17,7 @@ beforeEach(function () {
     $this->group_user = $this->group->groupUsers->where('user_id', $this->user->id)->first();
 });
 
-test('user can remove group users from a group they own', function() {
+test('user can delete group users from a group they own', function() {
     $this->actingAs($this->user);
 
     $response = $this->delete(route('group-users.destroy', $this->group->groupUsers[2]));
@@ -35,7 +31,7 @@ test('user can remove group users from a group they own', function() {
     ]);
 });
 
-test('user can not remove group users from a group they do not own', function() {
+test('user can not delete group users from a group they do not own', function() {
     $this->actingAs($this->user);
 
     $group = Group::factory()
@@ -53,79 +49,6 @@ test('user can not remove group users from a group they do not own', function() 
     $this->assertDatabaseHas('group_users', [
         'id' => $group_user->id,
         'deleted_at' => null,
-    ]);
-});
-
-test('deleting a group user also deletes their comments', function() {
-    Bus::fake();
-    
-    $this->actingAs($this->user);
-
-    $debt = Debt::factory()->create([
-        'group_id' => $this->group->id,
-        'group_user_id' => $this->group_user->id,
-    ]);
-
-    // todo: change this after fixing debt factory later
-    $comment = Comment::factory()->create([
-        'group_user_id' => $this->group->groupUsers[2]->id,
-        'debt_id' => $debt->id,
-        'content' => 'comment'
-    ]);
-
-    $response = $this->delete(route('group-users.destroy', $this->group->groupUsers[2]));
-
-    $response->assertStatus(302)
-        ->assertSessionHas('status', 'Group User deleted successfully. Your balance may take a moment to update.');
-
-    $this->assertDatabaseHas('comments', [
-        'id' => $comment->id,
-        'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
-        'group_user_id' => $this->group->groupUsers[2]->id,
-    ]);
-});
-
-test('deleting a group user also deletes their aliases', function() {
-    Bus::fake();
-    
-    $this->actingAs($this->user);
-
-    $alias = Alias::factory()->create([
-        'user_id' => $this->user->id,
-        'group_user_id' => $this->group->groupUsers[2]->id,
-    ]);
-
-    $response = $this->delete(route('group-users.destroy', $this->group->groupUsers[2]));
-
-    $response->assertStatus(302)
-        ->assertSessionHas('status', 'Group User deleted successfully. Your balance may take a moment to update.');
-
-    $this->assertDatabaseHas('aliases', [
-        'id' => $alias->id,
-        'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
-        'group_user_id' => $this->group->groupUsers[2]->id,
-    ]);
-});
-
-test('deleting a group user also deletes their shares', function() {
-    $this->actingAs($this->user);
-
-    $debt = Debt::factory()->withShares()->create([
-        'group_id' => $this->group->id,
-        'group_user_id' => $this->group_user->id,
-    ]);
-
-    $share = $debt->shares->where('group_user_id', $this->group->groupUsers[2]->id)->first();
-
-    $response = $this->delete(route('group-users.destroy', $this->group->groupUsers[2]));
-
-    $response->assertStatus(302)
-        ->assertSessionHas('status', 'Group User deleted successfully. Your balance may take a moment to update.');
-
-    $this->assertDatabaseHas('shares', [
-        'id' => $share->id,
-        'deleted_at' => Carbon::now()->format('Y-m-d H:i:s'),
-        'group_user_id' => $share->group_user_id,
     ]);
 });
 
@@ -163,3 +86,5 @@ test('user can delete themselves from a group and select a new group owner', fun
         'user_id' => $this->group->groupUsers[2]->user->id,
     ]);
 });
+
+// tests around extended functionality for deleting group users will be a separate test case

--- a/tests/Feature/Http/Controllers/GroupUserControllerTest.php
+++ b/tests/Feature/Http/Controllers/GroupUserControllerTest.php
@@ -26,7 +26,7 @@ test('user can remove group users from a group they own', function() {
     $response = $this->delete(route('group-users.destroy', $this->group->groupUsers[2]));
 
     $response->assertStatus(302)
-        ->assertSessionHas('status', 'Group User deleted successfully.');
+        ->assertSessionHas('status', 'Group User deleted successfully. Your balance may take a moment to update.');
 
     $this->assertDatabaseHas('group_users', [
         'id' => $this->group->groupUsers[2]->id,
@@ -73,7 +73,7 @@ test('deleting a group user also deletes their comments', function() {
     $response = $this->delete(route('group-users.destroy', $this->group->groupUsers[2]));
 
     $response->assertStatus(302)
-        ->assertSessionHas('status', 'Group User deleted successfully.');
+        ->assertSessionHas('status', 'Group User deleted successfully. Your balance may take a moment to update.');
 
     $this->assertDatabaseHas('comments', [
         'id' => $comment->id,
@@ -95,7 +95,7 @@ test('deleting a group user also deletes their shares', function() {
     $response = $this->delete(route('group-users.destroy', $this->group->groupUsers[2]));
 
     $response->assertStatus(302)
-        ->assertSessionHas('status', 'Group User deleted successfully.');
+        ->assertSessionHas('status', 'Group User deleted successfully. Your balance may take a moment to update.');
 
     $this->assertDatabaseHas('shares', [
         'id' => $share->id,
@@ -115,7 +115,7 @@ test('deleting a group user also deletes their aliases', function() {
     $response = $this->delete(route('group-users.destroy', $this->group->groupUsers[2]));
 
     $response->assertStatus(302)
-        ->assertSessionHas('status', 'Group User deleted successfully.');
+        ->assertSessionHas('status', 'Group User deleted successfully. Your balance may take a moment to update.');
 
     $this->assertDatabaseHas('aliases', [
         'id' => $alias->id,
@@ -146,7 +146,7 @@ test('user can delete themselves from a group and select a new group owner', fun
     ]);
 
     $response->assertStatus(302)
-        ->assertSessionHas('status', 'Group User deleted successfully.');
+        ->assertSessionHas('status', 'Group User deleted successfully. Your balance may take a moment to update.');
 
     $this->assertDatabaseHas('group_users', [
         'id' => $this->group_user->id,


### PR DESCRIPTION
Hopefully a smaller PR than the last, just a couple of changes that needed to be made.

- Revert the logic in the controller method around validating before checking policy
- `DeleteGroupUserAndData` now no longer uses the custom `involved()` query, massive oversight by me, it was breaking when deleting a user that wasn't yourself from a group. User owned debts and now queried first, then shares in non-user owned debts are queried afterwards, both go into separate batches at the beginning of the chain. 
- `DeleteShare` has been added and `DeleteDebt` is now `DeleteDebtAndShares` as realistically, a debt will never be deleted without it's shares. Same as the original version of `DeleteDebt`, `DeleteShares` replicates the logic in the ledger service but doesn't actually call the service so we don't spam notifications. 
- `TransferGroupOwnership` job has been added to cover the logic removed from the delete method in the controller. 
- Added some logic to `updateShares` in the share service to cover a split even debt having shares deleted to the point where 1 share remains, and called this conditionally in the `DeleteShare` job.
- Removed `ledgerService` as a param from `shareService` and just had it as a new object in the construct.
- Massively trimmed down `GroupUserController` test. All extended functionality will be tested in a separate test case that is specifically going to test the `DeleteGroupUserAndData` job, as the next PR is going to be moving comment & alias deletion out of model observers and making it part of the job batch. 
